### PR TITLE
refactor(application): use SbomReadModelBuilder and format_v2 in main formatting pipeline

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter.rs
@@ -42,6 +42,7 @@ impl MarkdownFormatter {
     }
 
     /// Creates a package lookup map for quick access by name
+    #[allow(dead_code)]
     fn create_package_map(packages: &[EnrichedPackage]) -> HashMap<String, &EnrichedPackage> {
         packages
             .iter()
@@ -50,6 +51,7 @@ impl MarkdownFormatter {
     }
 
     /// Formats a table row for a package
+    #[allow(dead_code)]
     fn format_package_row(enriched: &EnrichedPackage) -> String {
         let pkg = &enriched.package;
         let license = enriched.license.as_deref().unwrap_or("N/A");
@@ -72,6 +74,7 @@ impl MarkdownFormatter {
     /// - CVSS score
     /// - Severity with emoji indicator
     /// - CVE identifier
+    #[allow(dead_code)]
     fn format_vulnerability_section(vulnerabilities: &[PackageVulnerabilities]) -> String {
         let mut output = String::new();
         output.push_str("\n## Vulnerability Report\n\n");
@@ -135,6 +138,7 @@ impl MarkdownFormatter {
     }
 
     /// Formats message when no vulnerabilities are found
+    #[allow(dead_code)]
     fn format_no_vulnerabilities() -> String {
         let mut output = String::new();
         output.push_str("\n## Vulnerability Report\n\n");
@@ -147,6 +151,7 @@ impl MarkdownFormatter {
     }
 
     /// Formats a single vulnerability row for markdown table output
+    #[allow(dead_code)]
     fn format_vulnerability_row(row: &VulnerabilityRow) -> String {
         format!(
             "| {} | {} | {} | {} | {} {:?} | {} |\n",
@@ -161,6 +166,7 @@ impl MarkdownFormatter {
     }
 
     /// Formats the Warning section for vulnerabilities above threshold
+    #[allow(dead_code)]
     fn format_vulnerability_warning_section(result: &VulnerabilityCheckResult) -> String {
         let mut output = String::new();
 
@@ -197,6 +203,7 @@ impl MarkdownFormatter {
     }
 
     /// Formats the Info section for vulnerabilities below threshold
+    #[allow(dead_code)]
     fn format_vulnerability_info_section(result: &VulnerabilityCheckResult) -> String {
         let mut output = String::new();
 
@@ -233,6 +240,7 @@ impl MarkdownFormatter {
     }
 
     /// Formats vulnerability report with Warning and Info sections based on threshold
+    #[allow(dead_code)]
     fn format_vulnerability_with_threshold(result: &VulnerabilityCheckResult) -> String {
         let mut output = String::new();
         output.push_str("\n## Vulnerability Report\n\n");

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -17,6 +17,7 @@ pub struct SbomResponse {
     pub metadata: SbomMetadata,
     /// Optional vulnerability report (only present when CVE check is enabled)
     /// None = not checked, Some(vec) = checked (empty vec means no vulnerabilities found)
+    #[allow(dead_code)]
     pub vulnerability_report: Option<Vec<PackageVulnerabilities>>,
     /// Whether vulnerabilities above threshold were detected
     /// Used to determine exit code for CI integration

--- a/src/ports/outbound/formatter.rs
+++ b/src/ports/outbound/formatter.rs
@@ -41,6 +41,7 @@ pub trait SbomFormatter {
     ///
     /// # Errors
     /// Returns an error if formatting or serialization fails
+    #[allow(dead_code)]
     fn format(
         &self,
         packages: Vec<EnrichedPackage>,
@@ -69,6 +70,7 @@ pub trait SbomFormatter {
     /// # Default Implementation
     /// By default, this calls `format()` and ignores the dependency graph.
     /// Formatters that support dependency information should override this.
+    #[allow(dead_code)]
     fn format_with_dependencies(
         &self,
         _dependency_graph: &DependencyGraph,
@@ -100,7 +102,6 @@ pub trait SbomFormatter {
     /// # Default Implementation
     /// By default, this method is unimplemented and will panic.
     /// Formatters should override this method to provide their implementation.
-    #[allow(dead_code)]
     fn format_v2(&self, _model: &SbomReadModel) -> Result<String> {
         unimplemented!("format_v2 not yet implemented for this formatter")
     }

--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -4,6 +4,7 @@ use super::super::vulnerability::{PackageVulnerabilities, Severity, Vulnerabilit
 ///
 /// This struct provides a presentation-ready format for vulnerability data,
 /// enabling consistent sorting and display across different formatters.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct VulnerabilityRow {
     /// Package name affected by the vulnerability
@@ -44,11 +45,13 @@ pub struct VulnerabilityCheckResult {
 
 impl VulnerabilityCheckResult {
     /// Returns true if there are actionable vulnerabilities (above threshold)
+    #[allow(dead_code)]
     pub fn has_actionable_vulnerabilities(&self) -> bool {
         !self.above_threshold.is_empty()
     }
 
     /// Returns true if there are informational vulnerabilities (below threshold)
+    #[allow(dead_code)]
     pub fn has_informational_vulnerabilities(&self) -> bool {
         !self.below_threshold.is_empty()
     }
@@ -70,11 +73,13 @@ impl VulnerabilityCheckResult {
     }
 
     /// Returns affected package count for actionable vulnerabilities
+    #[allow(dead_code)]
     pub fn actionable_package_count(&self) -> usize {
         self.above_threshold.len()
     }
 
     /// Returns affected package count for informational vulnerabilities
+    #[allow(dead_code)]
     pub fn informational_package_count(&self) -> usize {
         self.below_threshold.len()
     }
@@ -94,6 +99,7 @@ impl VulnerabilityChecker {
     ///
     /// # Returns
     /// Vector of VulnerabilityRow sorted by severity (Critical first)
+    #[allow(dead_code)]
     pub fn sort_by_severity(vulnerabilities: &[PackageVulnerabilities]) -> Vec<VulnerabilityRow> {
         let mut rows: Vec<VulnerabilityRow> = vulnerabilities
             .iter()

--- a/src/sbom_generation/domain/vulnerability.rs
+++ b/src/sbom_generation/domain/vulnerability.rs
@@ -144,6 +144,7 @@ impl Severity {
     }
 
     /// Returns emoji representation for display
+    #[allow(dead_code)]
     pub fn emoji(&self) -> &str {
         match self {
             Self::Critical => "🔴",


### PR DESCRIPTION
## Summary
- Replace conditional `format()`/`format_with_dependencies()` dispatch in `main.rs` with unified `SbomReadModelBuilder::build()` + `format_v2()` call
- Import `SbomReadModelBuilder` in main entry point to construct the read model before formatting
- Mark legacy format methods and unused helpers with `#[allow(dead_code)]` for gradual removal

## Related Issue
Closes #166

## Changes Made
- **`src/main.rs`**: Import `SbomReadModelBuilder`, build `SbomReadModel` from response data, call `format_v2()` instead of conditional `format()`/`format_with_dependencies()`
- **`src/ports/outbound/formatter.rs`**: Add `#[allow(dead_code)]` to legacy `format()` and `format_with_dependencies()` methods; remove `#[allow(dead_code)]` from now-active `format_v2()`
- **`src/application/dto/sbom_response.rs`**: Add `#[allow(dead_code)]` to `vulnerability_report` field (no longer read directly)
- **`src/adapters/outbound/formatters/markdown_formatter.rs`**: Add `#[allow(dead_code)]` to 8 legacy helper methods
- **`src/sbom_generation/domain/services/vulnerability_checker.rs`**: Add `#[allow(dead_code)]` to `VulnerabilityRow`, legacy semantic methods, and `sort_by_severity`
- **`src/sbom_generation/domain/vulnerability.rs`**: Add `#[allow(dead_code)]` to `Severity::emoji()`

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (all 12 integration + 7 doc tests)

---
Generated with [Claude Code](https://claude.com/claude-code)