### PR TITLE
refactor(formatter): remove legacy format methods and rename format_v2 to format

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter.rs
@@ -2,12 +2,7 @@ use crate::application::read_models::{
     ComponentView, DependencyView, SbomReadModel, VulnerabilityReportView, VulnerabilitySummary,
     VulnerabilityView,
 };
-use crate::ports::outbound::{EnrichedPackage, SbomFormatter};
-use crate::sbom_generation::domain::services::{
-    VulnerabilityCheckResult, VulnerabilityChecker, VulnerabilityRow,
-};
-use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
-use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata};
+use crate::ports::outbound::SbomFormatter;
 use crate::shared::Result;
 use std::collections::HashMap;
 
@@ -40,243 +35,17 @@ impl MarkdownFormatter {
     fn escape_markdown_table_cell(text: &str) -> String {
         text.replace('|', "\\|").replace('\n', " ")
     }
-
-    /// Creates a package lookup map for quick access by name
-    #[allow(dead_code)]
-    fn create_package_map(packages: &[EnrichedPackage]) -> HashMap<String, &EnrichedPackage> {
-        packages
-            .iter()
-            .map(|p| (p.package.name().to_string(), p))
-            .collect()
-    }
-
-    /// Formats a table row for a package
-    #[allow(dead_code)]
-    fn format_package_row(enriched: &EnrichedPackage) -> String {
-        let pkg = &enriched.package;
-        let license = enriched.license.as_deref().unwrap_or("N/A");
-        let description = enriched.description.as_deref().unwrap_or("");
-
-        format!(
-            "| {} | {} | {} | {} |\n",
-            Self::escape_markdown_table_cell(pkg.name()),
-            Self::escape_markdown_table_cell(pkg.version()),
-            Self::escape_markdown_table_cell(license),
-            Self::escape_markdown_table_cell(description)
-        )
-    }
-
-    /// Formats vulnerability report section
-    ///
-    /// Returns markdown formatted vulnerability table with:
-    /// - Package name and current version
-    /// - Fixed version (if available)
-    /// - CVSS score
-    /// - Severity with emoji indicator
-    /// - CVE identifier
-    #[allow(dead_code)]
-    fn format_vulnerability_section(vulnerabilities: &[PackageVulnerabilities]) -> String {
-        let mut output = String::new();
-        output.push_str("\n## Vulnerability Report\n\n");
-        output.push_str("**⚠️ Security Issues Detected**\n\n");
-
-        // Calculate summary statistics
-        let total_vulnerabilities: usize = vulnerabilities
-            .iter()
-            .map(|pv| pv.vulnerabilities().len())
-            .sum();
-        let package_count = vulnerabilities.len();
-
-        output.push_str(&format!(
-            "Found {} {} in {} {}.\n\n",
-            total_vulnerabilities,
-            if total_vulnerabilities == 1 {
-                "vulnerability"
-            } else {
-                "vulnerabilities"
-            },
-            package_count,
-            if package_count == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        ));
-
-        // Table header
-        output.push_str(VULN_TABLE_HEADER);
-        output.push_str(VULN_TABLE_SEPARATOR);
-
-        // Table rows - one row per vulnerability
-        for pkg_vuln in vulnerabilities {
-            for vuln in pkg_vuln.vulnerabilities() {
-                let cvss_display = vuln
-                    .cvss_score()
-                    .map_or("N/A".to_string(), |s| format!("{:.1}", s.value()));
-                let fixed_version = vuln.fixed_version().unwrap_or("N/A");
-                let severity = vuln.severity();
-
-                output.push_str(&format!(
-                    "| {} | {} | {} | {} | {} {:?} | {} |\n",
-                    Self::escape_markdown_table_cell(pkg_vuln.package_name()),
-                    Self::escape_markdown_table_cell(pkg_vuln.current_version()),
-                    Self::escape_markdown_table_cell(fixed_version),
-                    cvss_display,
-                    severity.emoji(),
-                    severity,
-                    Self::escape_markdown_table_cell(vuln.id()),
-                ));
-            }
-        }
-
-        // Attribution
-        output.push_str("\n---\n\n");
-        output
-            .push_str("*Vulnerability data provided by [OSV](https://osv.dev) under CC-BY 4.0*\n");
-
-        output
-    }
-
-    /// Formats message when no vulnerabilities are found
-    #[allow(dead_code)]
-    fn format_no_vulnerabilities() -> String {
-        let mut output = String::new();
-        output.push_str("\n## Vulnerability Report\n\n");
-        output.push_str("**✅ No Known Vulnerabilities**\n\n");
-        output.push_str("No security vulnerabilities were found in the scanned packages.\n\n");
-        output.push_str("---\n\n");
-        output
-            .push_str("*Vulnerability data provided by [OSV](https://osv.dev) under CC-BY 4.0*\n");
-        output
-    }
-
-    /// Formats a single vulnerability row for markdown table output
-    #[allow(dead_code)]
-    fn format_vulnerability_row(row: &VulnerabilityRow) -> String {
-        format!(
-            "| {} | {} | {} | {} | {} {:?} | {} |\n",
-            Self::escape_markdown_table_cell(&row.package_name),
-            Self::escape_markdown_table_cell(&row.current_version),
-            Self::escape_markdown_table_cell(&row.fixed_version),
-            row.cvss_display,
-            row.severity.emoji(),
-            row.severity,
-            Self::escape_markdown_table_cell(&row.cve_id),
-        )
-    }
-
-    /// Formats the Warning section for vulnerabilities above threshold
-    #[allow(dead_code)]
-    fn format_vulnerability_warning_section(result: &VulnerabilityCheckResult) -> String {
-        let mut output = String::new();
-
-        let total_vulns = result.actionable_count();
-        let package_count = result.actionable_package_count();
-
-        output.push_str(&format!(
-            "### ⚠️Warning Found {} {} in {} {}.\n\n",
-            total_vulns,
-            if total_vulns == 1 {
-                "vulnerability"
-            } else {
-                "vulnerabilities"
-            },
-            package_count,
-            if package_count == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        ));
-
-        // Table header
-        output.push_str(VULN_TABLE_HEADER);
-        output.push_str(VULN_TABLE_SEPARATOR);
-
-        // Sort and format rows using domain service
-        let sorted_rows = VulnerabilityChecker::sort_by_severity(&result.above_threshold);
-        for row in &sorted_rows {
-            output.push_str(&Self::format_vulnerability_row(row));
-        }
-
-        output
-    }
-
-    /// Formats the Info section for vulnerabilities below threshold
-    #[allow(dead_code)]
-    fn format_vulnerability_info_section(result: &VulnerabilityCheckResult) -> String {
-        let mut output = String::new();
-
-        let total_vulns = result.informational_count();
-        let package_count = result.informational_package_count();
-
-        output.push_str(&format!(
-            "### ℹ️Info Found {} {} in {} {}.\n\n",
-            total_vulns,
-            if total_vulns == 1 {
-                "vulnerability"
-            } else {
-                "vulnerabilities"
-            },
-            package_count,
-            if package_count == 1 {
-                "package"
-            } else {
-                "packages"
-            }
-        ));
-
-        // Table header
-        output.push_str(VULN_TABLE_HEADER);
-        output.push_str(VULN_TABLE_SEPARATOR);
-
-        // Sort and format rows using domain service
-        let sorted_rows = VulnerabilityChecker::sort_by_severity(&result.below_threshold);
-        for row in &sorted_rows {
-            output.push_str(&Self::format_vulnerability_row(row));
-        }
-
-        output
-    }
-
-    /// Formats vulnerability report with Warning and Info sections based on threshold
-    #[allow(dead_code)]
-    fn format_vulnerability_with_threshold(result: &VulnerabilityCheckResult) -> String {
-        let mut output = String::new();
-        output.push_str("\n## Vulnerability Report\n\n");
-
-        // Warning section (above threshold)
-        if !result.has_actionable_vulnerabilities() {
-            output.push_str("### ⚠️Warning No vulnerabilities found above threshold.\n\n");
-        } else {
-            output.push_str(&Self::format_vulnerability_warning_section(result));
-            output.push('\n');
-        }
-
-        // Info section (below threshold)
-        if result.has_informational_vulnerabilities() {
-            output.push_str(&Self::format_vulnerability_info_section(result));
-        }
-
-        // Attribution
-        output.push_str("\n---\n\n");
-        output
-            .push_str("*Vulnerability data provided by [OSV](https://osv.dev) under CC-BY 4.0*\n");
-
-        output
-    }
 }
 
