### PR TITLE
refactor: split GenerateSbomUseCase::execute() into smaller methods

### DIFF
--- a/src/application/use_cases/generate_sbom.rs
+++ b/src/application/use_cases/generate_sbom.rs
@@ -60,6 +60,36 @@ where
     /// SbomResponse containing enriched packages, optional dependency graph, and metadata
     pub fn execute(&self, request: SbomRequest) -> Result<SbomResponse> {
         // Step 1: Read and parse lockfile
+        let (packages, dependency_map) = self.read_and_report_lockfile(&request)?;
+
+        // Step 2: Apply exclusion filters
+        let (filtered_packages, filtered_dependency_map) =
+            self.apply_exclusion_filters(packages, dependency_map, &request.exclude_patterns)?;
+
+        // Step 3: Analyze dependencies if requested
+        let dependency_graph = self.analyze_dependencies_if_requested(
+            &request,
+            &filtered_dependency_map,
+        )?;
+
+        // Step 4: Enrich packages with license information
+        let enriched_packages = self.fetch_license_info(filtered_packages)?;
+
+        // Step 5: Build and return response
+        Ok(self.build_response(enriched_packages, dependency_graph))
+    }
+
+    /// Reads and parses the lockfile, reporting progress
+    ///
+    /// # Arguments
+    /// * `request` - The SBOM request containing project path
+    ///
+    /// # Returns
+    /// Tuple of (packages, dependency_map)
+    fn read_and_report_lockfile(
+        &self,
+        request: &SbomRequest,
+    ) -> Result<(Vec<Package>, std::collections::HashMap<String, Vec<String>>)> {
         self.progress_reporter.report(&format!(
             "📖 Loading uv.lock file from: {}",
             request.project_path.display()
@@ -72,77 +102,124 @@ where
         self.progress_reporter
             .report(&format!("✅ Detected {} package(s)", packages.len()));
 
-        // Step 2: Apply exclusion filters
-        let (filtered_packages, filtered_dependency_map) = if !request.exclude_patterns.is_empty() {
-            let filter = PackageFilter::new(request.exclude_patterns)?;
-            let original_count = packages.len();
-            let filtered_pkgs = filter.filter_packages(packages);
-            let filtered_deps = filter.filter_dependency_map(dependency_map);
+        Ok((packages, dependency_map))
+    }
 
-            let excluded_count = original_count - filtered_pkgs.len();
-            if excluded_count > 0 {
-                self.progress_reporter.report(&format!(
-                    "🚫 Excluded {} package(s) based on filters",
-                    excluded_count
-                ));
-            }
+    /// Applies exclusion filters to packages and dependency map
+    ///
+    /// # Arguments
+    /// * `packages` - Original packages from lockfile
+    /// * `dependency_map` - Original dependency map
+    /// * `exclude_patterns` - Patterns to exclude
+    ///
+    /// # Returns
+    /// Tuple of (filtered_packages, filtered_dependency_map)
+    ///
+    /// # Errors
+    /// Returns an error if all packages are excluded
+    fn apply_exclusion_filters(
+        &self,
+        packages: Vec<Package>,
+        dependency_map: std::collections::HashMap<String, Vec<String>>,
+        exclude_patterns: &[String],
+    ) -> Result<(Vec<Package>, std::collections::HashMap<String, Vec<String>>)> {
+        if exclude_patterns.is_empty() {
+            return Ok((packages, dependency_map));
+        }
 
-            // Check if all packages were excluded
-            if filtered_pkgs.is_empty() {
-                anyhow::bail!(
-                    "All {} package(s) were excluded by the provided filters. \
-                         The SBOM would be empty. Please adjust your exclusion patterns.",
-                    original_count
-                );
-            }
+        let filter = PackageFilter::new(exclude_patterns.to_vec())?;
+        let original_count = packages.len();
+        let filtered_pkgs = filter.filter_packages(packages);
+        let filtered_deps = filter.filter_dependency_map(dependency_map);
 
-            (filtered_pkgs, filtered_deps)
-        } else {
-            (packages, dependency_map)
-        };
-
-        // Step 3: Analyze dependencies if requested
-        let dependency_graph = if request.include_dependency_info {
-            self.progress_reporter
-                .report("📊 Parsing dependency information...");
-
-            let project_name = self
-                .project_config_reader
-                .read_project_name(&request.project_path)?;
-            let project_package_name = PackageName::new(project_name)?;
-
-            let graph =
-                DependencyAnalyzer::analyze(&project_package_name, &filtered_dependency_map)?;
-
+        let excluded_count = original_count - filtered_pkgs.len();
+        if excluded_count > 0 {
             self.progress_reporter.report(&format!(
-                "   - Direct dependencies: {}",
-                graph.direct_dependency_count()
+                "🚫 Excluded {} package(s) based on filters",
+                excluded_count
             ));
-            self.progress_reporter.report(&format!(
-                "   - Transitive dependencies: {}",
-                graph.transitive_dependency_count()
-            ));
+        }
 
-            Some(graph)
-        } else {
-            None
-        };
+        // Check if all packages were excluded
+        if filtered_pkgs.is_empty() {
+            anyhow::bail!(
+                "All {} package(s) were excluded by the provided filters. \
+                     The SBOM would be empty. Please adjust your exclusion patterns.",
+                original_count
+            );
+        }
 
-        // Step 4: Enrich packages with license information
+        Ok((filtered_pkgs, filtered_deps))
+    }
+
+    /// Analyzes dependencies if requested in the SBOM request
+    ///
+    /// # Arguments
+    /// * `request` - The SBOM request
+    /// * `dependency_map` - Map of package dependencies
+    ///
+    /// # Returns
+    /// Optional DependencyGraph if analysis was requested
+    fn analyze_dependencies_if_requested(
+        &self,
+        request: &SbomRequest,
+        dependency_map: &std::collections::HashMap<String, Vec<String>>,
+    ) -> Result<Option<crate::sbom_generation::domain::DependencyGraph>> {
+        if !request.include_dependency_info {
+            return Ok(None);
+        }
+
+        self.progress_reporter
+            .report("📊 Parsing dependency information...");
+
+        let project_name = self
+            .project_config_reader
+            .read_project_name(&request.project_path)?;
+        let project_package_name = PackageName::new(project_name)?;
+
+        let graph = DependencyAnalyzer::analyze(&project_package_name, dependency_map)?;
+
+        self.progress_reporter.report(&format!(
+            "   - Direct dependencies: {}",
+            graph.direct_dependency_count()
+        ));
+        self.progress_reporter.report(&format!(
+            "   - Transitive dependencies: {}",
+            graph.transitive_dependency_count()
+        ));
+
+        Ok(Some(graph))
+    }
+
+    /// Fetches license information for packages
+    ///
+    /// # Arguments
+    /// * `packages` - Packages to enrich with license info
+    ///
+    /// # Returns
+    /// Vector of EnrichedPackage with license information
+    fn fetch_license_info(&self, packages: Vec<Package>) -> Result<Vec<EnrichedPackage>> {
         self.progress_reporter
             .report("🔍 Fetching license information...");
 
-        let enriched_packages = self.enrich_packages_with_licenses(filtered_packages)?;
+        self.enrich_packages_with_licenses(packages)
+    }
 
-        // Step 5: Generate SBOM metadata
+    /// Builds the final SBOM response
+    ///
+    /// # Arguments
+    /// * `enriched_packages` - Packages with license information
+    /// * `dependency_graph` - Optional dependency graph
+    ///
+    /// # Returns
+    /// Complete SbomResponse
+    fn build_response(
+        &self,
+        enriched_packages: Vec<EnrichedPackage>,
+        dependency_graph: Option<crate::sbom_generation::domain::DependencyGraph>,
+    ) -> SbomResponse {
         let metadata = SbomGenerator::generate_default_metadata();
-
-        // Step 6: Create response
-        Ok(SbomResponse::new(
-            enriched_packages,
-            dependency_graph,
-            metadata,
-        ))
+        SbomResponse::new(enriched_packages, dependency_graph, metadata)
     }
 
     /// Enriches packages with license information from the repository
@@ -392,5 +469,201 @@ version = "1.26.0"
         let graph = response.dependency_graph.unwrap();
         assert_eq!(graph.direct_dependency_count(), 1);
         assert_eq!(graph.transitive_dependency_count(), 1);
+    }
+
+    // ===== Tests for extracted methods =====
+
+    #[test]
+    fn test_apply_exclusion_filters_empty_patterns() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "test".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let packages = vec![
+            Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap(),
+            Package::new("pkg2".to_string(), "2.0.0".to_string()).unwrap(),
+        ];
+        let dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+        let exclude_patterns: Vec<String> = vec![];
+
+        let (filtered_pkgs, _filtered_deps) = use_case
+            .apply_exclusion_filters(packages.clone(), dependency_map, &exclude_patterns)
+            .unwrap();
+
+        assert_eq!(filtered_pkgs.len(), 2);
+    }
+
+    #[test]
+    fn test_apply_exclusion_filters_with_patterns() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "test".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let packages = vec![
+            Package::new("requests".to_string(), "1.0.0".to_string()).unwrap(),
+            Package::new("urllib3".to_string(), "2.0.0".to_string()).unwrap(),
+            Package::new("certifi".to_string(), "3.0.0".to_string()).unwrap(),
+        ];
+        let dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+        let exclude_patterns = vec!["requests".to_string()];
+
+        let (filtered_pkgs, _filtered_deps) = use_case
+            .apply_exclusion_filters(packages, dependency_map, &exclude_patterns)
+            .unwrap();
+
+        assert_eq!(filtered_pkgs.len(), 2);
+        assert!(!filtered_pkgs.iter().any(|p| p.name() == "requests"));
+    }
+
+    #[test]
+    fn test_apply_exclusion_filters_all_excluded_error() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "test".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let packages = vec![
+            Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap(),
+        ];
+        let dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+        let exclude_patterns = vec!["pkg1".to_string()];
+
+        let result = use_case.apply_exclusion_filters(packages, dependency_map, &exclude_patterns);
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("All 1 package(s) were excluded"));
+    }
+
+    #[test]
+    fn test_analyze_dependencies_disabled() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "test".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let request = SbomRequest::new(
+            std::path::PathBuf::from("/test/project"),
+            false, // dependency info disabled
+            vec![],
+        );
+        let dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+
+        let result = use_case
+            .analyze_dependencies_if_requested(&request, &dependency_map)
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_analyze_dependencies_enabled() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "myproject".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let request = SbomRequest::new(
+            std::path::PathBuf::from("/test/project"),
+            true, // dependency info enabled
+            vec![],
+        );
+        let mut dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+        dependency_map.insert("myproject".to_string(), vec!["requests".to_string()]);
+        dependency_map.insert("requests".to_string(), vec![]);
+
+        let result = use_case
+            .analyze_dependencies_if_requested(&request, &dependency_map)
+            .unwrap();
+
+        assert!(result.is_some());
+        let graph = result.unwrap();
+        assert_eq!(graph.direct_dependency_count(), 1);
+    }
+
+    #[test]
+    fn test_build_response() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "test".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let package = Package::new("test-pkg".to_string(), "1.0.0".to_string()).unwrap();
+        let enriched_packages = vec![EnrichedPackage::new(
+            package,
+            Some("MIT".to_string()),
+            Some("Test description".to_string()),
+        )];
+
+        let response = use_case.build_response(enriched_packages.clone(), None);
+
+        assert_eq!(response.enriched_packages.len(), 1);
+        assert!(response.dependency_graph.is_none());
+        assert!(!response.metadata.serial_number().is_empty());
+        assert!(!response.metadata.timestamp().is_empty());
+    }
+
+    #[test]
+    fn test_fetch_license_info() {
+        let use_case = GenerateSbomUseCase::new(
+            MockLockfileReader {
+                content: String::new(),
+            },
+            MockProjectConfigReader {
+                project_name: "test".to_string(),
+            },
+            MockLicenseRepository,
+            MockProgressReporter,
+        );
+
+        let packages = vec![
+            Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap(),
+            Package::new("pkg2".to_string(), "2.0.0".to_string()).unwrap(),
+        ];
+
+        let enriched = use_case.fetch_license_info(packages).unwrap();
+
+        assert_eq!(enriched.len(), 2);
+        // MockLicenseRepository always returns MIT license
+        assert!(enriched[0].license.is_some());
+        assert_eq!(enriched[0].license.as_ref().unwrap(), "MIT");
     }
 }


