### PR TITLE
feat(domain): integrate CVE ignore list into vulnerability checking

### DIFF
--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -25,7 +25,6 @@ pub struct SbomRequest {
     /// CVSS threshold for vulnerability filtering
     pub cvss_threshold: Option<f32>,
     /// CVE IDs to ignore during vulnerability checks
-    #[allow(dead_code)] // Will be used by vulnerability filtering in sub-issue #188
     pub ignore_cves: Vec<IgnoreCve>,
 }
 

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -103,7 +103,7 @@ where
         // Step 6: Apply threshold evaluation if vulnerabilities were found
         let vulnerability_check_result = vulnerability_report.as_ref().map(|report| {
             let threshold_config = Self::build_threshold_config(&request);
-            VulnerabilityChecker::check(report.clone(), threshold_config)
+            VulnerabilityChecker::check(report.clone(), threshold_config, &request.ignore_cves)
         });
 
         // Step 7: Build and return response

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,13 @@ pub struct IgnoreCve {
     pub reason: Option<String>,
 }
 
+impl IgnoreCve {
+    /// Returns the reason for ignoring this CVE, if provided
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+}
+
 /// Load config from an explicit path. Returns an error if the file is not found.
 pub fn load_config_from_path(path: &Path) -> Result<ConfigFile> {
     let content = std::fs::read_to_string(path).with_context(|| {

--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -1,4 +1,5 @@
 use super::super::vulnerability::{PackageVulnerabilities, Severity, Vulnerability};
+use crate::config::IgnoreCve;
 
 /// Represents a flattened vulnerability row for display purposes
 ///
@@ -123,22 +124,28 @@ impl VulnerabilityChecker {
         rows
     }
 
-    /// Checks vulnerabilities against the specified threshold
+    /// Checks vulnerabilities against the specified threshold, after filtering ignored CVEs
     ///
     /// # Arguments
     /// * `vulnerabilities` - List of package vulnerabilities to check
     /// * `threshold` - Threshold configuration
+    /// * `ignore_cves` - List of CVE IDs to ignore (excluded before threshold evaluation)
     ///
     /// # Returns
     /// VulnerabilityCheckResult with above/below threshold separation
     pub fn check(
         vulnerabilities: Vec<PackageVulnerabilities>,
         threshold: ThresholdConfig,
+        ignore_cves: &[IgnoreCve],
     ) -> VulnerabilityCheckResult {
+        // Step 1: Filter out ignored CVEs
+        let filtered = Self::filter_ignored_cves(vulnerabilities, ignore_cves);
+
+        // Step 2: Apply threshold evaluation
         let mut above_threshold = Vec::new();
         let mut below_threshold = Vec::new();
 
-        for pkg_vulns in vulnerabilities {
+        for pkg_vulns in filtered {
             let (above, below) = Self::partition_vulnerabilities(&pkg_vulns, &threshold);
 
             if !above.is_empty() {
@@ -165,6 +172,71 @@ impl VulnerabilityChecker {
             below_threshold,
             threshold_exceeded,
         }
+    }
+
+    /// Filters out ignored CVEs from vulnerability results
+    ///
+    /// Removes vulnerabilities whose IDs match the ignore list (exact, case-sensitive).
+    /// Logs each ignored CVE to stderr for transparency.
+    ///
+    /// # Arguments
+    /// * `vulnerabilities` - List of package vulnerabilities to filter
+    /// * `ignore_cves` - List of CVE entries to ignore
+    ///
+    /// # Returns
+    /// Filtered list with ignored CVEs removed (packages with no remaining vulns are dropped)
+    fn filter_ignored_cves(
+        vulnerabilities: Vec<PackageVulnerabilities>,
+        ignore_cves: &[IgnoreCve],
+    ) -> Vec<PackageVulnerabilities> {
+        if ignore_cves.is_empty() {
+            return vulnerabilities;
+        }
+
+        let ignore_ids: std::collections::HashSet<&str> =
+            ignore_cves.iter().map(|c| c.id.as_str()).collect();
+
+        let mut result = Vec::new();
+
+        for pkg_vulns in vulnerabilities {
+            let mut kept = Vec::new();
+
+            for vuln in pkg_vulns.vulnerabilities() {
+                if ignore_ids.contains(vuln.id()) {
+                    // Find the matching ignore entry to get the reason
+                    let reason = ignore_cves
+                        .iter()
+                        .find(|c| c.id == vuln.id())
+                        .and_then(|c| c.reason());
+
+                    match reason {
+                        Some(r) => eprintln!(
+                            "⚠ Ignored {} for package {} (reason: {})",
+                            vuln.id(),
+                            pkg_vulns.package_name(),
+                            r
+                        ),
+                        None => eprintln!(
+                            "⚠ Ignored {} for package {} (no reason provided)",
+                            vuln.id(),
+                            pkg_vulns.package_name()
+                        ),
+                    }
+                } else {
+                    kept.push(vuln.clone());
+                }
+            }
+
+            if !kept.is_empty() {
+                result.push(PackageVulnerabilities::new(
+                    pkg_vulns.package_name().to_string(),
+                    pkg_vulns.current_version().to_string(),
+                    kept,
+                ));
+            }
+        }
+
+        result
     }
 
     /// Partitions vulnerabilities into above and below threshold
@@ -225,7 +297,7 @@ mod tests {
         let vuln2 = create_vulnerability("CVE-2024-002", Some(9.8), Severity::Critical);
         let pkg = create_package_vulnerabilities("test-pkg", vec![vuln1, vuln2]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None);
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -245,7 +317,7 @@ mod tests {
         );
 
         let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High));
+            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -260,8 +332,11 @@ mod tests {
         let vuln_critical = create_vulnerability("CVE-2024-002", Some(9.8), Severity::Critical);
         let pkg = create_package_vulnerabilities("test-pkg", vec![vuln_high, vuln_critical]);
 
-        let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::Critical));
+        let result = VulnerabilityChecker::check(
+            vec![pkg],
+            ThresholdConfig::Severity(Severity::Critical),
+            &[],
+        );
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -278,7 +353,7 @@ mod tests {
         let pkg =
             create_package_vulnerabilities("test-pkg", vec![vuln_low, vuln_high, vuln_critical]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -294,7 +369,7 @@ mod tests {
         let pkg =
             create_package_vulnerabilities("test-pkg", vec![vuln_with_cvss, vuln_without_cvss]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -309,7 +384,7 @@ mod tests {
         let pkg = create_package_vulnerabilities("test-pkg", vec![vuln_low]);
 
         let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High));
+            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High), &[]);
 
         assert!(!result.threshold_exceeded);
         assert!(result.above_threshold.is_empty());
@@ -318,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_empty_input() {
-        let result = VulnerabilityChecker::check(vec![], ThresholdConfig::None);
+        let result = VulnerabilityChecker::check(vec![], ThresholdConfig::None, &[]);
 
         assert!(!result.threshold_exceeded);
         assert!(result.above_threshold.is_empty());
@@ -335,6 +410,7 @@ mod tests {
         let result = VulnerabilityChecker::check(
             vec![pkg1, pkg2],
             ThresholdConfig::Severity(Severity::High),
+            &[],
         );
 
         assert!(result.threshold_exceeded);
@@ -354,7 +430,7 @@ mod tests {
             vec![vuln_at_threshold, vuln_below_threshold],
         );
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold[0].vulnerabilities().len(), 1); // 7.0 is >= 7.0
@@ -683,5 +759,202 @@ mod tests {
         assert_eq!(sorted.len(), 2);
         assert_eq!(sorted[0].cve_id, "CVE-LOW");
         assert_eq!(sorted[1].cve_id, "CVE-NONE");
+    }
+
+    // Tests for CVE ignore filtering
+
+    #[test]
+    fn test_ignore_single_cve() {
+        let vuln1 = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let vuln2 = create_vulnerability("CVE-2024-002", Some(7.5), Severity::High);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln1, vuln2]);
+
+        let ignore = vec![IgnoreCve {
+            id: "CVE-2024-001".to_string(),
+            reason: Some("False positive".to_string()),
+        }];
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &ignore);
+
+        // Only CVE-2024-002 should remain
+        assert!(result.threshold_exceeded);
+        assert_eq!(result.above_threshold.len(), 1);
+        assert_eq!(result.above_threshold[0].vulnerabilities().len(), 1);
+        assert_eq!(
+            result.above_threshold[0].vulnerabilities()[0].id(),
+            "CVE-2024-002"
+        );
+    }
+
+    #[test]
+    fn test_ignore_multiple_cves() {
+        let vuln1 = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let vuln2 = create_vulnerability("CVE-2024-002", Some(7.5), Severity::High);
+        let vuln3 = create_vulnerability("CVE-2024-003", Some(3.0), Severity::Low);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln1, vuln2, vuln3]);
+
+        let ignore = vec![
+            IgnoreCve {
+                id: "CVE-2024-001".to_string(),
+                reason: None,
+            },
+            IgnoreCve {
+                id: "CVE-2024-002".to_string(),
+                reason: Some("Accepted risk".to_string()),
+            },
+        ];
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &ignore);
+
+        // Only CVE-2024-003 should remain
+        assert!(result.threshold_exceeded);
+        assert_eq!(result.above_threshold.len(), 1);
+        assert_eq!(result.above_threshold[0].vulnerabilities().len(), 1);
+        assert_eq!(
+            result.above_threshold[0].vulnerabilities()[0].id(),
+            "CVE-2024-003"
+        );
+    }
+
+    #[test]
+    fn test_ignore_cve_with_reason() {
+        let vuln = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln]);
+
+        let ignore = vec![IgnoreCve {
+            id: "CVE-2024-001".to_string(),
+            reason: Some("Code path not reachable".to_string()),
+        }];
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &ignore);
+
+        // All vulnerabilities ignored, threshold should NOT be exceeded
+        assert!(!result.threshold_exceeded);
+        assert!(result.above_threshold.is_empty());
+        assert!(result.below_threshold.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_cve_no_match() {
+        let vuln = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln]);
+
+        let ignore = vec![IgnoreCve {
+            id: "CVE-2024-999".to_string(),
+            reason: None,
+        }];
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &ignore);
+
+        // No CVE matched, so CVE-2024-001 should still be present
+        assert!(result.threshold_exceeded);
+        assert_eq!(result.above_threshold.len(), 1);
+        assert_eq!(result.above_threshold[0].vulnerabilities().len(), 1);
+    }
+
+    #[test]
+    fn test_ignore_cves_empty_list() {
+        let vuln = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln]);
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &[]);
+
+        // Empty ignore list should be a no-op
+        assert!(result.threshold_exceeded);
+        assert_eq!(result.above_threshold.len(), 1);
+    }
+
+    #[test]
+    fn test_ignore_all_cves_in_package_removes_package() {
+        let vuln1 = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let vuln2 = create_vulnerability("CVE-2024-002", Some(7.5), Severity::High);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln1, vuln2]);
+
+        let ignore = vec![
+            IgnoreCve {
+                id: "CVE-2024-001".to_string(),
+                reason: None,
+            },
+            IgnoreCve {
+                id: "CVE-2024-002".to_string(),
+                reason: None,
+            },
+        ];
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &ignore);
+
+        // All CVEs ignored → no packages in result
+        assert!(!result.threshold_exceeded);
+        assert!(result.above_threshold.is_empty());
+        assert!(result.below_threshold.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_cve_case_sensitive() {
+        let vuln = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln]);
+
+        // Lowercase should NOT match
+        let ignore = vec![IgnoreCve {
+            id: "cve-2024-001".to_string(),
+            reason: None,
+        }];
+
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &ignore);
+
+        // Case mismatch → no filtering applied
+        assert!(result.threshold_exceeded);
+        assert_eq!(result.above_threshold.len(), 1);
+    }
+
+    #[test]
+    fn test_ignore_cve_does_not_trigger_threshold() {
+        let vuln_critical = create_vulnerability("CVE-2024-001", Some(9.8), Severity::Critical);
+        let vuln_low = create_vulnerability("CVE-2024-002", Some(3.0), Severity::Low);
+        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln_critical, vuln_low]);
+
+        // Ignore the critical CVE
+        let ignore = vec![IgnoreCve {
+            id: "CVE-2024-001".to_string(),
+            reason: Some("False positive".to_string()),
+        }];
+
+        let result = VulnerabilityChecker::check(
+            vec![pkg],
+            ThresholdConfig::Severity(Severity::High),
+            &ignore,
+        );
+
+        // Only Low remains, which is below High threshold
+        assert!(!result.threshold_exceeded);
+        assert!(result.above_threshold.is_empty());
+        assert_eq!(result.below_threshold.len(), 1);
+    }
+
+    #[test]
+    fn test_ignore_cve_across_multiple_packages() {
+        let vuln1 = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let vuln2 = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
+        let vuln3 = create_vulnerability("CVE-2024-002", Some(7.5), Severity::High);
+        let pkg1 = create_package_vulnerabilities("pkg-1", vec![vuln1]);
+        let pkg2 = create_package_vulnerabilities("pkg-2", vec![vuln2, vuln3]);
+
+        let ignore = vec![IgnoreCve {
+            id: "CVE-2024-001".to_string(),
+            reason: None,
+        }];
+
+        let result = VulnerabilityChecker::check(vec![pkg1, pkg2], ThresholdConfig::None, &ignore);
+
+        // pkg-1 should be completely removed (only had CVE-2024-001)
+        // pkg-2 should remain with only CVE-2024-002
+        assert!(result.threshold_exceeded);
+        assert_eq!(result.above_threshold.len(), 1);
+        assert_eq!(result.above_threshold[0].package_name(), "pkg-2");
+        assert_eq!(result.above_threshold[0].vulnerabilities().len(), 1);
+        assert_eq!(
+            result.above_threshold[0].vulnerabilities()[0].id(),
+            "CVE-2024-002"
+        );
     }
 }

