### PR TITLE
refactor(adapter): simplify MarkdownFormatter using domain semantic methods

### DIFF
--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -42,8 +42,6 @@ pub struct VulnerabilityCheckResult {
     pub threshold_exceeded: bool,
 }
 
-// These methods will be used by MarkdownFormatter in Issue #153, #154
-#[allow(dead_code)]
 impl VulnerabilityCheckResult {
     /// Returns true if there are actionable vulnerabilities (above threshold)
     pub fn has_actionable_vulnerabilities(&self) -> bool {


### PR DESCRIPTION
## Summary

- Replace inline statistics calculations in `MarkdownFormatter` with semantic methods from `VulnerabilityCheckResult`
- Remove redundant `count_total_vulnerabilities()` private method
- Update section formatting methods to accept `&VulnerabilityCheckResult` instead of `&[PackageVulnerabilities]`

## Related Issue

Closes #154

## Parent Issue

- #150 - Extract vulnerability classification logic from MarkdownFormatter to domain layer

## Dependencies

- #152 - Add semantic methods to VulnerabilityCheckResult ✅
- #153 - Add severity sorting to VulnerabilityChecker ✅

## Changes Made

- Use `has_actionable_vulnerabilities()` and `has_informational_vulnerabilities()` instead of direct `is_empty()` checks
- Use `actionable_count()` / `informational_count()` for vulnerability totals
- Use `actionable_package_count()` / `informational_package_count()` for package counts
- Update `format_vulnerability_warning_section()` to accept `&VulnerabilityCheckResult`
- Update `format_vulnerability_info_section()` to accept `&VulnerabilityCheckResult`
- Remove `count_total_vulnerabilities()` private method from `MarkdownFormatter`
- Remove `#[allow(dead_code)]` from `VulnerabilityCheckResult` impl as methods are now used

## Test Plan

- [x] `cargo test --all` passes (230 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Updated existing tests to use new method signatures

## Benefits

1. **Reusability**: CycloneDX formatter (Issue #149) can use the same domain methods
2. **Testability**: Business logic is unit tested independently of output format
3. **Single Responsibility**: `MarkdownFormatter` focuses only on presentation
4. **Consistency**: Same classification logic produces same results across formats

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)