### PR DESCRIPTION
## Summary
- `GenerateSbomUseCase::execute()` メソッド（約85行）を5つの独立したメソッドに分割
- 各メソッドに対するユニットテストを追加
- `execute()` メソッドは約20行に簡潔化

### 抽出されたメソッド
| メソッド | 責務 |
|---------|------|
| `read_and_report_lockfile()` | ロックファイルの読み込みと進捗報告 |
| `apply_exclusion_filters()` | 除外パターンの適用 |
| `analyze_dependencies_if_requested()` | 依存関係解析（オプション） |
| `fetch_license_info()` | ライセンス情報の取得 |
| `build_response()` | 最終レスポンスの構築 |

## Benefits
- 各ステップを独立してテスト可能
- メソッド名が処理内容を明確に表現
- エラーハンドリングが各段階で明確化
- 将来の拡張が容易に

## Test plan
- [x] 既存の統合テストが全て通過
- [x] 既存のE2Eテストが全て通過
- [x] 新規ユニットテスト（7件）が通過
  - `test_apply_exclusion_filters_empty_patterns`
  - `test_apply_exclusion_filters_with_patterns`
  - `test_apply_exclusion_filters_all_excluded_error`
  - `test_analyze_dependencies_disabled`
  - `test_analyze_dependencies_enabled`
  - `test_build_response`
  - `test_fetch_license_info`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)