### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-02-06
+
+### Added
+
+#### Config File Support
+- **`--config` option**: Load settings from YAML configuration file
+- **`--ignore-cve` option**: Ignore specific CVEs from vulnerability checks
+- **`--init` option**: Generate config file template for quick setup
+- **`--verify-links` flag**: Validate that PyPI package URLs actually exist
+
+#### Output Enhancements
+- **PyPI hyperlinks**: Package names link directly to PyPI in Markdown output
+- **CVE hyperlinks**: Vulnerability IDs link to OSV/GHSA/CVE sources
+
+#### Developer Experience
+- **`/dependabot` skill**: Standardized workflow for handling Dependabot security alerts
+- **`/release` skill**: Standardized release preparation workflow
+- **`AGENTS.md`**: Codebase context documentation for AI-assisted development
+
+### Fixed
+- **Dependency classification**: Preserve dependency classification when root project is excluded (#213)
+- **Vulnerable dependency**: Replace vulnerable `serde_yml` with `serde_yaml_ng` (#199)
+
+### Changed
+
+#### Architecture Improvements
+- **`SbomReadModel` and `SbomReadModelBuilder`**: Cleaner formatting pipeline
+- **`format_v2` method**: Replacing legacy format methods
+- **`thiserror` crate**: Better error handling with derive macros
+- **Semantic methods**: Added semantic methods in `VulnerabilityCheckResult`
+
+#### Documentation
+- README updates for config file, CVE ignore, and `--verify-links` features
+- Japanese README kept in sync with English README
+
+### Dependencies
+- `bytes`: 1.11.0 → 1.11.1
+- `thiserror`: 1.0.69 → 2.0.17
+- `serde_yml` replaced with `serde_yaml_ng` (security fix)
+- Other dependency group updates
+
 ## [1.0.0] - 2025-01-24
 
 ### 🎉 First Stable Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "1.0.0"
+UV_SBOM_VERSION = "1.1.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v1.1.0
- Update version numbers in all required files
- Update CHANGELOG with release date

Closes #215

## Version Files Updated
- `Cargo.toml`: version = "1.1.0"
- `python-wrapper/pyproject.toml`: version = "1.1.0"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "1.1.0"

## CHANGELOG
- Converted [Unreleased] to [1.1.0] - 2026-02-06
- Added empty [Unreleased] section

## Changes in v1.1.0

### New Features
- Config file support (`--config`, `--ignore-cve`, `--init` options)
- `--verify-links` flag for PyPI URL validation
- PyPI hyperlinks in Markdown output
- CVE hyperlinks to OSV/GHSA/CVE sources
- `/dependabot` and `/release` skills

### Bug Fixes
- Preserve dependency classification when root project is excluded (#213)
- Replace vulnerable `serde_yml` with `serde_yaml_ng` (#199)

### Refactoring
- `SbomReadModel` and `SbomReadModelBuilder` for cleaner formatting pipeline
- `thiserror` crate for better error handling

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (308+ tests)
- [x] All version strings are consistent across 3 files

## Post-Merge Manual Steps
After merging this PR:
1. Create tag: `git tag v1.1.0`
2. Push tag: `git push origin v1.1.0`
3. Verify CI release workflow completes successfully

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)