### PR TITLE
chore: ignore .claude/saved-contexts/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Claude Code context saves (As it may contain sensitive information)
+.claude/saved-contexts/


### PR DESCRIPTION
This directory is used by Claude Code for context compaction and should not be tracked by version control.