### PR TITLE
refactor: migrate skill files to new directory structure with SKILL.md

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: commit
+description: Create commits with code quality checks and conventional commit messages
+---
+
 # /commit - Commit Creation Skill
 
 Create commits with proper code quality checks and conventional commit messages.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: implement
+description: Orchestrate complete issue implementation workflow from branch to PR
+---
+
 # /implement - Issue Implementation Skill
 
 Orchestrates the complete workflow for implementing a GitHub issue, from branch creation to PR submission.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: issue
+description: Create GitHub Issues with consistent formatting for autonomous implementation
+---
+
 # /issue - Issue Creation Skill
 
 Create GitHub Issues with consistent formatting and sufficient technical detail for autonomous implementation.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pr
+description: Create Pull Requests with pre-flight checks and proper formatting
+---
+
 # /pr - Pull Request Creation Skill
 
 Create Pull Requests that pass CI before creation and target the correct branch.

--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pre-push
+description: Run all validations before pushing to remote
+---
+
 # /pre-push - Pre-push Validation Skill
 
 Final validation before pushing commits to remote repository.


### PR DESCRIPTION
## Summary

- Migrate all 5 skill files from flat format to new directory structure recognized by Claude Code's Skill tool
- Add YAML frontmatter with `name` and `description` metadata to each skill
- Remove old flat `.md` files

## Related Issue

Closes #135

## Changes Made

| Old Path | New Path |
|----------|----------|
| `.claude/skills/commit.md` | `.claude/skills/commit/SKILL.md` |
| `.claude/skills/implement.md` | `.claude/skills/implement/SKILL.md` |
| `.claude/skills/issue.md` | `.claude/skills/issue/SKILL.md` |
| `.claude/skills/pr.md` | `.claude/skills/pr/SKILL.md` |
| `.claude/skills/pre-push.md` | `.claude/skills/pre-push/SKILL.md` |

Each SKILL.md now includes frontmatter:

```yaml
---
name: <skill-name>
description: <brief description for Claude's auto-invocation>
---
```

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Skill files migrated with correct structure
- [ ] Verify Claude Code's Skill tool recognizes all skills (requires manual testing after merge)

---
Generated with [Claude Code](https://claude.com/claude-code)