### PR TITLE
feat(adapters): render resolution guide in Markdown and CycloneDX formatters

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter.rs
@@ -1,6 +1,6 @@
 use crate::application::read_models::{
-    ComponentView, DependencyView, LicenseComplianceView, LicenseView, SbomMetadataView,
-    SbomReadModel, VulnerabilityReportView, VulnerabilityView,
+    ComponentView, DependencyView, LicenseComplianceView, LicenseView, ResolutionGuideView,
+    SbomMetadataView, SbomReadModel, VulnerabilityReportView, VulnerabilityView,
 };
 use crate::ports::outbound::SbomFormatter;
 use crate::shared::Result;
@@ -51,6 +51,8 @@ struct Vulnerability {
     #[serde(skip_serializing_if = "Option::is_none")]
     ratings: Option<Vec<Rating>>,
     affects: Vec<Affect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<Vec<Property>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -149,7 +151,7 @@ impl SbomFormatter for CycloneDxFormatter {
             vulnerabilities: model
                 .vulnerabilities
                 .as_ref()
-                .map(|v| self.build_vulnerabilities(v)),
+                .map(|v| self.build_vulnerabilities(v, model.resolution_guide.as_ref())),
             properties,
         };
 
@@ -228,24 +230,32 @@ impl CycloneDxFormatter {
     }
 
     /// Build vulnerabilities from VulnerabilityReportView
-    fn build_vulnerabilities(&self, report: &VulnerabilityReportView) -> Vec<Vulnerability> {
+    fn build_vulnerabilities(
+        &self,
+        report: &VulnerabilityReportView,
+        resolution_guide: Option<&ResolutionGuideView>,
+    ) -> Vec<Vulnerability> {
         let mut vulnerabilities = Vec::new();
 
         // Process actionable vulnerabilities
         for vuln in &report.actionable {
-            vulnerabilities.push(self.build_vulnerability(vuln));
+            vulnerabilities.push(self.build_vulnerability(vuln, resolution_guide));
         }
 
         // Process informational vulnerabilities
         for vuln in &report.informational {
-            vulnerabilities.push(self.build_vulnerability(vuln));
+            vulnerabilities.push(self.build_vulnerability(vuln, resolution_guide));
         }
 
         vulnerabilities
     }
 
     /// Build a single vulnerability from VulnerabilityView
-    fn build_vulnerability(&self, vuln: &VulnerabilityView) -> Vulnerability {
+    fn build_vulnerability(
+        &self,
+        vuln: &VulnerabilityView,
+        resolution_guide: Option<&ResolutionGuideView>,
+    ) -> Vulnerability {
         let source = vuln
             .source_url
             .as_ref()
@@ -257,6 +267,22 @@ impl CycloneDxFormatter {
             vector: vuln.cvss_vector.clone(),
         }]);
 
+        let properties = resolution_guide.and_then(|guide| {
+            let entry = guide.entries.iter().find(|e| {
+                e.vulnerability_id == vuln.id
+                    && e.vulnerable_package == vuln.affected_component_name
+            });
+            entry.map(|e| {
+                e.introduced_by
+                    .iter()
+                    .map(|ib| Property {
+                        name: "uv-sbom:introduced-by".to_string(),
+                        value: format!("{}@{}", ib.package_name, ib.version),
+                    })
+                    .collect::<Vec<_>>()
+            })
+        });
+
         Vulnerability {
             bom_ref: vuln.bom_ref.clone(),
             id: vuln.id.clone(),
@@ -266,6 +292,7 @@ impl CycloneDxFormatter {
             affects: vec![Affect {
                 bom_ref: vuln.affected_component.clone(),
             }],
+            properties,
         }
     }
 
@@ -449,5 +476,153 @@ mod tests {
         assert!(json.contains("\"licenses\""));
         assert!(json.contains("Apache-2.0"));
         assert!(json.contains("Apache License 2.0"));
+    }
+
+    // ============================================================
+    // Resolution guide property tests
+    // ============================================================
+
+    #[test]
+    fn test_format_with_resolution_guide_properties() {
+        use crate::application::read_models::{
+            IntroducedByView, ResolutionEntryView, ResolutionGuideView,
+        };
+
+        let mut model = create_test_read_model();
+        model.vulnerabilities = Some(VulnerabilityReportView {
+            actionable: vec![VulnerabilityView {
+                bom_ref: "vuln-001".to_string(),
+                id: "CVE-2024-1234".to_string(),
+                affected_component: "pkg:pypi/requests@2.31.0".to_string(),
+                affected_component_name: "requests".to_string(),
+                affected_version: "2.31.0".to_string(),
+                cvss_score: Some(7.5),
+                cvss_vector: None,
+                severity: SeverityView::High,
+                fixed_version: Some("2.32.0".to_string()),
+                description: None,
+                source_url: None,
+            }],
+            informational: vec![],
+            threshold_exceeded: false,
+            summary: VulnerabilitySummary {
+                total_count: 1,
+                actionable_count: 1,
+                informational_count: 0,
+                affected_package_count: 1,
+            },
+        });
+
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "requests".to_string(),
+                current_version: "2.31.0".to_string(),
+                fixed_version: Some("2.32.0".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-1234".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "my-app".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+            }],
+        });
+
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        assert!(json.contains("\"uv-sbom:introduced-by\""));
+        assert!(json.contains("my-app@1.0.0"));
+    }
+
+    #[test]
+    fn test_format_with_resolution_guide_multiple_introduced_by() {
+        use crate::application::read_models::{
+            IntroducedByView, ResolutionEntryView, ResolutionGuideView,
+        };
+
+        let mut model = create_test_read_model();
+        model.vulnerabilities = Some(VulnerabilityReportView {
+            actionable: vec![VulnerabilityView {
+                bom_ref: "vuln-001".to_string(),
+                id: "CVE-2024-1234".to_string(),
+                affected_component: "pkg:pypi/requests@2.31.0".to_string(),
+                affected_component_name: "requests".to_string(),
+                affected_version: "2.31.0".to_string(),
+                cvss_score: Some(7.5),
+                cvss_vector: None,
+                severity: SeverityView::High,
+                fixed_version: Some("2.32.0".to_string()),
+                description: None,
+                source_url: None,
+            }],
+            informational: vec![],
+            threshold_exceeded: false,
+            summary: VulnerabilitySummary {
+                total_count: 1,
+                actionable_count: 1,
+                informational_count: 0,
+                affected_package_count: 1,
+            },
+        });
+
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "requests".to_string(),
+                current_version: "2.31.0".to_string(),
+                fixed_version: Some("2.32.0".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-1234".to_string(),
+                introduced_by: vec![
+                    IntroducedByView {
+                        package_name: "my-app".to_string(),
+                        version: "1.0.0".to_string(),
+                    },
+                    IntroducedByView {
+                        package_name: "other-app".to_string(),
+                        version: "2.0.0".to_string(),
+                    },
+                ],
+            }],
+        });
+
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        assert!(json.contains("my-app@1.0.0"));
+        assert!(json.contains("other-app@2.0.0"));
+    }
+
+    #[test]
+    fn test_format_vulnerability_no_resolution_guide() {
+        let mut model = create_test_read_model();
+        model.vulnerabilities = Some(VulnerabilityReportView {
+            actionable: vec![VulnerabilityView {
+                bom_ref: "vuln-001".to_string(),
+                id: "CVE-2024-1234".to_string(),
+                affected_component: "pkg:pypi/requests@2.31.0".to_string(),
+                affected_component_name: "requests".to_string(),
+                affected_version: "2.31.0".to_string(),
+                cvss_score: Some(7.5),
+                cvss_vector: None,
+                severity: SeverityView::High,
+                fixed_version: Some("2.32.0".to_string()),
+                description: None,
+                source_url: None,
+            }],
+            informational: vec![],
+            threshold_exceeded: false,
+            summary: VulnerabilitySummary {
+                total_count: 1,
+                actionable_count: 1,
+                informational_count: 0,
+                affected_package_count: 1,
+            },
+        });
+
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        // No properties field when no resolution guide
+        assert!(!json.contains("\"uv-sbom:introduced-by\""));
     }
 }

