### PR TITLE
feat: Update application layer DTOs for CVE check (Issue #44)

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter.rs
@@ -139,7 +139,7 @@ mod tests {
             EnrichedPackage::new(pkg2, None, Some("Array library".to_string())),
         ];
 
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
+        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0", false);
         let formatter = CycloneDxFormatter::new();
         let result = formatter.format(enriched, &metadata);
 

--- a/src/adapters/outbound/formatters/markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter.rs
@@ -154,7 +154,7 @@ mod tests {
             Some("HTTP library".to_string()),
         )];
 
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
+        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0", false);
         let formatter = MarkdownFormatter::new();
         let result = formatter.format(enriched, &metadata);
 
@@ -190,7 +190,7 @@ mod tests {
         );
         let graph = DependencyGraph::new(direct_deps, transitive_deps);
 
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
+        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0", false);
         let formatter = MarkdownFormatter::new();
         let result = formatter.format_with_dependencies(&graph, enriched, &metadata);
 

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -14,6 +14,8 @@ pub struct SbomRequest {
     pub exclude_patterns: Vec<String>,
     /// Whether to perform dry-run validation only (skip network operations and output generation)
     pub dry_run: bool,
+    /// Whether to check for vulnerabilities using OSV API
+    pub check_cve: bool,
 }
 
 impl SbomRequest {
@@ -22,12 +24,14 @@ impl SbomRequest {
         include_dependency_info: bool,
         exclude_patterns: Vec<String>,
         dry_run: bool,
+        check_cve: bool,
     ) -> Self {
         Self {
             project_path,
             include_dependency_info,
             exclude_patterns,
             dry_run,
+            check_cve,
         }
     }
 }

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -1,4 +1,5 @@
 use crate::ports::outbound::EnrichedPackage;
+use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
 use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata};
 
 /// SbomResponse - Internal response DTO from SBOM generation use case
@@ -13,6 +14,10 @@ pub struct SbomResponse {
     pub dependency_graph: Option<DependencyGraph>,
     /// SBOM metadata (timestamp, tool info, serial number)
     pub metadata: SbomMetadata,
+    /// Optional vulnerability report (only present when CVE check is enabled)
+    /// None = not checked, Some(vec) = checked (empty vec means no vulnerabilities found)
+    #[allow(dead_code)] // Will be used in subsequent subtasks
+    pub vulnerability_report: Option<Vec<PackageVulnerabilities>>,
 }
 
 impl SbomResponse {
@@ -20,11 +25,13 @@ impl SbomResponse {
         enriched_packages: Vec<EnrichedPackage>,
         dependency_graph: Option<DependencyGraph>,
         metadata: SbomMetadata,
+        vulnerability_report: Option<Vec<PackageVulnerabilities>>,
     ) -> Self {
         Self {
             enriched_packages,
             dependency_graph,
             metadata,
+            vulnerability_report,
         }
     }
 }

--- a/src/application/use_cases/generate_sbom.rs
+++ b/src/application/use_cases/generate_sbom.rs
@@ -115,8 +115,8 @@ where
             self.progress_reporter
                 .report_completion("Success: Configuration validated. No issues found.");
             // Return empty response for dry-run
-            let metadata = SbomGenerator::generate_default_metadata();
-            return Ok(SbomResponse::new(vec![], None, metadata));
+            let metadata = SbomGenerator::generate_default_metadata(request.check_cve);
+            return Ok(SbomResponse::new(vec![], None, metadata, None));
         }
 
         // Step 3: Analyze dependencies if requested
@@ -153,13 +153,14 @@ where
         let enriched_packages = self.enrich_packages_with_licenses(filtered_packages)?;
 
         // Step 5: Generate SBOM metadata
-        let metadata = SbomGenerator::generate_default_metadata();
+        let metadata = SbomGenerator::generate_default_metadata(request.check_cve);
 
         // Step 6: Create response
         Ok(SbomResponse::new(
             enriched_packages,
             dependency_graph,
             metadata,
+            None, // TODO: Vulnerability report will be added in subsequent subtasks
         ))
     }
 
@@ -355,6 +356,7 @@ version = "3.4.0"
             false,  // no dependency info
             vec![], // no exclusion patterns
             false,  // not dry-run
+            false,  // no CVE check
         );
 
         let response = use_case.execute(request).unwrap();
@@ -402,6 +404,7 @@ version = "1.26.0"
             true,   // with dependency info
             vec![], // no exclusion patterns
             false,  // not dry-run
+            false,  // no CVE check
         );
 
         let response = use_case.execute(request).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! );
 //!
 //! // Execute
-//! let request = SbomRequest::new(PathBuf::from("."), false, vec![], false);
+//! let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
 //! let response = use_case.execute(request)?;
 //!
 //! // Format output

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ fn run() -> Result<()> {
         include_dependency_info,
         args.exclude,
         args.dry_run,
+        false, // TODO: CVE check will be added in subsequent subtasks
     );
 
     // Execute use case

