### PR TITLE
fix(deps): replace vulnerable serde_yml with serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,16 +899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,18 +1455,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1838,6 +1826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,7 +1895,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -1909,12 +1903,6 @@ dependencies = [
  "urlencoding",
  "uuid",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.20", features = ["v4", "serde"] }
 urlencoding = "2.1"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 indicatif = "0.18"
 dashmap = "6"
 owo-colors = "4.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct ConfigFile {
     pub ignore_cves: Option<Vec<IgnoreCve>>,
     /// Captures unknown fields for warnings.
     #[serde(flatten)]
-    pub unknown_fields: HashMap<String, serde_yml::Value>,
+    pub unknown_fields: HashMap<String, serde_yaml_ng::Value>,
 }
 
 /// A CVE entry to ignore during vulnerability checks.
@@ -49,7 +49,7 @@ pub fn load_config_from_path(path: &Path) -> Result<ConfigFile> {
         )
     })?;
 
-    let config: ConfigFile = serde_yml::from_str(&content).with_context(|| {
+    let config: ConfigFile = serde_yaml_ng::from_str(&content).with_context(|| {
         format!(
             "Failed to parse config file: {}\n\n💡 Hint: Ensure the file contains valid YAML syntax.",
             path.display()


### PR DESCRIPTION
## Summary
- Replace `serde_yml` v0.0.12 with `serde_yaml_ng` v0.10 to resolve vulnerability GHSA-gfxp-f68g-8x78
- `serde_yml` depends on the unsound and unmaintained `libyml` v0.0.5; `serde_yaml_ng` uses `unsafe-libyaml` instead
- API-compatible drop-in replacement — only 2 lines changed in `src/config.rs`

## Related Issue
Resolves [GHSA-gfxp-f68g-8x78](https://github.com/advisories/GHSA-gfxp-f68g-8x78) — `libyml::string::yaml_string_extend` is unsound and unmaintained

## Changes Made
- `Cargo.toml`: Replace `serde_yml = "0.0.12"` with `serde_yaml_ng = "0.10"`
- `Cargo.lock`: Updated lockfile (removes `libyml` v0.0.5 and `serde_yml` v0.0.12, adds `serde_yaml_ng` v0.10 and `unsafe-libyaml` v0.2.11)
- `src/config.rs`: Update `serde_yml::Value` → `serde_yaml_ng::Value` and `serde_yml::from_str` → `serde_yaml_ng::from_str`

## Test Plan
- [x] `cargo test --all` passes (302 unit tests + 12 integration tests + 5 doc-tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Verified `libyml` is no longer in the dependency tree via `cargo tree`

---
Generated with [Claude Code](https://claude.com/claude-code)