### PR TITLE
refactor(read-model): remove unnecessary #[allow(dead_code)] from read model types

### DIFF
--- a/src/application/read_models/component_view.rs
+++ b/src/application/read_models/component_view.rs
@@ -3,7 +3,6 @@
 //! These structs provide a flattened, query-optimized view of component data.
 
 /// View representation of a software component
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ComponentView {
     /// BOM reference identifier
@@ -19,13 +18,14 @@ pub struct ComponentView {
     /// Component description
     pub description: Option<String>,
     /// SHA256 hash of the component
+    #[allow(dead_code)]
     pub sha256_hash: Option<String>,
     /// Whether this is a direct dependency
+    #[allow(dead_code)]
     pub is_direct_dependency: bool,
 }
 
 /// View representation of license information
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct LicenseView {
     /// SPDX license identifier
@@ -33,5 +33,6 @@ pub struct LicenseView {
     /// License name
     pub name: String,
     /// URL to license text
+    #[allow(dead_code)]
     pub url: Option<String>,
 }

--- a/src/application/read_models/dependency_view.rs
+++ b/src/application/read_models/dependency_view.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 ///
 /// Provides a flattened view of direct and transitive dependencies
 /// for efficient querying.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct DependencyView {
     /// BOM references of direct dependencies

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -11,7 +11,6 @@ use super::vulnerability_view::VulnerabilityReportView;
 ///
 /// This struct provides a denormalized, query-optimized view of SBOM data
 /// following the CQRS-lite pattern.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct SbomReadModel {
     /// SBOM metadata
@@ -25,7 +24,6 @@ pub struct SbomReadModel {
 }
 
 /// View representation of SBOM metadata
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct SbomMetadataView {
     /// Timestamp when the SBOM was created

--- a/src/application/read_models/sbom_read_model_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder.rs
@@ -22,10 +22,8 @@ use std::collections::{HashMap, HashSet};
 /// This builder transforms domain objects into a query-optimized read model.
 /// Initial implementation focuses on metadata and components, with dependencies
 /// and vulnerabilities being handled in future iterations.
-#[allow(dead_code)]
 pub struct SbomReadModelBuilder;
 
-#[allow(dead_code)]
 impl SbomReadModelBuilder {
     /// Builds a SbomReadModel from domain objects
     ///

--- a/src/application/read_models/vulnerability_view.rs
+++ b/src/application/read_models/vulnerability_view.rs
@@ -7,7 +7,6 @@
 ///
 /// Provides pre-categorized vulnerabilities with summary statistics
 /// for efficient dashboard and reporting queries.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct VulnerabilityReportView {
     /// Vulnerabilities that require action (CRITICAL, HIGH, MEDIUM)
@@ -15,13 +14,13 @@ pub struct VulnerabilityReportView {
     /// Vulnerabilities for information only (LOW, NONE)
     pub informational: Vec<VulnerabilityView>,
     /// Whether the severity threshold was exceeded
+    #[allow(dead_code)]
     pub threshold_exceeded: bool,
     /// Summary statistics
     pub summary: VulnerabilitySummary,
 }
 
 /// View representation of a single vulnerability
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct VulnerabilityView {
     /// BOM reference identifier
@@ -49,7 +48,6 @@ pub struct VulnerabilityView {
 }
 
 /// Severity level for display purposes
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub enum SeverityView {
     /// Critical severity (CVSS 9.0-10.0)
@@ -67,7 +65,6 @@ pub enum SeverityView {
 
 impl SeverityView {
     /// Returns the display name of the severity
-    #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
         match self {
             SeverityView::Critical => "CRITICAL",
@@ -89,14 +86,15 @@ impl SeverityView {
 }
 
 /// Summary statistics for vulnerabilities
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct VulnerabilitySummary {
     /// Total number of vulnerabilities
     pub total_count: usize,
     /// Number of actionable vulnerabilities
+    #[allow(dead_code)]
     pub actionable_count: usize,
     /// Number of informational vulnerabilities
+    #[allow(dead_code)]
     pub informational_count: usize,
     /// Number of unique affected packages
     pub affected_package_count: usize,


### PR DESCRIPTION
## Summary
- Remove 12 struct/impl-level `#[allow(dead_code)]` annotations from read model types that are now actively used after completing all migration phases of Issue #151
- Retain field-level `#[allow(dead_code)]` on 5 fields not yet consumed by formatter implementations

## Related Issue
Closes #178

## Changes Made
- `dependency_view.rs`: Removed `#[allow(dead_code)]` from `DependencyView` struct
- `sbom_read_model.rs`: Removed from `SbomReadModel` and `SbomMetadataView` structs
- `vulnerability_view.rs`: Removed from `VulnerabilityReportView`, `VulnerabilityView`, `SeverityView` enum, `SeverityView::as_str()` method, and `VulnerabilitySummary` struct (7 annotations)
- `component_view.rs`: Removed from `ComponentView` and `LicenseView` structs
- `sbom_read_model_builder.rs`: Removed from `SbomReadModelBuilder` struct and its `impl` block
- Added field-level `#[allow(dead_code)]` on `sha256_hash`, `is_direct_dependency`, `url`, `threshold_exceeded`, `actionable_count`, and `informational_count` fields that are not yet read by formatters

## Test Plan
- [x] `cargo test --all` passes (all 261 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] No behavioral changes — pure cleanup

---
Generated with [Claude Code](https://claude.com/claude-code)