--- a/src/sbom_generation/domain/sbom_metadata.rs
+++ b/src/sbom_generation/domain/sbom_metadata.rs
@@ -5,6 +5,10 @@ pub struct SbomMetadata {
     tool_name: String,
     tool_version: String,
     serial_number: String,
+    /// OSV data attribution for CC-BY 4.0 license compliance
+    /// Only present when vulnerability data from OSV is included
+    #[allow(dead_code)] // Will be used in subsequent subtasks
+    osv_attribution: Option<String>,
 }
 
 impl SbomMetadata {
@@ -13,12 +17,14 @@ impl SbomMetadata {
         tool_name: String,
         tool_version: String,
         serial_number: String,
+        osv_attribution: Option<String>,
     ) -> Self {
         Self {
             timestamp,
             tool_name,
             tool_version,
             serial_number,
+            osv_attribution,
         }
     }
 
@@ -37,6 +43,43 @@ impl SbomMetadata {
     pub fn serial_number(&self) -> &str {
         &self.serial_number
     }
+
+    #[allow(dead_code)] // Will be used in subsequent subtasks
+    pub fn osv_attribution(&self) -> Option<&str> {
+        self.osv_attribution.as_deref()
+    }
+
+    /// Creates metadata with OSV attribution for CC-BY 4.0 compliance
+    ///
+    /// Use this when vulnerability data from OSV is included in the SBOM
+    pub fn with_osv_attribution(
+        timestamp: String,
+        tool_name: String,
+        tool_version: String,
+        serial_number: String,
+    ) -> Self {
+        Self::new(
+            timestamp,
+            tool_name,
+            tool_version,
+            serial_number,
+            Some(
+                "Vulnerability data provided by OSV (https://osv.dev) under CC-BY 4.0".to_string(),
+            ),
+        )
+    }
+
+    /// Creates metadata without OSV attribution
+    ///
+    /// Use this when no vulnerability data is included in the SBOM
+    pub fn without_osv_attribution(
+        timestamp: String,
+        tool_name: String,
+        tool_version: String,
+        serial_number: String,
+    ) -> Self {
+        Self::new(timestamp, tool_name, tool_version, serial_number, None)
+    }
 }
 
 #[cfg(test)]
@@ -50,11 +93,48 @@ mod tests {
             "uv-sbom".to_string(),
             "0.1.0".to_string(),
             "urn:uuid:12345".to_string(),
+            None,
         );
 
         assert_eq!(metadata.timestamp(), "2024-01-01T00:00:00Z");
         assert_eq!(metadata.tool_name(), "uv-sbom");
         assert_eq!(metadata.tool_version(), "0.1.0");
         assert_eq!(metadata.serial_number(), "urn:uuid:12345");
+        assert_eq!(metadata.osv_attribution(), None);
+    }
+
+    #[test]
+    fn test_sbom_metadata_with_osv_attribution() {
+        let metadata = SbomMetadata::with_osv_attribution(
+            "2024-01-01T00:00:00Z".to_string(),
+            "uv-sbom".to_string(),
+            "0.1.0".to_string(),
+            "urn:uuid:12345".to_string(),
+        );
+
+        assert_eq!(metadata.timestamp(), "2024-01-01T00:00:00Z");
+        assert_eq!(metadata.tool_name(), "uv-sbom");
+        assert_eq!(metadata.tool_version(), "0.1.0");
+        assert_eq!(metadata.serial_number(), "urn:uuid:12345");
+        assert_eq!(
+            metadata.osv_attribution(),
+            Some("Vulnerability data provided by OSV (https://osv.dev) under CC-BY 4.0")
+        );
+    }
+
+    #[test]
+    fn test_sbom_metadata_without_osv_attribution() {
+        let metadata = SbomMetadata::without_osv_attribution(
+            "2024-01-01T00:00:00Z".to_string(),
+            "uv-sbom".to_string(),
+            "0.1.0".to_string(),
+            "urn:uuid:12345".to_string(),
+        );
+
+        assert_eq!(metadata.timestamp(), "2024-01-01T00:00:00Z");
+        assert_eq!(metadata.tool_name(), "uv-sbom");
+        assert_eq!(metadata.tool_version(), "0.1.0");
+        assert_eq!(metadata.serial_number(), "urn:uuid:12345");
+        assert_eq!(metadata.osv_attribution(), None);
     }
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -21,7 +21,7 @@ fn test_e2e_json_format() {
         progress_reporter,
     );
 