-/// format_v2 helper methods
-#[allow(dead_code)]
+/// Helper methods for rendering sections
 impl MarkdownFormatter {
-    /// Renders the header section for format_v2 output
-    fn render_header_v2(&self, output: &mut String) {
+    /// Renders the header section
+    fn render_header(&self, output: &mut String) {
         output.push_str("# Software Bill of Materials (SBOM)\n\n");
     }
 
-    /// Renders the components section for format_v2 output
-    fn render_components_v2(&self, output: &mut String, components: &[ComponentView]) {
+    /// Renders the components section
+    fn render_components(&self, output: &mut String, components: &[ComponentView]) {
         output.push_str("## Component Inventory\n\n");
         output.push_str(
             "A comprehensive list of all software components and libraries included in this project.\n\n",
@@ -303,8 +72,8 @@ impl MarkdownFormatter {
         output.push('\n');
     }
 
-    /// Renders the dependencies section for format_v2 output
-    fn render_dependencies_v2(
+    /// Renders the dependencies section
+    fn render_dependencies(
         &self,
         output: &mut String,
         deps: &DependencyView,
@@ -394,23 +163,23 @@ impl MarkdownFormatter {
         }
     }
 
-    /// Renders the vulnerabilities section for format_v2 output
-    fn render_vulnerabilities_v2(&self, output: &mut String, vulns: &VulnerabilityReportView) {
+    /// Renders the vulnerabilities section
+    fn render_vulnerabilities(&self, output: &mut String, vulns: &VulnerabilityReportView) {
         output.push_str("\n## Vulnerability Report\n\n");
 
         // Summary section
-        self.render_vulnerability_summary_v2(output, &vulns.summary);
+        self.render_vulnerability_summary(output, &vulns.summary);
 
         // Actionable vulnerabilities (warning section)
         if vulns.actionable.is_empty() {
             output.push_str("### ⚠️Warning No vulnerabilities found above threshold.\n\n");
         } else {
-            self.render_actionable_vulnerabilities_v2(output, &vulns.actionable);
+            self.render_actionable_vulnerabilities(output, &vulns.actionable);
         }
 
         // Informational vulnerabilities
         if !vulns.informational.is_empty() {
-            self.render_informational_vulnerabilities_v2(output, &vulns.informational);
+            self.render_informational_vulnerabilities(output, &vulns.informational);
         }
 
         // Attribution
@@ -419,8 +188,8 @@ impl MarkdownFormatter {
             .push_str("*Vulnerability data provided by [OSV](https://osv.dev) under CC-BY 4.0*\n");
     }
 
-    /// Renders vulnerability summary statistics for format_v2 output
-    fn render_vulnerability_summary_v2(&self, output: &mut String, summary: &VulnerabilitySummary) {
+    /// Renders vulnerability summary statistics
+    fn render_vulnerability_summary(&self, output: &mut String, summary: &VulnerabilitySummary) {
         output.push_str(&format!(
             "**Found {} {} in {} {}.**\n\n",
             summary.total_count,
@@ -438,12 +207,8 @@ impl MarkdownFormatter {
         ));
     }
 
-    /// Renders the warning section for actionable vulnerabilities in format_v2 output
-    fn render_actionable_vulnerabilities_v2(
-        &self,
-        output: &mut String,
-        vulns: &[VulnerabilityView],
-    ) {
+    /// Renders the warning section for actionable vulnerabilities
+    fn render_actionable_vulnerabilities(&self, output: &mut String, vulns: &[VulnerabilityView]) {
         let total_vulns = vulns.len();
         let unique_packages = Self::count_unique_packages(vulns);
 
@@ -471,13 +236,13 @@ impl MarkdownFormatter {
         sorted_vulns.sort_by(|a, b| a.severity.cmp(&b.severity));
 
         for vuln in sorted_vulns {
-            self.render_vulnerability_row_v2(output, vuln);
+            self.render_vulnerability_row(output, vuln);
         }
         output.push('\n');
     }
 
-    /// Renders the info section for informational vulnerabilities in format_v2 output
-    fn render_informational_vulnerabilities_v2(
+    /// Renders the info section for informational vulnerabilities
+    fn render_informational_vulnerabilities(
         &self,
         output: &mut String,
         vulns: &[VulnerabilityView],
@@ -508,7 +273,7 @@ impl MarkdownFormatter {
         sorted_vulns.sort_by(|a, b| a.severity.cmp(&b.severity));
 
         for vuln in sorted_vulns {
-            self.render_vulnerability_row_v2(output, vuln);
+            self.render_vulnerability_row(output, vuln);
         }
     }
 
@@ -521,8 +286,8 @@ impl MarkdownFormatter {
         unique.len().max(1)
     }
 
-    /// Renders a single vulnerability row for format_v2 output
-    fn render_vulnerability_row_v2(&self, output: &mut String, vuln: &VulnerabilityView) {
+    /// Renders a single vulnerability row
+    fn render_vulnerability_row(&self, output: &mut String, vuln: &VulnerabilityView) {
         let cvss_display = vuln
             .cvss_score
             .map_or("N/A".to_string(), |s| format!("{:.1}", s));
@@ -555,138 +320,23 @@ impl Default for MarkdownFormatter {
 }
 
 impl SbomFormatter for MarkdownFormatter {
-    fn format(
-        &self,
-        packages: Vec<EnrichedPackage>,
-        _metadata: &SbomMetadata,
-        vulnerability_report: Option<&[PackageVulnerabilities]>,
-    ) -> Result<String> {
-        let mut output = String::new();
-
-        output.push_str("# Software Bill of Materials (SBOM)\n\n");
-        output.push_str("## Component Inventory\n\n");
-        output.push_str("A comprehensive list of all software components and libraries included in this project.\n\n");
-        output.push_str(TABLE_HEADER);
-        output.push_str(TABLE_SEPARATOR);
-
-        for enriched in &packages {
-            output.push_str(&Self::format_package_row(enriched));
-        }
-
-        // Add vulnerability section if present
-        if let Some(vulnerabilities) = vulnerability_report {
-            if vulnerabilities.is_empty() {
-                output.push_str(&Self::format_no_vulnerabilities());
-            } else {
-                output.push_str(&Self::format_vulnerability_section(vulnerabilities));
-            }
-        }
-
-        Ok(output)
-    }
-
-    fn format_with_dependencies(
-        &self,
-        dependency_graph: &DependencyGraph,
-        packages: Vec<EnrichedPackage>,
-        _metadata: &SbomMetadata,
-        vulnerability_report: Option<&[PackageVulnerabilities]>,
-        vulnerability_result: Option<&VulnerabilityCheckResult>,
-    ) -> Result<String> {
-        let mut output = String::new();
-        let package_map = Self::create_package_map(&packages);
-
-        // Header
-        output.push_str("# Software Bill of Materials (SBOM)\n\n");
-
-        // Component Inventory section (all packages)
-        output.push_str("## Component Inventory\n\n");
-        output.push_str("A comprehensive list of all software components and libraries included in this project.\n\n");
-        output.push_str(TABLE_HEADER);
-        output.push_str(TABLE_SEPARATOR);
-
-        for enriched in &packages {
-            output.push_str(&Self::format_package_row(enriched));
-        }
-        output.push('\n');
-
-        // Direct Dependencies section
-        output.push_str("## Direct Dependencies\n\n");
-        output.push_str("Primary packages explicitly defined in the project configuration(e.g., pyproject.toml).\n\n");
-
-        if dependency_graph.direct_dependency_count() > 0 {
-            output.push_str(TABLE_HEADER);
-            output.push_str(TABLE_SEPARATOR);
-
-            for dep in dependency_graph.direct_dependencies() {
-                if let Some(enriched) = package_map.get(dep.as_str()) {
-                    output.push_str(&Self::format_package_row(enriched));
-                }
-            }
-            output.push('\n');
-        } else {
-            output.push_str("*No direct dependencies*\n\n");
-        }
-
-        // Transitive Dependencies section
-        output.push_str("## Transitive Dependencies\n\n");
-        output.push_str("Secondary dependencies introduced by the primary packages.\n\n");
-
-        if dependency_graph.transitive_dependency_count() > 0 {
-            for (direct_dep, trans_deps) in dependency_graph.transitive_dependencies() {
-                output.push_str(&format!("### Dependencies for {}\n\n", direct_dep.as_str()));
-                output.push_str(TABLE_HEADER);
-                output.push_str(TABLE_SEPARATOR);
-
-                for trans_dep in trans_deps {
-                    if let Some(enriched) = package_map.get(trans_dep.as_str()) {
-                        output.push_str(&Self::format_package_row(enriched));
-                    }
-                }
-                output.push('\n');
-            }
-        } else {
-            output.push_str("*No transitive dependencies*\n\n");
-        }
-
-        // Add vulnerability section
-        // Priority: use VulnerabilityCheckResult if available, otherwise fall back to vulnerability_report
-        if let Some(result) = vulnerability_result {
-            if !result.has_actionable_vulnerabilities()
-                && !result.has_informational_vulnerabilities()
-            {
-                output.push_str(&Self::format_no_vulnerabilities());
-            } else {
-                output.push_str(&Self::format_vulnerability_with_threshold(result));
-            }
-        } else if let Some(vulnerabilities) = vulnerability_report {
-            if vulnerabilities.is_empty() {
-                output.push_str(&Self::format_no_vulnerabilities());
-            } else {
-                output.push_str(&Self::format_vulnerability_section(vulnerabilities));
-            }
-        }
-
-        Ok(output)
-    }
-
-    fn format_v2(&self, model: &SbomReadModel) -> Result<String> {
+    fn format(&self, model: &SbomReadModel) -> Result<String> {
         let mut output = String::new();
 
         // Header section
-        self.render_header_v2(&mut output);
+        self.render_header(&mut output);
 
         // Components section
-        self.render_components_v2(&mut output, &model.components);
+        self.render_components(&mut output, &model.components);
 
         // Dependencies section (if present)
         if let Some(deps) = &model.dependencies {
-            self.render_dependencies_v2(&mut output, deps, &model.components);
+            self.render_dependencies(&mut output, deps, &model.components);
         }
 
         // Vulnerabilities section (if present)
         if let Some(vulns) = &model.vulnerabilities {
-            self.render_vulnerabilities_v2(&mut output, vulns);
+            self.render_vulnerabilities(&mut output, vulns);
         }
 
         Ok(output)
@@ -699,471 +349,7 @@ mod tests {
     use crate::application::read_models::{
         LicenseView, SbomMetadataView, SeverityView, VulnerabilitySummary,
     };
-    use crate::sbom_generation::domain::{Package, PackageName};
-    use crate::sbom_generation::services::SbomGenerator;
     use std::collections::HashMap;
-
-    #[test]
-    fn test_markdown_formatter_basic() {
-        let pkg = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let enriched = vec![EnrichedPackage::new(
-            pkg,
-            Some("Apache 2.0".to_string()),
-            Some("HTTP library".to_string()),
-        )];
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let result = formatter.format(enriched, &metadata, None);
-
-        assert!(result.is_ok());
-        let markdown = result.unwrap();
-        assert!(markdown.contains("# Software Bill of Materials (SBOM)"));
-        assert!(markdown.contains("## Component Inventory"));
-        assert!(markdown.contains("requests"));
-        assert!(markdown.contains("Apache 2.0"));
-    }
-
-    #[test]
-    fn test_markdown_formatter_with_dependencies() {
-        let pkg1 = Package::new("myproject".to_string(), "1.0.0".to_string()).unwrap();
-        let pkg2 = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let pkg3 = Package::new("urllib3".to_string(), "1.26.0".to_string()).unwrap();
-
-        let enriched = vec![
-            EnrichedPackage::new(pkg1.clone(), None, None),
-            EnrichedPackage::new(
-                pkg2.clone(),
-                Some("Apache 2.0".to_string()),
-                Some("HTTP library".to_string()),
-            ),
-            EnrichedPackage::new(pkg3.clone(), Some("MIT".to_string()), None),
-        ];
-
-        let direct_deps = vec![PackageName::new("requests".to_string()).unwrap()];
-        let mut transitive_deps = HashMap::new();
-        transitive_deps.insert(
-            PackageName::new("requests".to_string()).unwrap(),
-            vec![PackageName::new("urllib3".to_string()).unwrap()],
-        );
-        let graph = DependencyGraph::new(direct_deps, transitive_deps);
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let result = formatter.format_with_dependencies(&graph, enriched, &metadata, None, None);
-
-        assert!(result.is_ok());
-        let markdown = result.unwrap();
-        assert!(markdown.contains("## Component Inventory"));
-        assert!(markdown.contains("## Direct Dependencies"));
-        assert!(markdown.contains("## Transitive Dependencies"));
-        assert!(markdown.contains("### Dependencies for requests"));
-        assert!(markdown.contains("requests"));
-        assert!(markdown.contains("urllib3"));
-    }
-
-    #[test]
-    fn test_escape_markdown_table_cell() {
-        let input = "Text with | pipe and\nnewline";
-        let escaped = MarkdownFormatter::escape_markdown_table_cell(input);
-        assert_eq!(escaped, "Text with \\| pipe and newline");
-    }
-
-    #[test]
-    fn test_markdown_formatter_with_vulnerabilities() {
-        use crate::sbom_generation::domain::vulnerability::{
-            CvssScore, PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        let pkg = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let enriched = vec![EnrichedPackage::new(
-            pkg,
-            Some("Apache 2.0".to_string()),
-            Some("HTTP library".to_string()),
-        )];
-
-        // Create vulnerability data
-        let vuln1 = Vulnerability::new(
-            "CVE-2024-1234".to_string(),
-            Some(CvssScore::new(9.8).unwrap()),
-            Severity::Critical,
-            Some("2.32.0".to_string()),
-            Some("Security issue".to_string()),
-        )
-        .unwrap();
-
-        let vuln2 = Vulnerability::new(
-            "CVE-2024-5678".to_string(),
-            Some(CvssScore::new(5.3).unwrap()),
-            Severity::Medium,
-            Some("2.32.1".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let pkg_vulns = PackageVulnerabilities::new(
-            "requests".to_string(),
-            "2.31.0".to_string(),
-            vec![vuln1, vuln2],
-        );
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let result = formatter.format(enriched, &metadata, Some(&[pkg_vulns]));
-
-        assert!(result.is_ok());
-        let markdown = result.unwrap();
-        assert!(markdown.contains("## Vulnerability Report"));
-        assert!(markdown.contains("⚠️ Security Issues Detected"));
-        assert!(markdown.contains("CVE-2024-1234"));
-        assert!(markdown.contains("CVE-2024-5678"));
-        assert!(markdown.contains("9.8"));
-        assert!(markdown.contains("5.3"));
-        assert!(markdown.contains("🔴"));
-        assert!(markdown.contains("🟡"));
-        assert!(markdown.contains("2.32.0"));
-        assert!(markdown.contains("2.32.1"));
-        assert!(markdown.contains("OSV"));
-        assert!(markdown.contains("CC-BY 4.0"));
-    }
-
-    #[test]
-    fn test_markdown_formatter_with_empty_vulnerabilities() {
-        let pkg = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let enriched = vec![EnrichedPackage::new(
-            pkg,
-            Some("Apache 2.0".to_string()),
-            Some("HTTP library".to_string()),
-        )];
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let result = formatter.format(enriched, &metadata, Some(&[]));
-
-        assert!(result.is_ok());
-        let markdown = result.unwrap();
-        assert!(markdown.contains("## Vulnerability Report"));
-        assert!(markdown.contains("✅ No Known Vulnerabilities"));
-        assert!(markdown.contains("No security vulnerabilities were found"));
-        assert!(markdown.contains("OSV"));
-        assert!(markdown.contains("CC-BY 4.0"));
-    }
-
-    #[test]
-    fn test_markdown_formatter_without_vulnerability_check() {
-        let pkg = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let enriched = vec![EnrichedPackage::new(
-            pkg,
-            Some("Apache 2.0".to_string()),
-            Some("HTTP library".to_string()),
-        )];
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let result = formatter.format(enriched, &metadata, None);
-
-        assert!(result.is_ok());
-        let markdown = result.unwrap();
-        assert!(!markdown.contains("## Vulnerability Report"));
-        assert!(!markdown.contains("OSV"));
-    }
-
-    #[test]
-    fn test_markdown_formatter_with_dependencies_and_vulnerabilities() {
-        use crate::sbom_generation::domain::vulnerability::{
-            CvssScore, PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        let pkg1 = Package::new("myproject".to_string(), "1.0.0".to_string()).unwrap();
-        let pkg2 = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let pkg3 = Package::new("urllib3".to_string(), "1.26.0".to_string()).unwrap();
-
-        let enriched = vec![
-            EnrichedPackage::new(pkg1.clone(), None, None),
-            EnrichedPackage::new(
-                pkg2.clone(),
-                Some("Apache 2.0".to_string()),
-                Some("HTTP library".to_string()),
-            ),
-            EnrichedPackage::new(pkg3.clone(), Some("MIT".to_string()), None),
-        ];
-
-        let direct_deps = vec![PackageName::new("requests".to_string()).unwrap()];
-        let mut transitive_deps = HashMap::new();
-        transitive_deps.insert(
-            PackageName::new("requests".to_string()).unwrap(),
-            vec![PackageName::new("urllib3".to_string()).unwrap()],
-        );
-        let graph = DependencyGraph::new(direct_deps, transitive_deps);
-
-        // Create vulnerability data
-        let vuln = Vulnerability::new(
-            "CVE-2024-1234".to_string(),
-            Some(CvssScore::new(7.5).unwrap()),
-            Severity::High,
-            Some("1.27.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let pkg_vulns =
-            PackageVulnerabilities::new("urllib3".to_string(), "1.26.0".to_string(), vec![vuln]);
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let result = formatter.format_with_dependencies(
-            &graph,
-            enriched,
-            &metadata,
-            Some(&[pkg_vulns]),
-            None,
-        );
-
-        assert!(result.is_ok());
-        let markdown = result.unwrap();
-        assert!(markdown.contains("## Component Inventory"));
-        assert!(markdown.contains("## Direct Dependencies"));
-        assert!(markdown.contains("## Transitive Dependencies"));
-        assert!(markdown.contains("## Vulnerability Report"));
-        assert!(markdown.contains("CVE-2024-1234"));
-        assert!(markdown.contains("urllib3"));
-        assert!(markdown.contains("7.5"));
-        assert!(markdown.contains("🟠"));
-    }
-
-    #[test]
-    fn test_vulnerability_formatting_with_missing_cvss() {
-        use crate::sbom_generation::domain::vulnerability::{
-            PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        let vuln = Vulnerability::new(
-            "GHSA-xxxx-yyyy-zzzz".to_string(),
-            None,
-            Severity::High,
-            None,
-            None,
-        )
-        .unwrap();
-
-        let pkg_vulns =
-            PackageVulnerabilities::new("test-pkg".to_string(), "1.0.0".to_string(), vec![vuln]);
-
-        let output = MarkdownFormatter::format_vulnerability_section(&[pkg_vulns]);
-
-        assert!(output.contains("N/A")); // CVSS should be N/A
-        assert!(output.contains("GHSA-xxxx-yyyy-zzzz"));
-    }
-
-    #[test]
-    fn test_vulnerability_warning_section() {
-        use crate::sbom_generation::domain::vulnerability::{
-            CvssScore, PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        let vuln1 = Vulnerability::new(
-            "CVE-2024-001".to_string(),
-            Some(CvssScore::new(9.8).unwrap()),
-            Severity::Critical,
-            Some("2.0.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let vuln2 = Vulnerability::new(
-            "CVE-2024-002".to_string(),
-            Some(CvssScore::new(7.5).unwrap()),
-            Severity::High,
-            Some("2.1.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let pkg_vulns = PackageVulnerabilities::new(
-            "requests".to_string(),
-            "2.25.0".to_string(),
-            vec![vuln1, vuln2],
-        );
-
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![pkg_vulns],
-            below_threshold: vec![],
-            threshold_exceeded: true,
-        };
-
-        let output = MarkdownFormatter::format_vulnerability_warning_section(&result);
-
-        assert!(output.contains("### ⚠️Warning Found 2 vulnerabilities in 1 package."));
-        assert!(output.contains("CVE-2024-001"));
-        assert!(output.contains("CVE-2024-002"));
-        assert!(output.contains("🔴"));
-        assert!(output.contains("🟠"));
-    }
-
-    #[test]
-    fn test_vulnerability_info_section() {
-        use crate::sbom_generation::domain::vulnerability::{
-            CvssScore, PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        let vuln1 = Vulnerability::new(
-            "CVE-2024-003".to_string(),
-            Some(CvssScore::new(3.1).unwrap()),
-            Severity::Low,
-            Some("6.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let vuln2 =
-            Vulnerability::new("CVE-2024-004".to_string(), None, Severity::None, None, None)
-                .unwrap();
-
-        let pkg_vulns = PackageVulnerabilities::new(
-            "pyyaml".to_string(),
-            "5.4".to_string(),
-            vec![vuln1, vuln2],
-        );
-
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![],
-            below_threshold: vec![pkg_vulns],
-            threshold_exceeded: false,
-        };
-
-        let output = MarkdownFormatter::format_vulnerability_info_section(&result);
-
-        assert!(output.contains("### ℹ️Info Found 2 vulnerabilities in 1 package."));
-        assert!(output.contains("CVE-2024-003"));
-        assert!(output.contains("CVE-2024-004"));
-        assert!(output.contains("🟢"));
-        assert!(output.contains("⚪"));
-    }
-
-    #[test]
-    fn test_vulnerability_with_threshold_result() {
-        use crate::sbom_generation::domain::vulnerability::{
-            CvssScore, PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        // Above threshold vulnerabilities
-        let vuln_critical = Vulnerability::new(
-            "CVE-2024-001".to_string(),
-            Some(CvssScore::new(9.8).unwrap()),
-            Severity::Critical,
-            Some("2.0.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let vuln_high = Vulnerability::new(
-            "CVE-2024-002".to_string(),
-            Some(CvssScore::new(7.5).unwrap()),
-            Severity::High,
-            Some("2.1.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let above_pkg = PackageVulnerabilities::new(
-            "requests".to_string(),
-            "2.25.0".to_string(),
-            vec![vuln_critical, vuln_high],
-        );
-
-        // Below threshold vulnerabilities
-        let vuln_low = Vulnerability::new(
-            "CVE-2024-003".to_string(),
-            Some(CvssScore::new(3.1).unwrap()),
-            Severity::Low,
-            Some("6.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let below_pkg =
-            PackageVulnerabilities::new("pyyaml".to_string(), "5.4".to_string(), vec![vuln_low]);
-
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![above_pkg],
-            below_threshold: vec![below_pkg],
-            threshold_exceeded: true,
-        };
-
-        let output = MarkdownFormatter::format_vulnerability_with_threshold(&result);
-
-        // Check Warning section
-        assert!(output.contains("## Vulnerability Report"));
-        assert!(output.contains("### ⚠️Warning Found 2 vulnerabilities in 1 package."));
-        assert!(output.contains("CVE-2024-001"));
-        assert!(output.contains("CVE-2024-002"));
-
-        // Check Info section
-        assert!(output.contains("### ℹ️Info Found 1 vulnerability in 1 package."));
-        assert!(output.contains("CVE-2024-003"));
-
-        // Check attribution
-        assert!(output.contains("OSV"));
-        assert!(output.contains("CC-BY 4.0"));
-    }
-
-    #[test]
-    fn test_vulnerability_with_threshold_empty_warning() {
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![],
-            below_threshold: vec![],
-            threshold_exceeded: false,
-        };
-
-        let output = MarkdownFormatter::format_vulnerability_with_threshold(&result);
-
-        assert!(output.contains("### ⚠️Warning No vulnerabilities found above threshold."));
-    }
-
-    #[test]
-    fn test_format_with_dependencies_uses_vulnerability_result() {
-        use crate::sbom_generation::domain::vulnerability::{
-            CvssScore, PackageVulnerabilities, Severity, Vulnerability,
-        };
-
-        let pkg = Package::new("requests".to_string(), "2.31.0".to_string()).unwrap();
-        let enriched = vec![EnrichedPackage::new(pkg, None, None)];
-
-        let direct_deps = vec![PackageName::new("requests".to_string()).unwrap()];
-        let graph = DependencyGraph::new(direct_deps, HashMap::new());
-
-        let vuln = Vulnerability::new(
-            "CVE-2024-1234".to_string(),
-            Some(CvssScore::new(9.0).unwrap()),
-            Severity::Critical,
-            Some("3.0.0".to_string()),
-            None,
-        )
-        .unwrap();
-
-        let above_pkg =
-            PackageVulnerabilities::new("requests".to_string(), "2.31.0".to_string(), vec![vuln]);
-
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![above_pkg],
-            below_threshold: vec![],
-            threshold_exceeded: true,
-        };
-
-        let metadata = SbomGenerator::generate_metadata("test-tool", "1.0.0");
-        let formatter = MarkdownFormatter::new();
-        let output = formatter
-            .format_with_dependencies(&graph, enriched, &metadata, None, Some(&result))
-            .unwrap();
-
-        // Should use VulnerabilityCheckResult format (Warning section)
-        assert!(output.contains("### ⚠️Warning Found 1 vulnerability in 1 package."));
-        assert!(output.contains("CVE-2024-1234"));
-    }
-
-    // ============================================================
-    // format_v2 tests
-    // ============================================================
 
     fn create_test_read_model() -> SbomReadModel {
         SbomReadModel {
@@ -1209,11 +395,18 @@ mod tests {
     }
 
     #[test]
-    fn test_format_v2_basic() {
+    fn test_escape_markdown_table_cell() {
+        let input = "Text with | pipe and\nnewline";
+        let escaped = MarkdownFormatter::escape_markdown_table_cell(input);
+        assert_eq!(escaped, "Text with \\| pipe and newline");
+    }
+
+    #[test]
+    fn test_format_basic() {
         let model = create_test_read_model();
         let formatter = MarkdownFormatter::new();
 
-        let result = formatter.format_v2(&model);
+        let result = formatter.format(&model);
 
         assert!(result.is_ok());
         let markdown = result.unwrap();
@@ -1226,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_v2_with_dependencies() {
+    fn test_format_with_dependencies() {
         let mut model = create_test_read_model();
         let mut transitive = HashMap::new();
         transitive.insert(
@@ -1240,7 +433,7 @@ mod tests {
         });
 
         let formatter = MarkdownFormatter::new();
-        let result = formatter.format_v2(&model);
+        let result = formatter.format(&model);
 
         assert!(result.is_ok());
         let markdown = result.unwrap();
@@ -1251,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_v2_with_vulnerabilities() {
+    fn test_format_with_vulnerabilities() {
         let mut model = create_test_read_model();
         model.vulnerabilities = Some(VulnerabilityReportView {
             actionable: vec![VulnerabilityView {
@@ -1278,7 +471,7 @@ mod tests {
         });
 
         let formatter = MarkdownFormatter::new();
-        let result = formatter.format_v2(&model);
+        let result = formatter.format(&model);
 
         assert!(result.is_ok());
         let markdown = result.unwrap();
@@ -1292,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_v2_with_informational_vulnerabilities() {
+    fn test_format_with_informational_vulnerabilities() {
         let mut model = create_test_read_model();
         model.vulnerabilities = Some(VulnerabilityReportView {
             actionable: vec![],
@@ -1319,7 +512,7 @@ mod tests {
         });
 
         let formatter = MarkdownFormatter::new();
-        let result = formatter.format_v2(&model);
+        let result = formatter.format(&model);
 
         assert!(result.is_ok());
         let markdown = result.unwrap();
@@ -1331,8 +524,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_v2_output_matches_format_with_dependencies() {
-        // Test that format_v2 produces similar output structure to format_with_dependencies
+    fn test_format_output_section_ordering() {
         let mut model = create_test_read_model();
         let mut transitive = HashMap::new();
         transitive.insert(
@@ -1345,7 +537,7 @@ mod tests {
         });
 
         let formatter = MarkdownFormatter::new();
-        let result = formatter.format_v2(&model);
+        let result = formatter.format(&model);
 
         assert!(result.is_ok());
         let markdown = result.unwrap();
@@ -1368,11 +560,11 @@ mod tests {
     }
 
     // ============================================================
-    // format_v2 vulnerability rendering unit tests
+    // Vulnerability rendering unit tests
     // ============================================================
 
     #[test]
-    fn test_render_vulnerability_summary_v2() {
+    fn test_render_vulnerability_summary() {
         let formatter = MarkdownFormatter::new();
         let summary = VulnerabilitySummary {
             total_count: 3,
@@ -1382,13 +574,13 @@ mod tests {
         };
 
         let mut output = String::new();
-        formatter.render_vulnerability_summary_v2(&mut output, &summary);
+        formatter.render_vulnerability_summary(&mut output, &summary);
 
         assert!(output.contains("**Found 3 vulnerabilities in 2 packages.**"));
     }
 
     #[test]
-    fn test_render_vulnerability_summary_v2_singular() {
+    fn test_render_vulnerability_summary_singular() {
         let formatter = MarkdownFormatter::new();
         let summary = VulnerabilitySummary {
             total_count: 1,
@@ -1398,13 +590,13 @@ mod tests {
         };
 
         let mut output = String::new();
-        formatter.render_vulnerability_summary_v2(&mut output, &summary);
+        formatter.render_vulnerability_summary(&mut output, &summary);
 
         assert!(output.contains("**Found 1 vulnerability in 1 package.**"));
     }
 
     #[test]
-    fn test_render_actionable_vulnerabilities_v2() {
+    fn test_render_actionable_vulnerabilities() {
         let formatter = MarkdownFormatter::new();
         let vulns = vec![
             VulnerabilityView {
@@ -1436,7 +628,7 @@ mod tests {
         ];
 
         let mut output = String::new();
-        formatter.render_actionable_vulnerabilities_v2(&mut output, &vulns);
+        formatter.render_actionable_vulnerabilities(&mut output, &vulns);
 
         assert!(output.contains("### ⚠️Warning Found 2 vulnerabilities in 1 package."));
         assert!(output.contains("CVE-2024-1111"));
@@ -1448,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_informational_vulnerabilities_v2() {
+    fn test_render_informational_vulnerabilities() {
         let formatter = MarkdownFormatter::new();
         let vulns = vec![VulnerabilityView {
             bom_ref: "vuln-003".to_string(),
@@ -1465,7 +657,7 @@ mod tests {
         }];
 
         let mut output = String::new();
-        formatter.render_informational_vulnerabilities_v2(&mut output, &vulns);
+        formatter.render_informational_vulnerabilities(&mut output, &vulns);
 
         assert!(output.contains("### ℹ️Info Found 1 vulnerability in 1 package."));
         assert!(output.contains("CVE-2024-3333"));
@@ -1475,7 +667,7 @@ mod tests {
     }
 
     #[test]
-    fn test_render_actionable_vulnerabilities_v2_multiple_packages() {
+    fn test_render_actionable_vulnerabilities_multiple_packages() {
         let formatter = MarkdownFormatter::new();
         let vulns = vec![
             VulnerabilityView {
@@ -1507,7 +699,7 @@ mod tests {
         ];
 
         let mut output = String::new();
-        formatter.render_actionable_vulnerabilities_v2(&mut output, &vulns);
+        formatter.render_actionable_vulnerabilities(&mut output, &vulns);
 
         assert!(output.contains("### ⚠️Warning Found 2 vulnerabilities in 2 packages."));
     }
@@ -1560,7 +752,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_v2_vulnerability_section_ordering() {
+    fn test_format_vulnerability_section_ordering() {
         let mut model = create_test_read_model();
         model.vulnerabilities = Some(VulnerabilityReportView {
             actionable: vec![VulnerabilityView {
@@ -1599,7 +791,7 @@ mod tests {
         });
 
         let formatter = MarkdownFormatter::new();
-        let markdown = formatter.format_v2(&model).unwrap();
+        let markdown = formatter.format(&model).unwrap();
 
         // Verify sections appear in correct order
         let summary_pos = markdown.find("**Found 2 vulnerabilities in 2 packages.**");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,15 @@
 //!     .build()?;
 //! let response = use_case.execute(request).await?;
 //!
-//! // Format output
+//! // Build read model and format output
+//! let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
+//!     response.enriched_packages,
+//!     &response.metadata,
+//!     None,
+//!     None,
+//! );
 //! let formatter = CycloneDxFormatter::new();
-//! let output = formatter.format(response.enriched_packages, &response.metadata, None)?;
+//! let output = formatter.format(&read_model)?;
 //! println!("{}", output);
 //! # Ok(())
 //! # }
@@ -70,8 +76,8 @@ pub mod prelude {
     pub use crate::application::factories::{FormatterFactory, PresenterFactory, PresenterType};
     pub use crate::application::use_cases::GenerateSbomUseCase;
     pub use crate::ports::outbound::{
-        EnrichedPackage, LicenseRepository, LockfileParseResult, LockfileReader, OutputPresenter,
-        ProgressReporter, ProjectConfigReader, SbomFormatter,
+        LicenseRepository, LockfileParseResult, LockfileReader, OutputPresenter, ProgressReporter,
+        ProjectConfigReader, SbomFormatter,
     };
     pub use crate::sbom_generation::domain::{
         DependencyGraph, LicenseInfo, Package, PackageName, SbomMetadata,

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,14 +137,14 @@ async fn run(args: Args) -> Result<bool> {
     // Create formatter using factory
     let formatter = FormatterFactory::create(args.format);
 
-    // Build read model and format using format_v2
+    // Build read model and format
     let read_model = SbomReadModelBuilder::build(
         response.enriched_packages,
         &response.metadata,
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
     );
-    let formatted_output = formatter.format_v2(&read_model)?;
+    let formatted_output = formatter.format(&read_model)?;
 
     // Create presenter using factory
     let presenter_type = if let Some(output_path) = args.output {

--- a/src/ports/outbound/enriched_package.rs
+++ b/src/ports/outbound/enriched_package.rs
@@ -1,0 +1,22 @@
+use crate::sbom_generation::domain::Package;
+
+/// EnrichedPackage represents a package with its license information
+///
+/// This is used to pass package data with license info from the use case
+/// to the read model builder.
+#[derive(Debug, Clone)]
+pub struct EnrichedPackage {
+    pub package: Package,
+    pub license: Option<String>,
+    pub description: Option<String>,
+}
+
+impl EnrichedPackage {
+    pub fn new(package: Package, license: Option<String>, description: Option<String>) -> Self {
+        Self {
+            package,
+            license,
+            description,
+        }
+    }
+}

--- a/src/ports/outbound/formatter.rs
+++ b/src/ports/outbound/formatter.rs
@@ -1,93 +1,12 @@
 use crate::application::read_models::SbomReadModel;
-use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
-use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
-use crate::sbom_generation::domain::{DependencyGraph, Package, SbomMetadata};
 use crate::shared::Result;
-
-/// EnrichedPackage represents a package with its license information
-///
-/// This is used to pass package data with license info to formatters.
-#[derive(Debug, Clone)]
-pub struct EnrichedPackage {
-    pub package: Package,
-    pub license: Option<String>,
-    pub description: Option<String>,
-}
-
-impl EnrichedPackage {
-    pub fn new(package: Package, license: Option<String>, description: Option<String>) -> Self {
-        Self {
-            package,
-            license,
-            description,
-        }
-    }
-}
 
 /// SbomFormatter port for formatting SBOM output
 ///
 /// This port abstracts the formatting logic for different SBOM formats
 /// (CycloneDX JSON, Markdown, etc.).
 pub trait SbomFormatter {
-    /// Formats packages with metadata into SBOM output
-    ///
-    /// # Arguments
-    /// * `packages` - List of enriched packages with license information
-    /// * `metadata` - SBOM metadata (timestamp, tool info, serial number)
-    /// * `vulnerability_report` - Optional vulnerability report from CVE check
-    ///
-    /// # Returns
-    /// Formatted SBOM content as a string
-    ///
-    /// # Errors
-    /// Returns an error if formatting or serialization fails
-    #[allow(dead_code)]
-    fn format(
-        &self,
-        packages: Vec<EnrichedPackage>,
-        metadata: &SbomMetadata,
-        vulnerability_report: Option<&[PackageVulnerabilities]>,
-    ) -> Result<String>;
-
-    /// Formats packages with dependency graph information
-    ///
-    /// This method is used for formats that include dependency relationship
-    /// information (e.g., Markdown format).
-    ///
-    /// # Arguments
-    /// * `dependency_graph` - Complete dependency graph
-    /// * `packages` - List of enriched packages with license information
-    /// * `metadata` - SBOM metadata
-    /// * `vulnerability_report` - Optional vulnerability report from CVE check
-    /// * `vulnerability_result` - Optional threshold-evaluated vulnerability result
-    ///
-    /// # Returns
-    /// Formatted SBOM content as a string
-    ///
-    /// # Errors
-    /// Returns an error if formatting fails
-    ///
-    /// # Default Implementation
-    /// By default, this calls `format()` and ignores the dependency graph.
-    /// Formatters that support dependency information should override this.
-    #[allow(dead_code)]
-    fn format_with_dependencies(
-        &self,
-        _dependency_graph: &DependencyGraph,
-        packages: Vec<EnrichedPackage>,
-        metadata: &SbomMetadata,
-        vulnerability_report: Option<&[PackageVulnerabilities]>,
-        vulnerability_result: Option<&VulnerabilityCheckResult>,
-    ) -> Result<String> {
-        // Default implementation ignores vulnerability_result
-        let _ = vulnerability_result;
-        self.format(packages, metadata, vulnerability_report)
-    }
-
     /// Formats SBOM output using the unified read model
-    ///
-    /// This method provides a simplified interface that accepts the pre-built
-    /// `SbomReadModel` containing all necessary data for formatting.
     ///
     /// # Arguments
     /// * `model` - The unified SBOM read model containing metadata, components,
@@ -98,11 +17,5 @@ pub trait SbomFormatter {
     ///
     /// # Errors
     /// Returns an error if formatting or serialization fails
-    ///
-    /// # Default Implementation
-    /// By default, this method is unimplemented and will panic.
-    /// Formatters should override this method to provide their implementation.
-    fn format_v2(&self, _model: &SbomReadModel) -> Result<String> {
-        unimplemented!("format_v2 not yet implemented for this formatter")
-    }
+    fn format(&self, model: &SbomReadModel) -> Result<String>;
 }

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -2,6 +2,7 @@
 ///
 /// These ports define the interfaces that the application core uses
 /// to interact with external systems (file system, network, console, etc.).
+pub mod enriched_package;
 pub mod formatter;
 pub mod license_repository;
 pub mod lockfile_reader;
@@ -10,7 +11,8 @@ pub mod progress_reporter;
 pub mod project_config_reader;
 pub mod vulnerability_repository;
 
-pub use formatter::{EnrichedPackage, SbomFormatter};
+pub use enriched_package::EnrichedPackage;
+pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};
 pub use lockfile_reader::{LockfileParseResult, LockfileReader};
 pub use output_presenter::OutputPresenter;

--- a/src/sbom_generation/domain/services/mod.rs
+++ b/src/sbom_generation/domain/services/mod.rs
@@ -1,5 +1,3 @@
 pub mod vulnerability_checker;
 
-pub use vulnerability_checker::{
-    ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker, VulnerabilityRow,
-};
+pub use vulnerability_checker::{ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker};

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -93,9 +93,15 @@ async fn test_e2e_json_format() {
     assert!(result.is_ok());
     let response = result.unwrap();
 
-    // Format as JSON
+    // Build read model and format as JSON
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
+        response.enriched_packages,
+        &response.metadata,
+        response.dependency_graph.as_ref(),
+        response.vulnerability_check_result.as_ref(),
+    );
     let formatter = CycloneDxFormatter::new();
-    let json_output = formatter.format(response.enriched_packages, &response.metadata, None);
+    let json_output = formatter.format(&read_model);
 
     assert!(json_output.is_ok());
     let json = json_output.unwrap();
@@ -134,17 +140,15 @@ async fn test_e2e_markdown_format() {
     assert!(result.is_ok());
     let response = result.unwrap();
 
-    // Format as Markdown
-    let formatter = MarkdownFormatter::new();
-    let markdown_output = formatter.format_with_dependencies(
-        &response
-            .dependency_graph
-            .expect("Dependency graph should be present"),
+    // Build read model and format as Markdown
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
         response.enriched_packages,
         &response.metadata,
-        None,
-        None,
+        response.dependency_graph.as_ref(),
+        response.vulnerability_check_result.as_ref(),
     );
+    let formatter = MarkdownFormatter::new();
+    let markdown_output = formatter.format(&read_model);
 
     assert!(markdown_output.is_ok());
     let markdown = markdown_output.unwrap();


### PR DESCRIPTION
## Summary
- Remove legacy `format()` and `format_with_dependencies()` methods from `SbomFormatter` trait and all implementations
- Rename `format_v2(&SbomReadModel)` to `format(&SbomReadModel)` as the sole formatting method
- Move `EnrichedPackage` to its own module and clean up dead code (~1000 lines removed)

## Related Issue
Closes #167

## Changes Made
- **`src/ports/outbound/formatter.rs`**: Simplified trait to single `format(&self, model: &SbomReadModel) -> Result<String>` method
- **`src/ports/outbound/enriched_package.rs`**: New module for `EnrichedPackage` (moved from formatter.rs)
- **`src/adapters/outbound/formatters/cyclonedx_formatter.rs`**: Removed old `format()` with `Vec<EnrichedPackage>`, renamed `format_v2` to `format`
- **`src/adapters/outbound/formatters/markdown_formatter.rs`**: Removed old `format()`, `format_with_dependencies()`, and all legacy helper methods. Renamed `render_*_v2` to `render_*`
- **`src/main.rs`**: Updated `format_v2()` call to `format()`
- **`src/lib.rs`**: Updated doc example, removed `EnrichedPackage` from prelude
- **`src/sbom_generation/domain/services/mod.rs`**: Removed unused `VulnerabilityRow` re-export
- **`tests/e2e_test.rs`**: Updated to use `SbomReadModelBuilder` + `format()` pipeline

## Test Plan
- [x] `cargo test --all` passes (261 unit tests + 12 integration tests + 7 doc tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)