### PR TITLE
feat(adapters): implement CachingPyPiLicenseRepository for license caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +512,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -741,7 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -846,6 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +947,19 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1089,6 +1137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1270,6 +1327,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1761,6 +1824,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "dashmap",
  "indicatif",
  "owo-colors",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 urlencoding = "2.1"
 indicatif = "0.18"
+dashmap = "6"
 owo-colors = "4.1"
 
 [dev-dependencies]

--- a/src/adapters/outbound/network/caching_pypi_client.rs
+++ b/src/adapters/outbound/network/caching_pypi_client.rs
@@ -1,0 +1,196 @@
+use crate::ports::outbound::{LicenseRepository, PyPiMetadata};
+use crate::shared::Result;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+/// Cache key for license information
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct CacheKey {
+    package_name: String,
+    version: String,
+}
+
+impl CacheKey {
+    fn new(package_name: &str, version: &str) -> Self {
+        Self {
+            package_name: package_name.to_string(),
+            version: version.to_string(),
+        }
+    }
+}
+
+/// CachingPyPiLicenseRepository wraps a LicenseRepository and adds in-memory caching.
+///
+/// This adapter implements the decorator pattern to add caching capability
+/// to any LicenseRepository implementation. The cache is thread-safe and
+/// suitable for concurrent access.
+///
+/// # Architecture
+/// In hexagonal architecture, caching is an implementation detail of the adapter layer.
+/// The domain layer only cares about fetching license information - whether it comes
+/// from cache or API is transparent to the domain.
+pub struct CachingPyPiLicenseRepository<R: LicenseRepository> {
+    inner: R,
+    cache: Arc<DashMap<CacheKey, PyPiMetadata>>,
+}
+
+impl<R: LicenseRepository> CachingPyPiLicenseRepository<R> {
+    /// Creates a new caching repository wrapping the given inner repository
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            cache: Arc::new(DashMap::new()),
+        }
+    }
+
+    /// Returns the current cache size (for testing/monitoring)
+    #[cfg(test)]
+    pub fn cache_size(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+#[async_trait]
+impl<R: LicenseRepository> LicenseRepository for CachingPyPiLicenseRepository<R> {
+    async fn fetch_license_info(&self, package_name: &str, version: &str) -> Result<PyPiMetadata> {
+        let key = CacheKey::new(package_name, version);
+
+        // Check cache first
+        if let Some(cached) = self.cache.get(&key) {
+            return Ok(cached.clone());
+        }
+
+        // Cache miss: fetch from inner repository
+        let metadata = self.inner.fetch_license_info(package_name, version).await?;
+
+        // Store in cache
+        self.cache.insert(key, metadata.clone());
+
+        Ok(metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Mock repository for testing that tracks call counts
+    struct MockLicenseRepository {
+        call_count: AtomicUsize,
+    }
+
+    impl MockLicenseRepository {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn get_call_count(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl LicenseRepository for MockLicenseRepository {
+        async fn fetch_license_info(
+            &self,
+            package_name: &str,
+            _version: &str,
+        ) -> Result<PyPiMetadata> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok((
+                Some(format!("{}-license", package_name)),
+                Some("MIT".to_string()),
+                vec!["License :: OSI Approved :: MIT License".to_string()],
+                Some(format!("{} description", package_name)),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_caching_repository_returns_cached_value() {
+        let mock = MockLicenseRepository::new();
+        let caching_repo = CachingPyPiLicenseRepository::new(mock);
+
+        // First call - should hit the inner repository
+        let result1 = caching_repo
+            .fetch_license_info("requests", "2.31.0")
+            .await
+            .unwrap();
+        assert_eq!(result1.0, Some("requests-license".to_string()));
+        assert_eq!(caching_repo.inner.get_call_count(), 1);
+
+        // Second call - should return cached value
+        let result2 = caching_repo
+            .fetch_license_info("requests", "2.31.0")
+            .await
+            .unwrap();
+        assert_eq!(result2.0, Some("requests-license".to_string()));
+        // Call count should still be 1 (cached)
+        assert_eq!(caching_repo.inner.get_call_count(), 1);
+
+        // Cache size should be 1
+        assert_eq!(caching_repo.cache_size(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_caching_repository_different_versions_cached_separately() {
+        let mock = MockLicenseRepository::new();
+        let caching_repo = CachingPyPiLicenseRepository::new(mock);
+
+        // Fetch version 2.31.0
+        caching_repo
+            .fetch_license_info("requests", "2.31.0")
+            .await
+            .unwrap();
+        assert_eq!(caching_repo.inner.get_call_count(), 1);
+
+        // Fetch version 2.32.0 - should hit inner repository
+        caching_repo
+            .fetch_license_info("requests", "2.32.0")
+            .await
+            .unwrap();
+        assert_eq!(caching_repo.inner.get_call_count(), 2);
+
+        // Cache size should be 2
+        assert_eq!(caching_repo.cache_size(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_caching_repository_different_packages_cached_separately() {
+        let mock = MockLicenseRepository::new();
+        let caching_repo = CachingPyPiLicenseRepository::new(mock);
+
+        // Fetch requests
+        let result1 = caching_repo
+            .fetch_license_info("requests", "2.31.0")
+            .await
+            .unwrap();
+        assert_eq!(result1.0, Some("requests-license".to_string()));
+
+        // Fetch flask - should hit inner repository
+        let result2 = caching_repo
+            .fetch_license_info("flask", "2.3.0")
+            .await
+            .unwrap();
+        assert_eq!(result2.0, Some("flask-license".to_string()));
+
+        assert_eq!(caching_repo.inner.get_call_count(), 2);
+        assert_eq!(caching_repo.cache_size(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_equality() {
+        let key1 = CacheKey::new("requests", "2.31.0");
+        let key2 = CacheKey::new("requests", "2.31.0");
+        let key3 = CacheKey::new("requests", "2.32.0");
+        let key4 = CacheKey::new("flask", "2.31.0");
+
+        assert_eq!(key1, key2);
+        assert_ne!(key1, key3);
+        assert_ne!(key1, key4);
+    }
+}

--- a/src/adapters/outbound/network/mod.rs
+++ b/src/adapters/outbound/network/mod.rs
@@ -1,7 +1,9 @@
 /// Network adapters for external API calls
+mod caching_pypi_client;
 mod osv_client;
 mod pypi_client;
 
+pub use caching_pypi_client::CachingPyPiLicenseRepository;
 // Note: This will be used in subsequent subtasks for CVE check feature
 #[allow(unused_imports)]
 pub use osv_client::OsvClient;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod shared;
 
 use adapters::outbound::console::StderrProgressReporter;
 use adapters::outbound::filesystem::FileSystemReader;
-use adapters::outbound::network::{OsvClient, PyPiLicenseRepository};
+use adapters::outbound::network::{CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository};
 use application::dto::{OutputFormat, SbomRequest};
 use application::factories::{FormatterFactory, PresenterFactory, PresenterType};
 use application::use_cases::GenerateSbomUseCase;
@@ -89,7 +89,8 @@ async fn run(args: Args) -> Result<bool> {
     // Create adapters (Dependency Injection)
     let lockfile_reader = FileSystemReader::new();
     let project_config_reader = FileSystemReader::new();
-    let license_repository = PyPiLicenseRepository::new()?;
+    let pypi_repository = PyPiLicenseRepository::new()?;
+    let license_repository = CachingPyPiLicenseRepository::new(pypi_repository);
     let progress_reporter = StderrProgressReporter::new();
 
     // Create vulnerability repository if CVE check is requested


### PR DESCRIPTION
## Summary
- Add in-memory caching for PyPI license API calls using DashMap
- Implement decorator pattern for transparent caching
- Reduce redundant API requests when querying the same package version multiple times

## Related Issue
Closes #86

## Changes Made
- Add `dashmap` v6 dependency for thread-safe HashMap
- Create `CachingPyPiLicenseRepository` in `src/adapters/outbound/network/caching_pypi_client.rs`
- Cache key uses package name + version for unique identification
- Update `main.rs` DI wiring to wrap `PyPiLicenseRepository` with caching decorator
- Add comprehensive unit tests for cache behavior (hit/miss, different versions, different packages)

## Architecture Decision
Following hexagonal architecture principles, caching is implemented as an Adapter implementation detail, not as a Port concern. The domain only needs "fetch license information" - whether it comes from cache or API is transparent to the domain.

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Unit tests cover cache hit, cache miss, different versions, and different packages scenarios

---
Generated with [Claude Code](https://claude.com/claude-code)