-    let request = SbomRequest::new(project_path, false, vec![], false);
+    let request = SbomRequest::new(project_path, false, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -57,7 +57,7 @@ fn test_e2e_markdown_format() {
         progress_reporter,
     );
 
-    let request = SbomRequest::new(project_path, true, vec![], false);
+    let request = SbomRequest::new(project_path, true, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -100,7 +100,7 @@ fn test_e2e_nonexistent_project() {
         progress_reporter,
     );
 
-    let request = SbomRequest::new(project_path, false, vec![], false);
+    let request = SbomRequest::new(project_path, false, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_err());
@@ -122,7 +122,7 @@ fn test_e2e_package_count() {
         progress_reporter,
     );
 
-    let request = SbomRequest::new(project_path, true, vec![], false);
+    let request = SbomRequest::new(project_path, true, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -156,7 +156,13 @@ fn test_e2e_exclude_single_package() {
     );
 
     // Exclude urllib3
-    let request = SbomRequest::new(project_path, false, vec!["urllib3".to_string()], false);
+    let request = SbomRequest::new(
+        project_path,
+        false,
+        vec!["urllib3".to_string()],
+        false,
+        false,
+    );
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -193,6 +199,7 @@ fn test_e2e_exclude_multiple_packages() {
         project_path,
         false,
         vec!["urllib3".to_string(), "certifi".to_string()],
+        false,
         false,
     );
     let result = use_case.execute(request);
@@ -231,7 +238,7 @@ fn test_e2e_exclude_with_wildcard() {
     );
 
     // Exclude packages starting with "char"
-    let request = SbomRequest::new(project_path, false, vec!["char*".to_string()], false);
+    let request = SbomRequest::new(project_path, false, vec!["char*".to_string()], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -275,6 +282,7 @@ fn test_e2e_exclude_all_packages_error() {
             "*certifi*".to_string(),
             "*sample*".to_string(),
         ],
+        false,
         false,
     );
     let result = use_case.execute(request);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40,7 +40,7 @@ source = { registry = "https://pypi.org/simple" }
         progress_reporter,
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -91,7 +91,7 @@ source = { registry = "https://pypi.org/simple" }
         progress_reporter,
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), true, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), true, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_ok());
@@ -119,7 +119,7 @@ fn test_generate_sbom_lockfile_read_failure() {
         progress_reporter,
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_err());
@@ -150,7 +150,7 @@ source = { registry = "https://pypi.org/simple" }
         progress_reporter,
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), true, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), true, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_err());
@@ -181,7 +181,7 @@ source = { registry = "https://pypi.org/simple" }
         progress_reporter.clone(),
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
     let result = use_case.execute(request);
 
     // License repository failures are treated as warnings, not errors
@@ -214,7 +214,7 @@ fn test_generate_sbom_invalid_toml() {
         progress_reporter,
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
     let result = use_case.execute(request);
 
     assert!(result.is_err());
@@ -249,7 +249,7 @@ source = { registry = "https://pypi.org/simple" }
         progress_reporter.clone(),
     );
 
-    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false);
+    let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
     let _result = use_case.execute(request);
 
     // Verify that progress was reported
@@ -301,6 +301,7 @@ source = { registry = "https://pypi.org/simple" }
         PathBuf::from("."),
         false,
         vec!["urllib3".to_string()],
+        false,
         false,
     );
     let result = use_case.execute(request);
@@ -373,6 +374,7 @@ source = { registry = "https://pypi.org/simple" }
         false,
         vec!["urllib3".to_string(), "certifi".to_string()],
         false,
+        false,
     );
     let result = use_case.execute(request);
 
@@ -429,6 +431,7 @@ source = { registry = "https://pypi.org/simple" }
         false,
         vec!["pytest*".to_string()],
         false,
+        false,
     );
     let result = use_case.execute(request);
 
@@ -469,6 +472,7 @@ source = { registry = "https://pypi.org/simple" }
         PathBuf::from("."),
         false,
         vec!["*requests*".to_string()],
+        false,
         false,
     );
     let result = use_case.execute(request);
@@ -526,7 +530,13 @@ source = { registry = "https://pypi.org/simple" }
     );
 
     // Exclude urllib3 and request dependency graph
-    let request = SbomRequest::new(PathBuf::from("."), true, vec!["urllib3".to_string()], false);
+    let request = SbomRequest::new(
+        PathBuf::from("."),
+        true,
+        vec!["urllib3".to_string()],
+        false,
+        false,
+    );
     let result = use_case.execute(request);
 
     assert!(result.is_ok());


### PR DESCRIPTION
## Summary
This PR updates the application layer DTOs to support the `--check-cve` option as part of the CVE vulnerability checking feature implementation.

**Changes:**
- ✅ Added `check_cve: bool` field to `SbomRequest`
- ✅ Added `vulnerability_report: Option<Vec<PackageVulnerabilities>>` field to `SbomResponse`  
- ✅ Added `osv_attribution: Option<String>` field to `SbomMetadata`
- ✅ Implemented `SbomMetadata::with_osv_attribution()` and `without_osv_attribution()` helper methods
- ✅ Updated all existing call sites to use new constructor signatures
- ✅ All tests pass, `cargo build` and `cargo clippy` succeed

## Implementation Details
- The `vulnerability_report` field uses `Option<Vec<...>>` to distinguish between "not checked" (None) and "checked but clean" (Some(empty vec))
- The `osv_attribution` field includes proper CC-BY 4.0 license attribution text when CVE data is included
- Used `#[allow(dead_code)]` for fields that will be utilized in subsequent subtasks

## Test Plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo build` succeeds
- [x] All existing tests pass

## Related Issues
Closes #44
Part of #2 (Feature Request: Add --check-cve option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)