### PR TITLE
refactor(ports): Add format_v2 method to SbomFormatter trait

### DIFF
--- a/src/ports/outbound/formatter.rs
+++ b/src/ports/outbound/formatter.rs
@@ -1,3 +1,4 @@
+use crate::application::read_models::SbomReadModel;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
 use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
 use crate::sbom_generation::domain::{DependencyGraph, Package, SbomMetadata};
@@ -79,5 +80,28 @@ pub trait SbomFormatter {
         // Default implementation ignores vulnerability_result
         let _ = vulnerability_result;
         self.format(packages, metadata, vulnerability_report)
+    }
+
+    /// Formats SBOM output using the unified read model
+    ///
+    /// This method provides a simplified interface that accepts the pre-built
+    /// `SbomReadModel` containing all necessary data for formatting.
+    ///
+    /// # Arguments
+    /// * `model` - The unified SBOM read model containing metadata, components,
+    ///   dependencies, and vulnerability information
+    ///
+    /// # Returns
+    /// Formatted SBOM content as a string
+    ///
+    /// # Errors
+    /// Returns an error if formatting or serialization fails
+    ///
+    /// # Default Implementation
+    /// By default, this method is unimplemented and will panic.
+    /// Formatters should override this method to provide their implementation.
+    #[allow(dead_code)]
+    fn format_v2(&self, _model: &SbomReadModel) -> Result<String> {
+        unimplemented!("format_v2 not yet implemented for this formatter")
     }
 }


### PR DESCRIPTION
## Summary
- Add `format_v2` method to `SbomFormatter` trait that accepts `SbomReadModel`
- Provides a simplified, unified interface for SBOM formatting
- Existing methods remain unchanged for backward compatibility

## Related Issue
Closes #162

## Changes Made
- Added `SbomReadModel` import to `formatter.rs`
- Added `format_v2` method with default `unimplemented!()` implementation
- Added comprehensive documentation comments

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Existing tests still pass (backward compatible)

---
Generated with [Claude Code](https://claude.com/claude-code)