### PR TITLE
feat(config): add config file data structures and YAML parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,6 +1462,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -1870,6 +1901,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yml",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1877,6 +1909,12 @@ dependencies = [
  "urlencoding",
  "uuid",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 urlencoding = "2.1"
+serde_yml = "0.0.12"
 indicatif = "0.18"
 dashmap = "6"
 owo-colors = "4.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,262 @@
+//! Configuration file support for uv-sbom.
+//!
+//! Provides YAML-based configuration through `uv-sbom.config.yml` files,
+//! including data structures, file loading, and validation.
+
+use anyhow::{bail, Context};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::shared::Result;
+
+const CONFIG_FILENAME: &str = "uv-sbom.config.yml";
+
+/// Top-level configuration file schema.
+#[derive(Debug, Deserialize, Default)]
+pub struct ConfigFile {
+    pub format: Option<String>,
+    pub exclude_packages: Option<Vec<String>>,
+    pub check_cve: Option<bool>,
+    pub severity_threshold: Option<String>,
+    pub cvss_threshold: Option<f64>,
+    pub ignore_cves: Option<Vec<IgnoreCve>>,
+    /// Captures unknown fields for warnings.
+    #[serde(flatten)]
+    pub unknown_fields: HashMap<String, serde_yml::Value>,
+}
+
+/// A CVE entry to ignore during vulnerability checks.
+#[derive(Debug, Deserialize)]
+pub struct IgnoreCve {
+    pub id: String,
+    pub reason: Option<String>,
+}
+
+/// Load config from an explicit path. Returns an error if the file is not found.
+pub fn load_config_from_path(path: &Path) -> Result<ConfigFile> {
+    let content = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "Failed to read config file: {}\n\n💡 Hint: Check that the file exists and is readable.",
+            path.display()
+        )
+    })?;
+
+    let config: ConfigFile = serde_yml::from_str(&content).with_context(|| {
+        format!(
+            "Failed to parse config file: {}\n\n💡 Hint: Ensure the file contains valid YAML syntax.",
+            path.display()
+        )
+    })?;
+
+    validate_config(&config)?;
+    warn_unknown_fields(&config);
+
+    Ok(config)
+}
+
+/// Auto-discover config in a directory. Returns `None` silently if not found.
+pub fn discover_config(dir: &Path) -> Result<Option<ConfigFile>> {
+    let config_path = dir.join(CONFIG_FILENAME);
+
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let config = load_config_from_path(&config_path)?;
+    Ok(Some(config))
+}
+
+/// Validate the loaded configuration.
+fn validate_config(config: &ConfigFile) -> Result<()> {
+    if let Some(ref ignore_cves) = config.ignore_cves {
+        for (i, entry) in ignore_cves.iter().enumerate() {
+            if entry.id.trim().is_empty() {
+                bail!(
+                    "Invalid config: ignore_cves[{}].id must not be empty.\n\n\
+                     💡 Hint: Each ignore_cves entry must have a non-empty 'id' field (e.g., \"CVE-2024-1234\").",
+                    i
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Warn about unknown fields in the config file.
+fn warn_unknown_fields(config: &ConfigFile) {
+    for key in config.unknown_fields.keys() {
+        eprintln!(
+            "⚠️  Warning: Unknown config field '{}' will be ignored.",
+            key
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_valid_config() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.yml");
+        fs::write(
+            &config_path,
+            r#"
+format: markdown
+exclude_packages:
+  - setuptools
+  - pip
+check_cve: true
+severity_threshold: HIGH
+cvss_threshold: 7.0
+ignore_cves:
+  - id: CVE-2024-1234
+    reason: "Not applicable to our usage"
+  - id: CVE-2024-5678
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from_path(&config_path).unwrap();
+        assert_eq!(config.format.as_deref(), Some("markdown"));
+        assert_eq!(
+            config.exclude_packages.as_deref(),
+            Some(&["setuptools".to_string(), "pip".to_string()][..])
+        );
+        assert_eq!(config.check_cve, Some(true));
+        assert_eq!(config.severity_threshold.as_deref(), Some("HIGH"));
+        assert_eq!(config.cvss_threshold, Some(7.0));
+        let cves = config.ignore_cves.unwrap();
+        assert_eq!(cves.len(), 2);
+        assert_eq!(cves[0].id, "CVE-2024-1234");
+        assert_eq!(
+            cves[0].reason.as_deref(),
+            Some("Not applicable to our usage")
+        );
+        assert_eq!(cves[1].id, "CVE-2024-5678");
+        assert!(cves[1].reason.is_none());
+    }
+
+    #[test]
+    fn test_discover_config_found() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(CONFIG_FILENAME);
+        fs::write(
+            &config_path,
+            r#"
+format: json
+check_cve: false
+"#,
+        )
+        .unwrap();
+
+        let config = discover_config(dir.path()).unwrap();
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert_eq!(config.format.as_deref(), Some("json"));
+        assert_eq!(config.check_cve, Some(false));
+    }
+
+    #[test]
+    fn test_discover_config_not_found() {
+        let dir = TempDir::new().unwrap();
+        let config = discover_config(dir.path()).unwrap();
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_load_config_missing_file() {
+        let result = load_config_from_path(Path::new("/nonexistent/config.yml"));
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("Failed to read config file"));
+    }
+
+    #[test]
+    fn test_load_config_parse_error() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("bad.yml");
+        fs::write(&config_path, "invalid: yaml: [[[broken").unwrap();
+
+        let result = load_config_from_path(&config_path);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("Failed to parse config file"));
+    }
+
+    #[test]
+    fn test_empty_cve_id_validation_error() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.yml");
+        fs::write(
+            &config_path,
+            r#"
+ignore_cves:
+  - id: ""
+    reason: "empty id"
+"#,
+        )
+        .unwrap();
+
+        let result = load_config_from_path(&config_path);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_whitespace_only_cve_id_validation_error() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.yml");
+        fs::write(
+            &config_path,
+            r#"
+ignore_cves:
+  - id: "   "
+    reason: "whitespace only"
+"#,
+        )
+        .unwrap();
+
+        let result = load_config_from_path(&config_path);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_unknown_fields_warning() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.yml");
+        fs::write(
+            &config_path,
+            r#"
+format: json
+unknown_field: true
+another_unknown: value
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from_path(&config_path).unwrap();
+        assert_eq!(config.unknown_fields.len(), 2);
+        assert!(config.unknown_fields.contains_key("unknown_field"));
+        assert!(config.unknown_fields.contains_key("another_unknown"));
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = ConfigFile::default();
+        assert!(config.format.is_none());
+        assert!(config.exclude_packages.is_none());
+        assert!(config.check_cve.is_none());
+        assert!(config.severity_threshold.is_none());
+        assert!(config.cvss_threshold.is_none());
+        assert!(config.ignore_cves.is_none());
+        assert!(config.unknown_fields.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 
 pub mod adapters;
 pub mod application;
+pub mod config;
 pub mod ports;
 pub mod sbom_generation;
 pub mod shared;


### PR DESCRIPTION
## Summary
- Add foundational `config` module with `ConfigFile` and `IgnoreCve` data structures for YAML-based configuration
- Implement `load_config_from_path()` and `discover_config()` functions with validation and error handling
- Add `serde_yml` dependency for YAML parsing support

## Related Issue
Closes #186

## Changes Made
- **`Cargo.toml`**: Added `serde_yml = "0.0.12"` dependency
- **`src/config.rs`** (new): Config module with structs, loading logic, validation, and unit tests
- **`src/lib.rs`**: Exported `config` module

### Key Features
- `ConfigFile` struct with serde deserialization and `#[serde(flatten)]` for unknown field detection
- `IgnoreCve` struct for CVE ignore entries with id and optional reason
- `load_config_from_path()`: Explicit path loading with clear error messages
- `discover_config()`: Auto-discovery of `uv-sbom.config.yml` (returns `None` silently if not found)
- Validation: empty `ignore_cves[].id` triggers error
- Unknown fields: produces stderr warning and continues

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (293 lib tests + 5 doc tests)
- [x] Unit tests cover: valid config, missing file (auto-discovery), missing file (explicit), parse error, empty CVE ID, whitespace-only CVE ID, unknown fields, default config

---
Generated with [Claude Code](https://claude.com/claude-code)