### PR TITLE
feat(cli): add --severity-threshold and --cvss-threshold options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,11 +36,13 @@ pub struct Args {
     pub check_cve: bool,
 
     /// Severity threshold for vulnerability check (low/medium/high/critical)
-    #[arg(long, value_parser = parse_severity_threshold, group = "threshold")]
+    /// Requires --check-cve to be enabled
+    #[arg(long, value_parser = parse_severity_threshold, group = "threshold", requires = "check_cve")]
     pub severity_threshold: Option<Severity>,
 
     /// CVSS threshold for vulnerability check (0.0-10.0)
-    #[arg(long, value_parser = parse_cvss_threshold, group = "threshold")]
+    /// Requires --check-cve to be enabled
+    #[arg(long, value_parser = parse_cvss_threshold, group = "threshold", requires = "check_cve")]
     pub cvss_threshold: Option<f32>,
 }
 


### PR DESCRIPTION
## Summary

- Add `--severity-threshold` option accepting low/medium/high/critical (case-insensitive)
- Add `--cvss-threshold` option accepting 0.0-10.0 float values
- Implement mutual exclusion using clap's group attribute
- Add unit tests for parser functions

## Test plan

- [x] `--severity-threshold` accepts low/medium/high/critical (case-insensitive)
- [x] `--cvss-threshold` accepts 0.0-10.0 float values
- [x] Using both options results in clap error (Exit Code 2)
- [x] Invalid values show appropriate error messages
- [x] Unit tests for parser functions pass

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)