### PR TITLE
ci: skip CI runs for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,16 @@ on:
       - main
       - develop
       - 'feature/**'
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
   pull_request:
     branches:
       - main
       - develop
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Add `paths-ignore` filters to the CI workflow to skip execution when only documentation files (*.md, .gitignore) are modified. This optimization reduces unnecessary CI runs and saves GitHub Actions resources.

## Changes

- Add `paths-ignore` to `on.push` trigger
  - Skip CI when only `**.md` files are changed
  - Skip CI when only `.gitignore` is changed
- Add `paths-ignore` to `on.pull_request` trigger with same patterns

## Behavior

### CI will be SKIPPED when:
- Only markdown files are changed (README.md, SECURITY.md, .claude/*.md, etc.)
- Only .gitignore is changed
- Combination of markdown files and .gitignore

### CI will still RUN when:
- Any code file is changed (src/**, Cargo.toml, Cargo.lock, etc.)
- Code files are changed along with documentation
- Workflow files (.github/workflows/**) are changed

## Test Plan

After merge, this can be tested by:
1. Creating a feature branch
2. Making a commit that only changes a markdown file
3. Pushing the branch
4. Verifying that CI shows "Skipped" status in GitHub Actions

## Notes

- This PR itself triggers CI because it modifies a workflow file, which is correct behavior
- No Rust code changes, so no formatting/clippy checks needed
- First documentation-only commits after merge will demonstrate the optimization

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)