### PR TITLE
docs: add status badges to README files

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -1,6 +1,7 @@
 # uv-sbom
 
-[![shield_license]][license_file]
+[![GitHub release](https://img.shields.io/github/release/Taketo-Yoda/uv-sbom.svg)](https://github.com/Taketo-Yoda/uv-sbom/releases) [![PyPI - Version](https://img.shields.io/pypi/v/uv-sbom-bin?logo=python&logoColor=white&label=PyPI)](https://pypi.org/project/uv-sbom-bin/) [![Crates.io Version](https://img.shields.io/crates/v/uv-sbom?logo=rust&logoColor=white)](https://crates.io/crates/uv-sbom)
+[![shield_license]][license_file] [![CI](https://github.com/Taketo-Yoda/uv-sbom/actions/workflows/ci.yml/badge.svg)](https://github.com/Taketo-Yoda/uv-sbom/actions/workflows/ci.yml)
 
 [English](README.md) | [日本語](README-JP.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # uv-sbom
 
-[![shield_license]][license_file] 
+[![GitHub release](https://img.shields.io/github/release/Taketo-Yoda/uv-sbom.svg)](https://github.com/Taketo-Yoda/uv-sbom/releases) [![PyPI - Version](https://img.shields.io/pypi/v/uv-sbom-bin?logo=python&logoColor=white&label=PyPI)](https://pypi.org/project/uv-sbom-bin/) [![Crates.io Version](https://img.shields.io/crates/v/uv-sbom?logo=rust&logoColor=white)](https://crates.io/crates/uv-sbom)
+[![shield_license]][license_file] [![CI](https://github.com/Taketo-Yoda/uv-sbom/actions/workflows/ci.yml/badge.svg)](https://github.com/Taketo-Yoda/uv-sbom/actions/workflows/ci.yml)
 
 [English](README.md) | [日本語](README-JP.md)
 


### PR DESCRIPTION
Add GitHub release, PyPI version, crates.io version, and CI status badges to both README.md and README-JP.md to improve project visibility and provide quick access to build/release status.