### PR TITLE
feat(cyclonedx): add component group field and SPDX license ID mapping

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter.rs
@@ -91,6 +91,9 @@ struct Tool {
 struct Component {
     #[serde(rename = "type")]
     component_type: String,
+    #[serde(rename = "bom-ref")]
+    bom_ref: String,
+    group: String,
     name: String,
     version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -179,6 +182,8 @@ impl CycloneDxFormatter {
                 let licenses = c.license.as_ref().map(|l| self.build_license(l));
                 Component {
                     component_type: "library".to_string(),
+                    bom_ref: c.bom_ref.clone(),
+                    group: "pypi".to_string(),
                     name: c.name.clone(),
                     version: c.version.clone(),
                     description: c.description.clone(),
@@ -190,11 +195,21 @@ impl CycloneDxFormatter {
     }
 
     /// Build license from LicenseView
+    ///
+    /// When a SPDX license ID is available, outputs `id` only (CycloneDX spec preference).
+    /// Falls back to `name` when no SPDX mapping exists.
     fn build_license(&self, license: &LicenseView) -> Vec<License> {
         vec![License {
-            license: LicenseContent {
-                id: license.spdx_id.clone(),
-                name: Some(license.name.clone()),
+            license: if license.spdx_id.is_some() {
+                LicenseContent {
+                    id: license.spdx_id.clone(),
+                    name: None,
+                }
+            } else {
+                LicenseContent {
+                    id: None,
+                    name: Some(license.name.clone()),
+                }
             },
         }]
     }
@@ -465,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_with_license() {
+    fn test_format_with_license_spdx_id() {
         let model = create_test_read_model();
         let formatter = CycloneDxFormatter::new();
 
@@ -474,8 +489,51 @@ mod tests {
         assert!(result.is_ok());
         let json = result.unwrap();
         assert!(json.contains("\"licenses\""));
-        assert!(json.contains("Apache-2.0"));
-        assert!(json.contains("Apache License 2.0"));
+        // When SPDX ID is present, only id is output (no name)
+        assert!(json.contains("\"id\": \"Apache-2.0\""));
+        assert!(!json.contains("\"name\": \"Apache License 2.0\""));
+    }
+
+    #[test]
+    fn test_format_with_license_fallback_to_name() {
+        let mut model = create_test_read_model();
+        model.components[0].license = Some(LicenseView {
+            spdx_id: None,
+            name: "Some Proprietary License".to_string(),
+            url: None,
+        });
+        let formatter = CycloneDxFormatter::new();
+
+        let result = formatter.format(&model);
+
+        assert!(result.is_ok());
+        let json = result.unwrap();
+        assert!(json.contains("\"name\": \"Some Proprietary License\""));
+        assert!(!json.contains("\"id\""));
+    }
+
+    #[test]
+    fn test_format_with_group_field() {
+        let model = create_test_read_model();
+        let formatter = CycloneDxFormatter::new();
+
+        let result = formatter.format(&model);
+
+        assert!(result.is_ok());
+        let json = result.unwrap();
+        assert!(json.contains("\"group\": \"pypi\""));
+    }
+
+    #[test]
+    fn test_format_with_bom_ref_field() {
+        let model = create_test_read_model();
+        let formatter = CycloneDxFormatter::new();
+
+        let result = formatter.format(&model);
+
+        assert!(result.is_ok());
+        let json = result.unwrap();
+        assert!(json.contains("\"bom-ref\": \"pkg:pypi/requests@2.31.0\""));
     }
 
     // ============================================================

--- a/src/application/read_models/sbom_read_model_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder.rs
@@ -21,6 +21,7 @@ use crate::sbom_generation::domain::vulnerability::{
     PackageVulnerabilities, Severity, Vulnerability,
 };
 use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata};
+use crate::sbom_generation::policies::spdx_license_map;
 use std::collections::{HashMap, HashSet};
 
 /// Builder for constructing SbomReadModel from domain objects
@@ -121,10 +122,13 @@ impl SbomReadModelBuilder {
                     })
                     .unwrap_or(false);
 
-                let license = enriched.license.as_ref().map(|license_str| LicenseView {
-                    spdx_id: Some(license_str.clone()),
-                    name: license_str.clone(),
-                    url: None,
+                let license = enriched.license.as_ref().map(|license_str| {
+                    let spdx_id = spdx_license_map::get_spdx_id(license_str);
+                    LicenseView {
+                        spdx_id,
+                        name: license_str.clone(),
+                        url: None,
+                    }
                 });
 
                 ComponentView {

--- a/src/sbom_generation/policies/mod.rs
+++ b/src/sbom_generation/policies/mod.rs
@@ -1,3 +1,4 @@
 mod license_priority;
+pub mod spdx_license_map;
 
 pub use license_priority::LicensePriority;

--- a/src/sbom_generation/policies/spdx_license_map.rs
+++ b/src/sbom_generation/policies/spdx_license_map.rs
@@ -1,0 +1,213 @@
+//! SPDX License ID mapping for common Python package licenses
+//!
+//! Maps license name strings (as reported by PyPI) to their corresponding
+//! SPDX license identifiers. Uses case-insensitive matching.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Lookup table mapping normalized license names to SPDX identifiers.
+static LICENSE_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    let entries: Vec<(&str, &str)> = vec![
+        // MIT variants
+        ("mit license", "MIT"),
+        ("mit", "MIT"),
+        ("the mit license", "MIT"),
+        ("the mit license (mit)", "MIT"),
+        // Apache variants
+        ("apache software license", "Apache-2.0"),
+        ("apache license 2.0", "Apache-2.0"),
+        ("apache license, version 2.0", "Apache-2.0"),
+        ("apache 2.0", "Apache-2.0"),
+        ("apache-2.0", "Apache-2.0"),
+        ("apache 2", "Apache-2.0"),
+        // BSD variants
+        ("bsd license", "BSD-3-Clause"),
+        ("bsd", "BSD-3-Clause"),
+        ("bsd 3-clause license", "BSD-3-Clause"),
+        ("bsd-3-clause", "BSD-3-Clause"),
+        ("new bsd license", "BSD-3-Clause"),
+        ("modified bsd license", "BSD-3-Clause"),
+        ("3-clause bsd license", "BSD-3-Clause"),
+        ("bsd 2-clause license", "BSD-2-Clause"),
+        ("bsd-2-clause", "BSD-2-Clause"),
+        ("simplified bsd license", "BSD-2-Clause"),
+        ("bsd 2-clause \"simplified\" license", "BSD-2-Clause"),
+        // GPL variants
+        ("gnu general public license v3 (gplv3)", "GPL-3.0-only"),
+        ("gpl-3.0", "GPL-3.0-only"),
+        ("gpl-3.0-only", "GPL-3.0-only"),
+        ("gplv3", "GPL-3.0-only"),
+        (
+            "gnu general public license v3 or later (gplv3+)",
+            "GPL-3.0-or-later",
+        ),
+        ("gpl-3.0+", "GPL-3.0-or-later"),
+        ("gpl-3.0-or-later", "GPL-3.0-or-later"),
+        ("gnu general public license v2 (gplv2)", "GPL-2.0-only"),
+        ("gpl-2.0", "GPL-2.0-only"),
+        ("gpl-2.0-only", "GPL-2.0-only"),
+        ("gplv2", "GPL-2.0-only"),
+        (
+            "gnu general public license v2 or later (gplv2+)",
+            "GPL-2.0-or-later",
+        ),
+        ("gpl-2.0+", "GPL-2.0-or-later"),
+        ("gpl-2.0-or-later", "GPL-2.0-or-later"),
+        // LGPL variants
+        (
+            "gnu lesser general public license v3 (lgplv3)",
+            "LGPL-3.0-only",
+        ),
+        ("lgpl-3.0", "LGPL-3.0-only"),
+        ("lgpl-3.0-only", "LGPL-3.0-only"),
+        ("lgplv3", "LGPL-3.0-only"),
+        (
+            "gnu lesser general public license v2 (lgplv2)",
+            "LGPL-2.1-only",
+        ),
+        ("lgpl-2.1", "LGPL-2.1-only"),
+        ("lgpl-2.1-only", "LGPL-2.1-only"),
+        (
+            "gnu lesser general public license v2 or later (lgplv2+)",
+            "LGPL-2.1-or-later",
+        ),
+        // MPL
+        ("mozilla public license 2.0", "MPL-2.0"),
+        ("mozilla public license 2.0 (mpl 2.0)", "MPL-2.0"),
+        ("mpl-2.0", "MPL-2.0"),
+        ("mpl 2.0", "MPL-2.0"),
+        // ISC
+        ("isc license", "ISC"),
+        ("isc license (iscl)", "ISC"),
+        ("isc", "ISC"),
+        // PSF / Python
+        ("python software foundation license", "PSF-2.0"),
+        ("psf license", "PSF-2.0"),
+        ("psf-2.0", "PSF-2.0"),
+        // Unlicense
+        ("the unlicense", "Unlicense"),
+        ("the unlicense (unlicense)", "Unlicense"),
+        ("unlicense", "Unlicense"),
+        // CC0
+        ("cc0 1.0 universal", "CC0-1.0"),
+        ("cc0-1.0", "CC0-1.0"),
+        (
+            "cc0 1.0 universal (cc0 1.0) public domain dedication",
+            "CC0-1.0",
+        ),
+        // Zlib
+        ("zlib license", "Zlib"),
+        ("zlib", "Zlib"),
+        // Eclipse
+        ("eclipse public license 2.0", "EPL-2.0"),
+        ("epl-2.0", "EPL-2.0"),
+        // WTFPL
+        ("do what the f*ck you want to public license", "WTFPL"),
+        ("wtfpl", "WTFPL"),
+        // Artistic
+        ("artistic license 2.0", "Artistic-2.0"),
+        ("artistic-2.0", "Artistic-2.0"),
+    ];
+
+    entries.into_iter().collect()
+});
+
+/// Attempts to resolve a license name to its SPDX identifier.
+///
+/// Performs case-insensitive matching with leading/trailing whitespace trimmed.
+/// Returns `None` if no mapping is found.
+pub fn get_spdx_id(license_name: &str) -> Option<String> {
+    let normalized = license_name.trim().to_lowercase();
+    LICENSE_MAP
+        .get(normalized.as_str())
+        .map(|id| id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mit_license_variants() {
+        assert_eq!(get_spdx_id("MIT License"), Some("MIT".to_string()));
+        assert_eq!(get_spdx_id("MIT"), Some("MIT".to_string()));
+        assert_eq!(get_spdx_id("mit license"), Some("MIT".to_string()));
+        assert_eq!(get_spdx_id("The MIT License"), Some("MIT".to_string()));
+    }
+
+    #[test]
+    fn test_apache_license_variants() {
+        assert_eq!(
+            get_spdx_id("Apache Software License"),
+            Some("Apache-2.0".to_string())
+        );
+        assert_eq!(
+            get_spdx_id("Apache License 2.0"),
+            Some("Apache-2.0".to_string())
+        );
+        assert_eq!(get_spdx_id("Apache-2.0"), Some("Apache-2.0".to_string()));
+        assert_eq!(get_spdx_id("apache 2.0"), Some("Apache-2.0".to_string()));
+    }
+
+    #[test]
+    fn test_bsd_license_variants() {
+        assert_eq!(get_spdx_id("BSD License"), Some("BSD-3-Clause".to_string()));
+        assert_eq!(
+            get_spdx_id("BSD-3-Clause"),
+            Some("BSD-3-Clause".to_string())
+        );
+        assert_eq!(
+            get_spdx_id("BSD 2-Clause License"),
+            Some("BSD-2-Clause".to_string())
+        );
+    }
+
+    #[test]
+    fn test_gpl_license_variants() {
+        assert_eq!(
+            get_spdx_id("GNU General Public License v3 (GPLv3)"),
+            Some("GPL-3.0-only".to_string())
+        );
+        assert_eq!(get_spdx_id("GPL-3.0"), Some("GPL-3.0-only".to_string()));
+        assert_eq!(get_spdx_id("GPLv2"), Some("GPL-2.0-only".to_string()));
+    }
+
+    #[test]
+    fn test_case_insensitive_matching() {
+        assert_eq!(get_spdx_id("MIT LICENSE"), Some("MIT".to_string()));
+        assert_eq!(get_spdx_id("mit"), Some("MIT".to_string()));
+        assert_eq!(get_spdx_id("Mit License"), Some("MIT".to_string()));
+        assert_eq!(
+            get_spdx_id("APACHE SOFTWARE LICENSE"),
+            Some("Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_whitespace_trimming() {
+        assert_eq!(get_spdx_id("  MIT License  "), Some("MIT".to_string()));
+        assert_eq!(get_spdx_id("\tMIT\n"), Some("MIT".to_string()));
+    }
+
+    #[test]
+    fn test_unknown_license_returns_none() {
+        assert_eq!(get_spdx_id("Some Proprietary License"), None);
+        assert_eq!(get_spdx_id("Custom License v1.0"), None);
+        assert_eq!(get_spdx_id(""), None);
+    }
+
+    #[test]
+    fn test_other_licenses() {
+        assert_eq!(get_spdx_id("ISC License"), Some("ISC".to_string()));
+        assert_eq!(
+            get_spdx_id("Mozilla Public License 2.0"),
+            Some("MPL-2.0".to_string())
+        );
+        assert_eq!(get_spdx_id("The Unlicense"), Some("Unlicense".to_string()));
+        assert_eq!(
+            get_spdx_id("CC0 1.0 Universal"),
+            Some("CC0-1.0".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `group` ("pypi") and `bom-ref` fields to CycloneDX Component struct for CycloneDX 1.6 compliance
- Create SPDX license name-to-ID mapping module with case-insensitive lookup covering common Python licenses
- Update license serialization to prefer SPDX `id` over `name`, with fallback for unknown licenses

## Related Issue
Closes #219

## Changes Made
- **`cyclonedx_formatter.rs`**: Added `group` and `bom-ref` fields to `Component` struct; updated `build_license()` to output only `id` when SPDX mapping exists, falling back to `name` otherwise
- **`spdx_license_map.rs`** (new): License name → SPDX ID mapping table with ~50 entries covering MIT, Apache, BSD, GPL, LGPL, MPL, ISC, PSF, Unlicense, CC0, Zlib, EPL, WTFPL, and Artistic licenses
- **`policies/mod.rs`**: Registered new `spdx_license_map` module
- **`sbom_read_model_builder.rs`**: Integrated SPDX lookup into `build_components()` replacing direct license string assignment

## Test Plan
- [x] `cargo test --all` passes (all existing + new tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New tests: SPDX mapping variants, case-insensitive matching, whitespace trimming, unknown license fallback
- [x] New tests: `group` field presence, `bom-ref` field presence, license id-only and name-fallback output

---
Generated with [Claude Code](https://claude.com/claude-code)