--- a/tests/e2e_vulnerability_threshold.rs
+++ b/tests/e2e_vulnerability_threshold.rs
@@ -205,7 +205,7 @@ mod threshold_evaluation_tests {
         let vuln_low = create_vulnerability("CVE-2024-001", Some(2.0), Severity::Low);
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_low]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None);
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::None, &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -215,7 +215,7 @@ mod threshold_evaluation_tests {
     #[test]
     fn test_no_threshold_no_vulnerabilities() {
         // With no vulnerabilities, threshold should not be exceeded
-        let result = VulnerabilityChecker::check(vec![], ThresholdConfig::None);
+        let result = VulnerabilityChecker::check(vec![], ThresholdConfig::None, &[]);
 
         assert!(!result.threshold_exceeded);
         assert!(result.above_threshold.is_empty());
@@ -231,7 +231,7 @@ mod threshold_evaluation_tests {
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_critical]);
 
         let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High));
+            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -245,7 +245,7 @@ mod threshold_evaluation_tests {
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_high]);
 
         let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High));
+            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -259,7 +259,7 @@ mod threshold_evaluation_tests {
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_low, vuln_medium]);
 
         let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High));
+            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::High), &[]);
 
         assert!(!result.threshold_exceeded);
         assert!(result.above_threshold.is_empty());
