### PR TITLE
fix: Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ on:
       - '**.md'
       - '.gitignore'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Add explicit `permissions` block to CI workflow
- Set minimal `contents: read` permission following the principle of least privilege
- Resolve Code Scanning Alert #1

## Test plan
- [ ] Verify CI workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)