### PR TITLE
feat: add --check-cve CLI option and wire dependencies (Issue #47)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,11 @@ pub struct Args {
     /// Validate configuration without performing network operations or generating output
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Check for known vulnerabilities using OSV API (Markdown format only)
+    /// Vulnerability data provided by OSV (https://osv.dev) under CC-BY 4.0
+    #[arg(long)]
+    pub check_cve: bool,
 }
 
 impl Args {


### PR DESCRIPTION
## Summary

This PR implements the final integration task for the `--check-cve` feature, making vulnerability checking fully functional. It adds the CLI option and wires up all dependencies through dependency injection.

**Changes:**
- Added `--check-cve` CLI option with help text explaining Markdown-only support and OSV attribution (CC-BY 4.0)
- Created `OsvClient` conditionally when `--check-cve` flag is set (lazy initialization)
- Passed `vulnerability_repository` to `GenerateSbomUseCase`
- Passed `check_cve` flag to `SbomRequest`
- Added warning when `--check-cve` is used with JSON format (feature not supported yet)
- Removed unnecessary type annotation from `use_case` (now inferred correctly)

## Related Issues

- Closes #47
- Part of #2: Feature Request: Add --check-cve option for Markdown output using OSV API
- Depends on: #41, #42, #43, #44, #45, #46 (all completed)

## Test Plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (153 tests, all existing tests work without modification)
- [x] All existing tests already pass `check_cve: false`, maintaining backward compatibility

## Manual Testing

Test the new CLI option:
```bash
# Show help text
uv-sbom --help

# Run with CVE check (requires real project with uv.lock)
uv-sbom --format markdown --check-cve

# Verify warning with JSON format
uv-sbom --format json --check-cve

# Dry-run mode (should skip CVE check)
uv-sbom --dry-run --check-cve
```

## Implementation Details

**Lazy Initialization:**
The `OsvClient` is only created when `--check-cve` is set, avoiding unnecessary network connections and faster startup when CVE check is not requested.

**Format Validation:**
Users are warned (but not blocked) when using `--check-cve` with JSON format, as the initial implementation only supports Markdown output.

**Backward Compatibility:**
All existing tests continue to work without modification since they already pass `check_cve: false` to `SbomRequest::new()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)