@@ -276,8 +276,11 @@ mod threshold_evaluation_tests {
         let pkg =
             create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_high, vuln_critical]);
 
-        let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::Critical));
+        let result = VulnerabilityChecker::check(
+            vec![pkg],
+            ThresholdConfig::Severity(Severity::Critical),
+            &[],
+        );
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -293,7 +296,7 @@ mod threshold_evaluation_tests {
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_low]);
 
         let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::Low));
+            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::Low), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -306,8 +309,11 @@ mod threshold_evaluation_tests {
         let vuln_medium = create_vulnerability("CVE-2024-002", Some(5.0), Severity::Medium);
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln_low, vuln_medium]);
 
-        let result =
-            VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Severity(Severity::Medium));
+        let result = VulnerabilityChecker::check(
+            vec![pkg],
+            ThresholdConfig::Severity(Severity::Medium),
+            &[],
+        );
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -324,7 +330,7 @@ mod threshold_evaluation_tests {
         let vuln = create_vulnerability("CVE-2024-001", Some(7.5), Severity::High);
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -336,7 +342,7 @@ mod threshold_evaluation_tests {
         let vuln = create_vulnerability("CVE-2024-001", Some(6.9), Severity::Medium);
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(!result.threshold_exceeded);
         assert!(result.above_threshold.is_empty());
@@ -349,7 +355,7 @@ mod threshold_evaluation_tests {
         let vuln = create_vulnerability("CVE-2024-001", Some(7.0), Severity::High);
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -367,7 +373,7 @@ mod threshold_evaluation_tests {
             vec![vuln_with_cvss, vuln_without_cvss],
         );
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         // Only the one with CVSS >= 7.0 should be above threshold
@@ -385,7 +391,7 @@ mod threshold_evaluation_tests {
         let vuln2 = create_vulnerability("CVE-2024-002", None, Severity::High);
         let pkg = create_package_vulnerabilities("test-pkg", "1.0.0", vec![vuln1, vuln2]);
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(!result.threshold_exceeded);
         assert!(result.above_threshold.is_empty());
@@ -405,7 +411,7 @@ mod threshold_evaluation_tests {
             vec![vuln_high, vuln_medium, vuln_low],
         );
 
-        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0));
+        let result = VulnerabilityChecker::check(vec![pkg], ThresholdConfig::Cvss(7.0), &[]);
 
         assert!(result.threshold_exceeded);
         assert_eq!(result.above_threshold.len(), 1);
@@ -429,6 +435,7 @@ mod threshold_evaluation_tests {
         let result = VulnerabilityChecker::check(
             vec![pkg1, pkg2],
             ThresholdConfig::Severity(Severity::High),
+            &[],
         );
 
         assert!(result.threshold_exceeded);
@@ -450,6 +457,7 @@ mod threshold_evaluation_tests {
         let result = VulnerabilityChecker::check(
             vec![pkg1, pkg2],
             ThresholdConfig::Severity(Severity::High),
+            &[],
         );
 
         assert!(!result.threshold_exceeded);


### PR DESCRIPTION
## Summary
- Add CVE ignore filter step to `VulnerabilityChecker` that removes matching CVE IDs before threshold evaluation
- Ignored CVEs are logged to stderr with reason (if provided) for transparency
- Thread `ignore_cves` from `SbomRequest` through the vulnerability checking pipeline

## Related Issue
Closes #188

## Changes Made
- `src/sbom_generation/domain/services/vulnerability_checker.rs`: Add `filter_ignored_cves()` method and update `check()` signature to accept `&[IgnoreCve]`
- `src/application/use_cases/generate_sbom/mod.rs`: Pass `request.ignore_cves` to `VulnerabilityChecker::check()`
- `src/config.rs`: Add `IgnoreCve::reason()` accessor method
- `src/application/dto/sbom_request.rs`: Remove `#[allow(dead_code)]` from `ignore_cves` field
- `tests/e2e_vulnerability_threshold.rs`: Update all `check()` calls with new signature

## Filter Pipeline
```
PackageVulnerabilities[]
  ↓
1. ignore_cves filter  ← NEW: remove ignored CVE IDs
  ↓
2. severity_threshold filter (existing)
  ↓
3. cvss_threshold filter (existing)
  ↓
VulnerabilityCheckResult
```

## Test Plan
- [x] `cargo test --all` passes (302 unit tests + 12 integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Unit tests added: ignore single CVE, ignore multiple CVEs, ignore with reason, no match, empty ignore list, case-sensitive matching, cross-package filtering, threshold interaction

---
Generated with [Claude Code](https://claude.com/claude-code)