### PR TITLE
docs: fix incorrect exit code documentation in Common Error Scenarios

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -455,31 +455,31 @@ uv-sbom --format markdown --check-cve --cvss-threshold 7.0
 
 ### よくあるエラーシナリオ
 
-**終了コード 1 - アプリケーションエラー:**
+**終了コード 3 - アプリケーションエラー:**
 ```bash
 # uv.lockファイルが見つからない
 $ uv-sbom --path /path/without/uv-lock
 ❌ An error occurred:
 uv.lock file not found: /path/without/uv-lock/uv.lock
-# 終了コード: 1
+# 終了コード: 3
 
 # 無効な除外パターン（空）
 $ uv-sbom -e ""
 ❌ An error occurred:
 Exclusion pattern cannot be empty
-# 終了コード: 1
+# 終了コード: 3
 
 # 無効な除外パターン（無効な文字）
 $ uv-sbom -e "pkg;name"
 ❌ An error occurred:
 Exclusion pattern contains invalid character ';' in pattern 'pkg;name'
-# 終了コード: 1
+# 終了コード: 3
 
 # 存在しないプロジェクトパス
 $ uv-sbom --path /nonexistent
 ❌ An error occurred:
 Invalid project path: /nonexistent
-# 終了コード: 1
+# 終了コード: 3
 ```
 
 **終了コード 2 - CLI引数エラー:**
@@ -507,12 +507,16 @@ case $? in
     echo "SBOMの生成に成功しました"
     ;;
   1)
-    echo "アプリケーションエラーが発生しました"
+    echo "しきい値を超える脆弱性が検出されました"
     exit 1
     ;;
   2)
     echo "無効なコマンドライン引数です"
     exit 2
+    ;;
+  3)
+    echo "アプリケーションエラーが発生しました"
+    exit 3
     ;;
 esac
 ```

--- a/README.md
+++ b/README.md
@@ -456,31 +456,31 @@ uv-sbom --format markdown --check-cve --cvss-threshold 7.0
 
 ### Common Error Scenarios
 
-**Exit code 1 - Application errors:**
+**Exit code 3 - Application errors:**
 ```bash
 # Missing uv.lock file
 $ uv-sbom --path /path/without/uv-lock
 ❌ An error occurred:
 uv.lock file not found: /path/without/uv-lock/uv.lock
-# Exit code: 1
+# Exit code: 3
 
 # Invalid exclude pattern (empty)
 $ uv-sbom -e ""
 ❌ An error occurred:
 Exclusion pattern cannot be empty
-# Exit code: 1
+# Exit code: 3
 
 # Invalid exclude pattern (invalid characters)
 $ uv-sbom -e "pkg;name"
 ❌ An error occurred:
 Exclusion pattern contains invalid character ';' in pattern 'pkg;name'
-# Exit code: 1
+# Exit code: 3
 
 # Nonexistent project path
 $ uv-sbom --path /nonexistent
 ❌ An error occurred:
 Invalid project path: /nonexistent
-# Exit code: 1
+# Exit code: 3
 ```
 
 **Exit code 2 - CLI argument errors:**
@@ -508,12 +508,16 @@ case $? in
     echo "SBOM generated successfully"
     ;;
   1)
-    echo "Application error occurred"
+    echo "Vulnerabilities detected above threshold"
     exit 1
     ;;
   2)
     echo "Invalid command-line arguments"
     exit 2
+    ;;
+  3)
+    echo "Application error occurred"
+    exit 3
     ;;
 esac
 ```


### PR DESCRIPTION
## Summary
- Fix incorrect exit code documentation in "Common Error Scenarios" section
- Application errors should return exit code 3, not exit code 1
- Exit code 1 is for vulnerabilities detected (with `--check-cve`)

## Related Issue
Closes #144

## Changes Made
- **README.md**:
  - Changed "Exit code 1 - Application errors" to "Exit code 3 - Application errors"
  - Updated all `# Exit code: 1` comments to `# Exit code: 3` in the application errors section
  - Added exit code 1 (vulnerabilities) and exit code 3 (application errors) to script example
- **README-JP.md**:
  - Changed "終了コード 1 - アプリケーションエラー" to "終了コード 3 - アプリケーションエラー"
  - Updated all exit code comments in the application errors section
  - Added exit code 1 and 3 to script example

## Correct Exit Code Definition (from `src/shared/error.rs`)
| Exit Code | Meaning |
|-----------|---------|
| 0 | Success |
| 1 | VulnerabilitiesDetected (when using `--check-cve`) |
| 2 | InvalidArguments (CLI parsing errors) |
| 3 | ApplicationError (file I/O, network, invalid path, etc.) |

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation changes verified against `src/shared/error.rs`

---
Generated with [Claude Code](https://claude.com/claude-code)