--- a/src/adapters/outbound/formatters/markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter.rs
@@ -1,6 +1,6 @@
 use crate::application::read_models::{
-    ComponentView, DependencyView, LicenseComplianceView, SbomReadModel, VulnerabilityReportView,
-    VulnerabilitySummary, VulnerabilityView,
+    ComponentView, DependencyView, LicenseComplianceView, ResolutionGuideView, SbomReadModel,
+    VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
 };
 use crate::ports::outbound::SbomFormatter;
 use crate::shared::Result;
@@ -410,6 +410,48 @@ impl MarkdownFormatter {
         }
     }
 
+    /// Renders the resolution guide section
+    fn render_resolution_guide(&self, output: &mut String, guide: &ResolutionGuideView) {
+        output.push_str("\n## Vulnerability Resolution Guide\n\n");
+        output.push_str("The following transitive dependencies have known vulnerabilities. ");
+        output.push_str(
+            "The table shows which direct dependency introduces each vulnerable package.\n\n",
+        );
+
+        output.push_str("| Vulnerable Package | Current | Fixed Version | Severity | Introduced By (Direct Dep) | Vulnerability ID |\n");
+        output.push_str("|--------------------|---------|--------------|---------|--------------------------|-----------------|\n");
+
+        for entry in &guide.entries {
+            let fixed = entry.fixed_version.as_deref().unwrap_or("N/A");
+            let severity_emoji = match entry.severity {
+                crate::application::read_models::SeverityView::Critical => "🔴",
+                crate::application::read_models::SeverityView::High => "🟠",
+                crate::application::read_models::SeverityView::Medium => "🟡",
+                crate::application::read_models::SeverityView::Low => "🟢",
+                crate::application::read_models::SeverityView::None => "⚪",
+            };
+
+            let introduced_by = entry
+                .introduced_by
+                .iter()
+                .map(|ib| format!("{} ({})", ib.package_name, ib.version))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            output.push_str(&format!(
+                "| {} | {} | {} | {} {} | {} | {} |\n",
+                Self::escape_markdown_table_cell(&entry.vulnerable_package),
+                Self::escape_markdown_table_cell(&entry.current_version),
+                Self::escape_markdown_table_cell(fixed),
+                severity_emoji,
+                entry.severity.as_str(),
+                Self::escape_markdown_table_cell(&introduced_by),
+                Self::vulnerability_id_to_link(&entry.vulnerability_id),
+            ));
+        }
+        output.push('\n');
+    }
+
     /// Renders a single vulnerability row
     fn render_vulnerability_row(&self, output: &mut String, vuln: &VulnerabilityView) {
         let cvss_display = vuln
@@ -461,6 +503,13 @@ impl SbomFormatter for MarkdownFormatter {
         // Vulnerabilities section (if present)
         if let Some(vulns) = &model.vulnerabilities {
             self.render_vulnerabilities(&mut output, vulns);
+        }
+
+        // Resolution guide section (if present)
+        if let Some(guide) = &model.resolution_guide {
+            if !guide.entries.is_empty() {
+                self.render_resolution_guide(&mut output, guide);
+            }
         }
 
         // License compliance section (if present)
@@ -1200,5 +1249,128 @@ mod tests {
         let formatter = MarkdownFormatter::with_verified_packages(verified);
         let result = formatter.format_package_name("nonexistent-pkg");
         assert_eq!(result, "nonexistent-pkg");
+    }
+
+    // ============================================================
+    // Resolution guide tests
+    // ============================================================
+
+    #[test]
+    fn test_render_resolution_guide_with_entries() {
+        use crate::application::read_models::{
+            IntroducedByView, ResolutionEntryView, ResolutionGuideView,
+        };
+
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: Some(">= 2.0.7".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-XXXXX".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+            }],
+        });
+
+        let formatter = MarkdownFormatter::new();
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("## Vulnerability Resolution Guide"));
+        assert!(markdown.contains("urllib3"));
+        assert!(markdown.contains("1.26.15"));
+        assert!(markdown.contains(">= 2.0.7"));
+        assert!(markdown.contains("🟠 HIGH"));
+        assert!(markdown.contains("requests (2.31.0)"));
+        assert!(
+            markdown.contains("[CVE-2024-XXXXX](https://nvd.nist.gov/vuln/detail/CVE-2024-XXXXX)")
+        );
+    }
+
+    #[test]
+    fn test_render_resolution_guide_multiple_introduced_by() {
+        use crate::application::read_models::{
+            IntroducedByView, ResolutionEntryView, ResolutionGuideView,
+        };
+
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "certifi".to_string(),
+                current_version: "2023.7.22".to_string(),
+                fixed_version: Some(">= 2024.2.2".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-YYYYY".to_string(),
+                introduced_by: vec![
+                    IntroducedByView {
+                        package_name: "requests".to_string(),
+                        version: "2.31.0".to_string(),
+                    },
+                    IntroducedByView {
+                        package_name: "httpx".to_string(),
+                        version: "0.25.0".to_string(),
+                    },
+                ],
+            }],
+        });
+
+        let formatter = MarkdownFormatter::new();
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("requests (2.31.0), httpx (0.25.0)"));
+    }
+
+    #[test]
+    fn test_resolution_guide_omitted_when_empty() {
+        use crate::application::read_models::ResolutionGuideView;
+
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView { entries: vec![] });
+
+        let formatter = MarkdownFormatter::new();
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(!markdown.contains("## Vulnerability Resolution Guide"));
+    }
+
+    #[test]
+    fn test_resolution_guide_omitted_when_none() {
+        let model = create_test_read_model();
+        let formatter = MarkdownFormatter::new();
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(!markdown.contains("## Vulnerability Resolution Guide"));
+    }
+
+    #[test]
+    fn test_resolution_guide_ghsa_link() {
+        use crate::application::read_models::{
+            IntroducedByView, ResolutionEntryView, ResolutionGuideView,
+        };
+
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: None,
+                severity: SeverityView::Medium,
+                vulnerability_id: "GHSA-abcd-efgh-ijkl".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+            }],
+        });
+
+        let formatter = MarkdownFormatter::new();
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown
+            .contains("[GHSA-abcd-efgh-ijkl](https://github.com/advisories/GHSA-abcd-efgh-ijkl)"));
+        assert!(markdown.contains("N/A")); // fixed_version is None
     }
 }


### PR DESCRIPTION
## Summary
- Add "Vulnerability Resolution Guide" section to Markdown formatter showing which direct dependencies introduce vulnerable transitive packages
- Add `uv-sbom:introduced-by` properties to CycloneDX vulnerability entries with resolution guide data
- Include comprehensive tests for both formatters

## Related Issue
Closes #232

## Changes Made
- **markdown_formatter.rs**: Added `render_resolution_guide()` method with table rendering (vulnerable package, current/fixed version, severity, introduced-by, vulnerability ID with hyperlinks). Section is omitted when no resolution data exists.
- **cyclonedx_formatter.rs**: Added `properties` field to `Vulnerability` struct. Updated `build_vulnerability()` to populate `uv-sbom:introduced-by` property entries from resolution guide data. Multiple direct deps are represented as separate property entries.
- Added 5 tests for Markdown formatter (entries rendering, multiple introduced-by, empty entries, none guide, GHSA link)
- Added 3 tests for CycloneDX formatter (properties, multiple introduced-by, no resolution guide)

## Test Plan
- [x] `cargo test --all` passes (364 unit + 5 doc tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)