### PR TITLE
refactor(error): use thiserror crate for SbomError type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "urlencoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.9"
 anyhow = "1.0"
+thiserror = "1.0"
 reqwest = { version = "0.13", features = ["json", "blocking"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }


### PR DESCRIPTION
## Summary
- Introduce `thiserror` crate for declarative error type definitions
- Replace manual `Display` and `Error` trait implementations with derive macros
- Reduce boilerplate code by ~42 lines while maintaining identical error messages

## Related Issue
Closes #62

## Changes Made
- Add `thiserror = "1.0"` to Cargo.toml dependencies
- Replace manual `impl Display for SbomError` with `#[error(...)]` attributes
- Remove manual `impl std::error::Error for SbomError`
- Add documentation comments for `SbomError` enum

## Benefits
- Centralized error message management via `#[error(...)]` attributes
- Automatic `Display` and `Error` trait derivation
- Cleaner, more maintainable code
- Type-safe error definitions

## Test Plan
- [x] `cargo test --all` passes (all 204 tests pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Existing error display tests verify message format is unchanged

---
Generated with [Claude Code](https://claude.com/claude-code)