### PR TITLE
feat: make GenerateSbomUseCase asynchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.8"
 anyhow = "1.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 urlencoding = "2.1"

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -16,7 +16,6 @@ pub struct SbomResponse {
     pub metadata: SbomMetadata,
     /// Optional vulnerability report (only present when CVE check is enabled)
     /// None = not checked, Some(vec) = checked (empty vec means no vulnerabilities found)
-    #[allow(dead_code)] // Will be used in subsequent subtasks
     pub vulnerability_report: Option<Vec<PackageVulnerabilities>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@
 //! use uv_sbom::prelude::*;
 //! use std::path::PathBuf;
 //!
-//! # fn main() -> Result<()> {
+//! # #[tokio::main]
+//! # async fn main() -> Result<()> {
 //! // Create adapters
 //! let lockfile_reader = FileSystemReader::new();
 //! let project_config_reader = FileSystemReader::new();
@@ -37,7 +38,7 @@
 //!
 //! // Execute
 //! let request = SbomRequest::new(PathBuf::from("."), false, vec![], false, false);
-//! let response = use_case.execute(request)?;
+//! let response = use_case.execute(request).await?;
 //!
 //! // Format output
 //! let formatter = CycloneDxFormatter::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,9 @@ use shared::Result;
 use std::path::{Path, PathBuf};
 use std::process;
 
-fn main() {
-    if let Err(e) = run() {
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
         eprintln!("\n❌ An error occurred:\n");
         eprintln!("{}", e);
 
@@ -35,7 +36,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<()> {
+async fn run() -> Result<()> {
     // Display startup banner
     display_banner();
 
@@ -89,7 +90,7 @@ fn run() -> Result<()> {
     );
 
     // Execute use case
-    let response = use_case.execute(request)?;
+    let response = use_case.execute(request).await?;
 
     // Skip output generation for dry-run mode
     if args.dry_run {

--- a/src/ports/outbound/vulnerability_repository.rs
+++ b/src/ports/outbound/vulnerability_repository.rs
@@ -47,8 +47,6 @@ use async_trait::async_trait;
 /// # Ok(())
 /// # }
 /// ```
-// Note: This trait will be used in subsequent subtasks (Subtask 3-8) for CVE check implementation
-#[allow(dead_code)]
 #[async_trait]
 pub trait VulnerabilityRepository: Send + Sync {
     /// Fetches vulnerability information for multiple packages

--- a/src/sbom_generation/domain/vulnerability.rs
+++ b/src/sbom_generation/domain/vulnerability.rs
@@ -4,11 +4,9 @@ use crate::shared::Result;
 ///
 /// Ensures that CVSS scores are always valid (0.0-10.0, not NaN).
 /// This provides type safety and guarantees that a Vulnerability can only hold a valid score.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CvssScore(f32);
 
-#[allow(dead_code)]
 impl CvssScore {
     /// Creates a new CvssScore with validation
     ///
@@ -38,10 +36,6 @@ impl CvssScore {
 }
 
 /// Represents a single vulnerability (CVE) affecting a package
-///
-/// Note: This is currently unused but will be utilized in subsequent subtasks
-/// (Subtask 2-8) for the CVE check feature implementation.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Vulnerability {
     /// Vulnerability ID (e.g., "CVE-2024-1234", "GHSA-xxxx-xxxx-xxxx")
@@ -60,7 +54,6 @@ pub struct Vulnerability {
     summary: Option<String>,
 }
 
-#[allow(dead_code)]
 impl Vulnerability {
     /// Creates a new Vulnerability with validation
     ///
@@ -118,18 +111,9 @@ impl Vulnerability {
     pub fn fixed_version(&self) -> Option<&str> {
         self.fixed_version.as_deref()
     }
-
-    /// Returns the summary if available
-    pub fn summary(&self) -> Option<&str> {
-        self.summary.as_deref()
-    }
 }
 
 /// Severity levels based on CVSS scores
-///
-/// Note: This is currently unused but will be utilized in subsequent subtasks
-/// (Subtask 2-8) for the CVE check feature implementation.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
     None,     // CVSS 0.0 or unknown
@@ -139,7 +123,6 @@ pub enum Severity {
     Critical, // CVSS 9.0-10.0
 }
 
-#[allow(dead_code)]
 impl Severity {
     /// Converts CVSS score to severity level
     ///
@@ -170,24 +153,9 @@ impl Severity {
             Self::None => "⚪",
         }
     }
-
-    /// Returns color indicator for terminal output
-    pub fn color(&self) -> &str {
-        match self {
-            Self::Critical => "red",
-            Self::High => "orange",
-            Self::Medium => "yellow",
-            Self::Low => "green",
-            Self::None => "gray",
-        }
-    }
 }
 
 /// Represents vulnerability information for a specific package
-///
-/// Note: This is currently unused but will be utilized in subsequent subtasks
-/// (Subtask 2-8) for the CVE check feature implementation.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct PackageVulnerabilities {
     /// Package name
@@ -200,7 +168,6 @@ pub struct PackageVulnerabilities {
     vulnerabilities: Vec<Vulnerability>,
 }
 
-#[allow(dead_code)]
 impl PackageVulnerabilities {
     /// Creates a new PackageVulnerabilities
     ///
@@ -218,22 +185,6 @@ impl PackageVulnerabilities {
             current_version,
             vulnerabilities,
         }
-    }
-
-    /// Returns true if package has any vulnerabilities
-    pub fn has_vulnerabilities(&self) -> bool {
-        !self.vulnerabilities.is_empty()
-    }
-
-    /// Returns the highest severity among all vulnerabilities
-    ///
-    /// Returns `Severity::None` if there are no vulnerabilities
-    pub fn max_severity(&self) -> Severity {
-        self.vulnerabilities
-            .iter()
-            .map(|v| v.severity())
-            .max()
-            .unwrap_or(Severity::None)
     }
 
     /// Returns the package name
@@ -311,7 +262,6 @@ mod tests {
         assert_eq!(vuln.cvss_score().map(|s| s.value()), Some(9.8));
         assert_eq!(vuln.severity(), Severity::Critical);
         assert_eq!(vuln.fixed_version(), Some("2.0.0"));
-        assert_eq!(vuln.summary(), Some("SQL injection vulnerability"));
     }
 
     #[test]
@@ -340,7 +290,6 @@ mod tests {
         assert_eq!(vuln.id(), "GHSA-xxxx-yyyy-zzzz");
         assert_eq!(vuln.cvss_score(), None);
         assert_eq!(vuln.fixed_version(), None);
-        assert_eq!(vuln.summary(), None);
     }
 
     #[test]
@@ -393,15 +342,6 @@ mod tests {
     }
 
     #[test]
-    fn test_severity_color() {
-        assert_eq!(Severity::Critical.color(), "red");
-        assert_eq!(Severity::High.color(), "orange");
-        assert_eq!(Severity::Medium.color(), "yellow");
-        assert_eq!(Severity::Low.color(), "green");
-        assert_eq!(Severity::None.color(), "gray");
-    }
-
-    #[test]
     fn test_severity_ordering() {
         assert!(Severity::Critical > Severity::High);
         assert!(Severity::High > Severity::Medium);
@@ -438,71 +378,5 @@ mod tests {
         assert_eq!(pkg_vulns.package_name(), "requests");
         assert_eq!(pkg_vulns.current_version(), "1.0.0");
         assert_eq!(pkg_vulns.vulnerabilities().len(), 2);
-    }
-
-    #[test]
-    fn test_package_vulnerabilities_has_vulnerabilities() {
-        let pkg_vulns =
-            PackageVulnerabilities::new("safe-package".to_string(), "1.0.0".to_string(), vec![]);
-        assert!(!pkg_vulns.has_vulnerabilities());
-
-        let vuln = Vulnerability::new(
-            "CVE-2024-1234".to_string(),
-            Some(CvssScore::new(5.0).unwrap()),
-            Severity::Medium,
-            None,
-            None,
-        )
-        .unwrap();
-
-        let pkg_vulns = PackageVulnerabilities::new(
-            "unsafe-package".to_string(),
-            "1.0.0".to_string(),
-            vec![vuln],
-        );
-        assert!(pkg_vulns.has_vulnerabilities());
-    }
-
-    #[test]
-    fn test_package_vulnerabilities_max_severity() {
-        // Empty vulnerabilities
-        let pkg_vulns =
-            PackageVulnerabilities::new("safe-package".to_string(), "1.0.0".to_string(), vec![]);
-        assert_eq!(pkg_vulns.max_severity(), Severity::None);
-
-        // Multiple vulnerabilities
-        let vuln1 = Vulnerability::new(
-            "CVE-1".to_string(),
-            Some(CvssScore::new(5.0).unwrap()),
-            Severity::Medium,
-            None,
-            None,
-        )
-        .unwrap();
-
-        let vuln2 = Vulnerability::new(
-            "CVE-2".to_string(),
-            Some(CvssScore::new(9.8).unwrap()),
-            Severity::Critical,
-            None,
-            None,
-        )
-        .unwrap();
-
-        let vuln3 = Vulnerability::new(
-            "CVE-3".to_string(),
-            Some(CvssScore::new(7.5).unwrap()),
-            Severity::High,
-            None,
-            None,
-        )
-        .unwrap();
-
-        let pkg_vulns = PackageVulnerabilities::new(
-            "package".to_string(),
-            "1.0.0".to_string(),
-            vec![vuln1, vuln2, vuln3],
-        );
-        assert_eq!(pkg_vulns.max_severity(), Severity::Critical);
     }
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -2,8 +2,8 @@
 use std::path::PathBuf;
 use uv_sbom::prelude::*;
 
-#[test]
-fn test_e2e_json_format() {
+#[tokio::test]
+async fn test_e2e_json_format() {
     // Use the sample project fixture
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
@@ -23,7 +23,7 @@ fn test_e2e_json_format() {
     );
 
     let request = SbomRequest::new(project_path, false, vec![], false, false);
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
@@ -42,8 +42,8 @@ fn test_e2e_json_format() {
     assert!(json.contains("urllib3"));
 }
 
-#[test]
-fn test_e2e_markdown_format() {
+#[tokio::test]
+async fn test_e2e_markdown_format() {
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
     let lockfile_reader = FileSystemReader::new();
@@ -60,7 +60,7 @@ fn test_e2e_markdown_format() {
     );
 
     let request = SbomRequest::new(project_path, true, vec![], false, false);
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
@@ -87,8 +87,8 @@ fn test_e2e_markdown_format() {
     assert!(markdown.contains("requests"));
 }
 
-#[test]
-fn test_e2e_nonexistent_project() {
+#[tokio::test]
+async fn test_e2e_nonexistent_project() {
     let project_path = PathBuf::from("tests/fixtures/nonexistent");
 
     let lockfile_reader = FileSystemReader::new();
@@ -105,13 +105,13 @@ fn test_e2e_nonexistent_project() {
     );
 
     let request = SbomRequest::new(project_path, false, vec![], false, false);
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_err());
 }
 
-#[test]
-fn test_e2e_package_count() {
+#[tokio::test]
+async fn test_e2e_package_count() {
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
     let lockfile_reader = FileSystemReader::new();
@@ -128,7 +128,7 @@ fn test_e2e_package_count() {
     );
 
     let request = SbomRequest::new(project_path, true, vec![], false, false);
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
@@ -144,8 +144,8 @@ fn test_e2e_package_count() {
     assert!(graph.transitive_dependency_count() > 0); // requests has transitive deps
 }
 
-#[test]
-fn test_e2e_exclude_single_package() {
+#[tokio::test]
+async fn test_e2e_exclude_single_package() {
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
     let lockfile_reader = FileSystemReader::new();
@@ -169,7 +169,7 @@ fn test_e2e_exclude_single_package() {
         false,
         false,
     );
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
@@ -184,8 +184,8 @@ fn test_e2e_exclude_single_package() {
         .any(|p| p.package.name() == "urllib3"));
 }
 
-#[test]
-fn test_e2e_exclude_multiple_packages() {
+#[tokio::test]
+async fn test_e2e_exclude_multiple_packages() {
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
     let lockfile_reader = FileSystemReader::new();
@@ -209,7 +209,7 @@ fn test_e2e_exclude_multiple_packages() {
         false,
         false,
     );
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
@@ -228,8 +228,8 @@ fn test_e2e_exclude_multiple_packages() {
         .any(|p| p.package.name() == "certifi"));
 }
 
-#[test]
-fn test_e2e_exclude_with_wildcard() {
+#[tokio::test]
+async fn test_e2e_exclude_with_wildcard() {
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
     let lockfile_reader = FileSystemReader::new();
@@ -247,7 +247,7 @@ fn test_e2e_exclude_with_wildcard() {
 
     // Exclude packages starting with "char"
     let request = SbomRequest::new(project_path, false, vec!["char*".to_string()], false, false);
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     assert!(result.is_ok());
     let response = result.unwrap();
@@ -262,8 +262,8 @@ fn test_e2e_exclude_with_wildcard() {
         .any(|p| p.package.name() == "charset-normalizer"));
 }
 
-#[test]
-fn test_e2e_exclude_all_packages_error() {
+#[tokio::test]
+async fn test_e2e_exclude_all_packages_error() {
     let project_path = PathBuf::from("tests/fixtures/sample-project");
 
     let lockfile_reader = FileSystemReader::new();
@@ -294,7 +294,7 @@ fn test_e2e_exclude_all_packages_error() {
         false,
         false,
     );
-    let result = use_case.execute(request);
+    let result = use_case.execute(request).await;
 
     // Should fail because all packages would be excluded
     assert!(result.is_err());


### PR DESCRIPTION
## Summary
- Convert `GenerateSbomUseCase::execute` and related methods to async
- Update `main.rs` to use `#[tokio::main] async fn main()`
- Remove `Runtime::new()` and `block_on()` calls, use direct `await` instead
- Remove unused methods: `Vulnerability::summary()`, `Severity::color()`, `PackageVulnerabilities::has_vulnerabilities()`, `max_severity()`
- Remove `#[allow(dead_code)]` from types that are now actually used

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` all pass

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)