### PR TITLE
ci: remove pull_request trigger to reduce resource usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,6 @@ on:
     paths-ignore:
       - '**.md'
       - '.gitignore'
-  pull_request:
-    branches:
-      - main
-      - develop
-    paths-ignore:
-      - '**.md'
-      - '.gitignore'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Removes the `pull_request` trigger from the CI workflow to eliminate redundant CI runs and reduce GitHub Actions resource consumption.

## Changes

- **`.github/workflows/ci.yml`**: Removed `pull_request` trigger section
- Kept `push` trigger for `main`, `develop`, and `feature/**` branches
- Maintained existing `paths-ignore` configuration

## Rationale

**Current Problem:**
- CI runs on every `push` to feature branches
- CI runs again when creating a PR from that feature branch
- This results in duplicate CI runs consuming unnecessary GitHub Actions minutes

**Solution:**
- Remove `pull_request` trigger
- Rely solely on `push` trigger which already covers all feature branches
- PR checks will display the status from the most recent push-triggered CI run

## Benefits

- ✅ Reduces GitHub Actions resource consumption
- ✅ Eliminates redundant CI runs (no duplicate testing)
- ✅ Faster feedback (no waiting for duplicate CI runs)
- ✅ Simpler CI logs (one run per commit instead of multiple)
- ✅ Maintains same quality assurance level (all commits tested before PR creation)

## Verification

After merging this PR:
1. Push to a feature branch → CI runs ✅
2. Create PR from that branch → CI does NOT run again ✅
3. PR shows the latest push-triggered CI status ✅

## Test Plan

- [x] Modified `.github/workflows/ci.yml`
- [x] Removed `pull_request` trigger section
- [x] Kept `push` trigger with existing branch patterns
- [x] Verified git diff shows only the intended changes
- [x] Pushed to feature branch and confirmed CI runs on push

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)