### PR TITLE
refactor(domain): add severity sorting to VulnerabilityChecker

### DIFF
--- a/src/sbom_generation/domain/services/mod.rs
+++ b/src/sbom_generation/domain/services/mod.rs
@@ -1,3 +1,5 @@
 pub mod vulnerability_checker;
 
-pub use vulnerability_checker::{ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker};
+pub use vulnerability_checker::{
+    ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker, VulnerabilityRow,
+};

--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -1,5 +1,25 @@
 use super::super::vulnerability::{PackageVulnerabilities, Severity, Vulnerability};
 
+/// Represents a flattened vulnerability row for display purposes
+///
+/// This struct provides a presentation-ready format for vulnerability data,
+/// enabling consistent sorting and display across different formatters.
+#[derive(Debug, Clone)]
+pub struct VulnerabilityRow {
+    /// Package name affected by the vulnerability
+    pub package_name: String,
+    /// Current installed version of the package
+    pub current_version: String,
+    /// Version that fixes the vulnerability (or "N/A" if unknown)
+    pub fixed_version: String,
+    /// CVSS score as display string (e.g., "9.8" or "N/A")
+    pub cvss_display: String,
+    /// Severity level of the vulnerability
+    pub severity: Severity,
+    /// CVE or vulnerability identifier
+    pub cve_id: String,
+}
+
 /// Configuration for threshold evaluation
 #[derive(Debug, Clone, PartialEq)]
 pub enum ThresholdConfig {
@@ -66,6 +86,39 @@ impl VulnerabilityCheckResult {
 pub struct VulnerabilityChecker;
 
 impl VulnerabilityChecker {
+    /// Returns vulnerabilities sorted by severity (Critical first, then High, Medium, Low, None)
+    ///
+    /// This method flattens package vulnerabilities into individual rows and sorts them
+    /// by severity in descending order for consistent display across formatters.
+    ///
+    /// # Arguments
+    /// * `vulnerabilities` - List of package vulnerabilities to sort
+    ///
+    /// # Returns
+    /// Vector of VulnerabilityRow sorted by severity (Critical first)
+    pub fn sort_by_severity(vulnerabilities: &[PackageVulnerabilities]) -> Vec<VulnerabilityRow> {
+        let mut rows: Vec<VulnerabilityRow> = vulnerabilities
+            .iter()
+            .flat_map(|pv| {
+                pv.vulnerabilities()
+                    .iter()
+                    .map(move |vuln| VulnerabilityRow {
+                        package_name: pv.package_name().to_string(),
+                        current_version: pv.current_version().to_string(),
+                        fixed_version: vuln.fixed_version().unwrap_or("N/A").to_string(),
+                        cvss_display: vuln
+                            .cvss_score()
+                            .map_or("N/A".to_string(), |s| format!("{:.1}", s.value())),
+                        severity: vuln.severity(),
+                        cve_id: vuln.id().to_string(),
+                    })
+            })
+            .collect();
+
+        rows.sort_by(|a, b| b.severity.cmp(&a.severity));
+        rows
+    }
+
     /// Checks vulnerabilities against the specified threshold
     ///
     /// # Arguments
@@ -500,5 +553,131 @@ mod tests {
         assert_eq!(result.informational_count(), 2);
         assert_eq!(result.actionable_package_count(), 1);
         assert_eq!(result.informational_package_count(), 2);
+    }
+
+    // Tests for VulnerabilityChecker::sort_by_severity
+
+    #[test]
+    fn test_sort_by_severity_orders_critical_first() {
+        let vuln_low = create_vulnerability("CVE-LOW", Some(2.0), Severity::Low);
+        let vuln_critical = create_vulnerability("CVE-CRITICAL", Some(9.8), Severity::Critical);
+        let vuln_medium = create_vulnerability("CVE-MEDIUM", Some(5.0), Severity::Medium);
+        let vuln_high = create_vulnerability("CVE-HIGH", Some(8.0), Severity::High);
+
+        let pkg = create_package_vulnerabilities(
+            "test-pkg",
+            vec![vuln_low, vuln_critical, vuln_medium, vuln_high],
+        );
+
+        let sorted = VulnerabilityChecker::sort_by_severity(&[pkg]);
+
+        assert_eq!(sorted.len(), 4);
+        assert_eq!(sorted[0].cve_id, "CVE-CRITICAL");
+        assert_eq!(sorted[1].cve_id, "CVE-HIGH");
+        assert_eq!(sorted[2].cve_id, "CVE-MEDIUM");
+        assert_eq!(sorted[3].cve_id, "CVE-LOW");
+    }
+
+    #[test]
+    fn test_sort_by_severity_preserves_package_info() {
+        let vuln = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let pkg =
+            PackageVulnerabilities::new("my-package".to_string(), "2.5.0".to_string(), vec![vuln]);
+
+        let sorted = VulnerabilityChecker::sort_by_severity(&[pkg]);
+
+        assert_eq!(sorted.len(), 1);
+        assert_eq!(sorted[0].package_name, "my-package");
+        assert_eq!(sorted[0].current_version, "2.5.0");
+        assert_eq!(sorted[0].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_sort_by_severity_handles_fixed_version() {
+        let vuln_with_fix = Vulnerability::new(
+            "CVE-WITH-FIX".to_string(),
+            Some(CvssScore::new(8.0).unwrap()),
+            Severity::High,
+            Some("3.0.0".to_string()),
+            None,
+        )
+        .unwrap();
+
+        let vuln_without_fix = Vulnerability::new(
+            "CVE-NO-FIX".to_string(),
+            Some(CvssScore::new(7.0).unwrap()),
+            Severity::High,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln_with_fix, vuln_without_fix]);
+
+        let sorted = VulnerabilityChecker::sort_by_severity(&[pkg]);
+
+        assert_eq!(sorted.len(), 2);
+        let with_fix = sorted.iter().find(|r| r.cve_id == "CVE-WITH-FIX").unwrap();
+        let without_fix = sorted.iter().find(|r| r.cve_id == "CVE-NO-FIX").unwrap();
+        assert_eq!(with_fix.fixed_version, "3.0.0");
+        assert_eq!(without_fix.fixed_version, "N/A");
+    }
+
+    #[test]
+    fn test_sort_by_severity_handles_cvss_display() {
+        let vuln_with_cvss = create_vulnerability("CVE-WITH-CVSS", Some(7.5), Severity::High);
+        let vuln_without_cvss =
+            Vulnerability::new("CVE-NO-CVSS".to_string(), None, Severity::High, None, None)
+                .unwrap();
+
+        let pkg =
+            create_package_vulnerabilities("test-pkg", vec![vuln_with_cvss, vuln_without_cvss]);
+
+        let sorted = VulnerabilityChecker::sort_by_severity(&[pkg]);
+
+        assert_eq!(sorted.len(), 2);
+        let with_cvss = sorted.iter().find(|r| r.cve_id == "CVE-WITH-CVSS").unwrap();
+        let without_cvss = sorted.iter().find(|r| r.cve_id == "CVE-NO-CVSS").unwrap();
+        assert_eq!(with_cvss.cvss_display, "7.5");
+        assert_eq!(without_cvss.cvss_display, "N/A");
+    }
+
+    #[test]
+    fn test_sort_by_severity_multiple_packages() {
+        let vuln1 = create_vulnerability("CVE-PKG1-HIGH", Some(8.0), Severity::High);
+        let vuln2 = create_vulnerability("CVE-PKG2-CRITICAL", Some(9.5), Severity::Critical);
+        let vuln3 = create_vulnerability("CVE-PKG1-LOW", Some(2.0), Severity::Low);
+
+        let pkg1 = create_package_vulnerabilities("pkg-1", vec![vuln1, vuln3]);
+        let pkg2 = create_package_vulnerabilities("pkg-2", vec![vuln2]);
+
+        let sorted = VulnerabilityChecker::sort_by_severity(&[pkg1, pkg2]);
+
+        assert_eq!(sorted.len(), 3);
+        // Critical should be first regardless of package
+        assert_eq!(sorted[0].cve_id, "CVE-PKG2-CRITICAL");
+        assert_eq!(sorted[0].package_name, "pkg-2");
+        assert_eq!(sorted[1].cve_id, "CVE-PKG1-HIGH");
+        assert_eq!(sorted[2].cve_id, "CVE-PKG1-LOW");
+    }
+
+    #[test]
+    fn test_sort_by_severity_empty_input() {
+        let sorted = VulnerabilityChecker::sort_by_severity(&[]);
+        assert!(sorted.is_empty());
+    }
+
+    #[test]
+    fn test_sort_by_severity_includes_none_severity() {
+        let vuln_none = create_vulnerability("CVE-NONE", Some(0.0), Severity::None);
+        let vuln_low = create_vulnerability("CVE-LOW", Some(2.0), Severity::Low);
+
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln_none, vuln_low]);
+
+        let sorted = VulnerabilityChecker::sort_by_severity(&[pkg]);
+
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(sorted[0].cve_id, "CVE-LOW");
+        assert_eq!(sorted[1].cve_id, "CVE-NONE");
     }
 }


### PR DESCRIPTION
## Summary
- Add `VulnerabilityRow` struct and `sort_by_severity()` method to the domain layer
- Migrate sorting logic from `MarkdownFormatter` to `VulnerabilityChecker` domain service
- Enable consistent vulnerability sorting across different formatters

## Related Issue
Closes #153

## Changes Made
- Add `VulnerabilityRow` struct for presentation-ready vulnerability data in domain layer
- Add `VulnerabilityChecker::sort_by_severity()` method that returns vulnerabilities sorted by severity (Critical first)
- Update `MarkdownFormatter` to use the domain sorting method
- Remove private `sort_vulnerabilities_by_severity()` from `MarkdownFormatter`
- Add `format_vulnerability_row()` helper method to `MarkdownFormatter`
- Add comprehensive unit tests for the new domain method (7 new tests)
- Export `VulnerabilityRow` from the services module

## Files Modified
- `src/sbom_generation/domain/services/vulnerability_checker.rs` - Added struct and method
- `src/sbom_generation/domain/services/mod.rs` - Export VulnerabilityRow
- `src/adapters/outbound/formatters/markdown_formatter.rs` - Migrated to use domain method

## Test Plan
- [x] `cargo test --all` passes (231 tests + 7 new tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)