### PR TITLE
refactor(application): add SbomReadModel and core view structs

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -4,4 +4,5 @@
 /// domain services and coordinates with infrastructure through ports.
 pub mod dto;
 pub mod factories;
+pub mod read_models;
 pub mod use_cases;

--- a/src/application/read_models/component_view.rs
+++ b/src/application/read_models/component_view.rs
@@ -1,0 +1,37 @@
+//! Component view structs for read model
+//!
+//! These structs provide a flattened, query-optimized view of component data.
+
+/// View representation of a software component
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct ComponentView {
+    /// BOM reference identifier
+    pub bom_ref: String,
+    /// Component name
+    pub name: String,
+    /// Component version
+    pub version: String,
+    /// Package URL (purl)
+    pub purl: String,
+    /// License information
+    pub license: Option<LicenseView>,
+    /// Component description
+    pub description: Option<String>,
+    /// SHA256 hash of the component
+    pub sha256_hash: Option<String>,
+    /// Whether this is a direct dependency
+    pub is_direct_dependency: bool,
+}
+
+/// View representation of license information
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct LicenseView {
+    /// SPDX license identifier
+    pub spdx_id: Option<String>,
+    /// License name
+    pub name: String,
+    /// URL to license text
+    pub url: Option<String>,
+}

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -1,0 +1,14 @@
+//! Read models for CQRS-lite pattern
+//!
+//! This module contains view-optimized structs that provide
+//! a denormalized representation of domain data for queries.
+
+pub mod component_view;
+pub mod sbom_read_model;
+
+#[allow(unused_imports)]
+pub use component_view::{ComponentView, LicenseView};
+#[allow(unused_imports)]
+pub use sbom_read_model::{
+    DependencyView, SbomMetadataView, SbomReadModel, VulnerabilityReportView,
+};

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -1,0 +1,51 @@
+//! SBOM read model for query operations
+//!
+//! This module provides the main read model struct that aggregates
+//! all SBOM data in a query-optimized format.
+
+use super::component_view::ComponentView;
+
+/// Main read model for SBOM data
+///
+/// This struct provides a denormalized, query-optimized view of SBOM data
+/// following the CQRS-lite pattern.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct SbomReadModel {
+    /// SBOM metadata
+    pub metadata: SbomMetadataView,
+    /// List of components
+    pub components: Vec<ComponentView>,
+    /// Dependency information
+    pub dependencies: Option<DependencyView>,
+    /// Vulnerability report
+    pub vulnerabilities: Option<VulnerabilityReportView>,
+}
+
+/// View representation of SBOM metadata
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct SbomMetadataView {
+    /// Timestamp when the SBOM was created
+    pub timestamp: String,
+    /// Name of the tool that generated the SBOM
+    pub tool_name: String,
+    /// Version of the tool
+    pub tool_version: String,
+    /// Serial number of the SBOM
+    pub serial_number: String,
+}
+
+/// Placeholder for dependency view (to be implemented in future issues)
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DependencyView {
+    // To be defined in a future issue
+}
+
+/// Placeholder for vulnerability report view (to be implemented in future issues)
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct VulnerabilityReportView {
+    // To be defined in a future issue
+}


### PR DESCRIPTION
## Summary
- Add foundation read model structs for CQRS-lite pattern
- Introduce `SbomReadModel` as the main aggregate view for SBOM data
- Define `ComponentView`, `LicenseView`, and metadata view structs

## Related Issue
Closes #158

## Changes Made
- Add `src/application/read_models/mod.rs` - module exports
- Add `src/application/read_models/sbom_read_model.rs` - main read model and metadata view
- Add `src/application/read_models/component_view.rs` - component and license views
- Update `src/application/mod.rs` to export the new `read_models` module

## Structs Added
- `SbomReadModel` - main aggregate with metadata, components, dependencies, vulnerabilities
- `SbomMetadataView` - timestamp, tool info, serial number
- `ComponentView` - bom_ref, name, version, purl, license, description, hash, dependency flag
- `LicenseView` - spdx_id, name, url
- `DependencyView` - placeholder for future implementation
- `VulnerabilityReportView` - placeholder for future implementation

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)