### PR TITLE
feat(cyclonedx): add package hashes from PyPI and metadata.component

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter.rs
@@ -79,6 +79,18 @@ struct Affect {
 struct Metadata {
     timestamp: String,
     tools: Vec<Tool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    component: Option<MetadataComponent>,
+}
+
+#[derive(Debug, Serialize)]
+struct MetadataComponent {
+    #[serde(rename = "type")]
+    component_type: String,
+    #[serde(rename = "bom-ref")]
+    bom_ref: String,
+    name: String,
+    version: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -99,8 +111,16 @@ struct Component {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    hashes: Option<Vec<Hash>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     licenses: Option<Vec<License>>,
     purl: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Hash {
+    alg: String,
+    content: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -165,12 +185,20 @@ impl SbomFormatter for CycloneDxFormatter {
 impl CycloneDxFormatter {
     /// Build metadata from SbomMetadataView
     fn build_metadata(&self, metadata: &SbomMetadataView) -> Metadata {
+        let component = metadata.component.as_ref().map(|c| MetadataComponent {
+            component_type: "application".to_string(),
+            bom_ref: format!("{}-{}", c.name, c.version),
+            name: c.name.clone(),
+            version: c.version.clone(),
+        });
+
         Metadata {
             timestamp: metadata.timestamp.clone(),
             tools: vec![Tool {
                 name: metadata.tool_name.clone(),
                 version: metadata.tool_version.clone(),
             }],
+            component,
         }
     }
 
@@ -180,6 +208,12 @@ impl CycloneDxFormatter {
             .iter()
             .map(|c| {
                 let licenses = c.license.as_ref().map(|l| self.build_license(l));
+                let hashes = c.sha256_hash.as_ref().map(|hash| {
+                    vec![Hash {
+                        alg: "SHA-256".to_string(),
+                        content: hash.clone(),
+                    }]
+                });
                 Component {
                     component_type: "library".to_string(),
                     bom_ref: c.bom_ref.clone(),
@@ -187,6 +221,7 @@ impl CycloneDxFormatter {
                     name: c.name.clone(),
                     version: c.version.clone(),
                     description: c.description.clone(),
+                    hashes,
                     licenses,
                     purl: c.purl.clone(),
                 }
@@ -366,6 +401,7 @@ mod tests {
                 tool_name: "uv-sbom".to_string(),
                 tool_version: "1.0.0".to_string(),
                 serial_number: "urn:uuid:test-123".to_string(),
+                component: None,
             },
             components: vec![
                 ComponentView {
@@ -648,6 +684,70 @@ mod tests {
 
         assert!(json.contains("my-app@1.0.0"));
         assert!(json.contains("other-app@2.0.0"));
+    }
+
+    // ============================================================
+    // Hash tests
+    // ============================================================
+
+    #[test]
+    fn test_format_with_hashes() {
+        let mut model = create_test_read_model();
+        model.components[0].sha256_hash =
+            Some("942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1".to_string());
+
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        assert!(json.contains("\"hashes\""));
+        assert!(json.contains("\"alg\": \"SHA-256\""));
+        assert!(json.contains(
+            "\"content\": \"942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1\""
+        ));
+    }
+
+    #[test]
+    fn test_format_without_hashes_omits_field() {
+        let model = create_test_read_model();
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        // Components without sha256_hash should not have hashes field
+        assert!(!json.contains("\"hashes\""));
+    }
+
+    // ============================================================
+    // Metadata component tests
+    // ============================================================
+
+    #[test]
+    fn test_format_with_metadata_component() {
+        use crate::application::read_models::MetadataComponentView;
+
+        let mut model = create_test_read_model();
+        model.metadata.component = Some(MetadataComponentView {
+            name: "my-project".to_string(),
+            version: "1.0.0".to_string(),
+        });
+
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        assert!(json.contains("\"type\": \"application\""));
+        assert!(json.contains("\"bom-ref\": \"my-project-1.0.0\""));
+        assert!(json.contains("\"name\": \"my-project\""));
+        assert!(json.contains("\"version\": \"1.0.0\""));
+    }
+
+    #[test]
+    fn test_format_without_metadata_component() {
+        let model = create_test_read_model();
+        let formatter = CycloneDxFormatter::new();
+        let json = formatter.format(&model).unwrap();
+
+        // metadata should not contain component field when None
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["metadata"]["component"].is_null());
     }
 
     #[test]

--- a/src/adapters/outbound/formatters/markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter.rs
@@ -536,6 +536,7 @@ mod tests {
                 tool_name: "uv-sbom".to_string(),
                 tool_version: "1.0.0".to_string(),
                 serial_number: "urn:uuid:test-123".to_string(),
+                component: None,
             },
             components: vec![
                 ComponentView {

--- a/src/adapters/outbound/network/caching_pypi_client.rs
+++ b/src/adapters/outbound/network/caching_pypi_client.rs
@@ -106,6 +106,7 @@ mod tests {
                 Some("MIT".to_string()),
                 vec!["License :: OSI Approved :: MIT License".to_string()],
                 Some(format!("{} description", package_name)),
+                None,
             ))
         }
     }

--- a/src/adapters/outbound/network/pypi_client.rs
+++ b/src/adapters/outbound/network/pypi_client.rs
@@ -8,6 +8,20 @@ use std::time::Duration;
 #[derive(Debug, Deserialize)]
 struct PyPiPackageInfo {
     info: PyPiInfo,
+    #[serde(default)]
+    urls: Vec<PyPiUrl>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PyPiUrl {
+    #[serde(default)]
+    digests: PyPiDigests,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PyPiDigests {
+    #[serde(default)]
+    sha256: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -177,11 +191,17 @@ impl LicenseRepository for PyPiLicenseRepository {
     async fn fetch_license_info(&self, package_name: &str, version: &str) -> Result<PyPiMetadata> {
         let package_info = self.fetch_with_retry(package_name, version).await?;
 
+        let sha256_hash = package_info
+            .urls
+            .iter()
+            .find_map(|url| url.digests.sha256.clone());
+
         Ok((
             package_info.info.license,
             package_info.info.license_expression,
             package_info.info.classifiers,
             package_info.info.summary,
+            sha256_hash,
         ))
     }
 }
@@ -201,6 +221,61 @@ mod tests {
         let client = PyPiLicenseRepository::new().unwrap();
         let result = client.verify_packages(&[]).await;
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_pypi_url_deserialization_with_digests() {
+        let json = r#"{
+            "info": {
+                "license": "MIT",
+                "summary": "A test package"
+            },
+            "urls": [
+                {
+                    "digests": {
+                        "sha256": "abc123def456"
+                    }
+                }
+            ]
+        }"#;
+
+        let package_info: PyPiPackageInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(package_info.urls.len(), 1);
+        assert_eq!(
+            package_info.urls[0].digests.sha256,
+            Some("abc123def456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_pypi_url_deserialization_without_urls() {
+        let json = r#"{
+            "info": {
+                "license": "MIT",
+                "summary": "A test package"
+            }
+        }"#;
+
+        let package_info: PyPiPackageInfo = serde_json::from_str(json).unwrap();
+        assert!(package_info.urls.is_empty());
+    }
+
+    #[test]
+    fn test_pypi_url_deserialization_empty_digests() {
+        let json = r#"{
+            "info": {
+                "license": "MIT",
+                "summary": "A test package"
+            },
+            "urls": [
+                {
+                    "digests": {}
+                }
+            ]
+        }"#;
+
+        let package_info: PyPiPackageInfo = serde_json::from_str(json).unwrap();
+        assert!(package_info.urls[0].digests.sha256.is_none());
     }
 
     // Integration tests - require network access

--- a/src/application/read_models/component_view.rs
+++ b/src/application/read_models/component_view.rs
@@ -18,7 +18,6 @@ pub struct ComponentView {
     /// Component description
     pub description: Option<String>,
     /// SHA256 hash of the component
-    #[allow(dead_code)]
     pub sha256_hash: Option<String>,
     /// Whether this is a direct dependency
     #[allow(dead_code)]

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -22,7 +22,7 @@ pub use license_compliance_view::{
 #[allow(unused_imports)]
 pub use resolution_guide_view::{IntroducedByView, ResolutionEntryView, ResolutionGuideView};
 #[allow(unused_imports)]
-pub use sbom_read_model::{SbomMetadataView, SbomReadModel};
+pub use sbom_read_model::{MetadataComponentView, SbomMetadataView, SbomReadModel};
 #[allow(unused_imports)]
 pub use sbom_read_model_builder::SbomReadModelBuilder;
 #[allow(unused_imports)]

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -41,4 +41,15 @@ pub struct SbomMetadataView {
     pub tool_version: String,
     /// Serial number of the SBOM
     pub serial_number: String,
+    /// The main project component being analyzed
+    pub component: Option<MetadataComponentView>,
+}
+
+/// View representation of the main project component in metadata
+#[derive(Debug, Clone)]
+pub struct MetadataComponentView {
+    /// Component name (project name)
+    pub name: String,
+    /// Component version
+    pub version: String,
 }

--- a/src/application/read_models/sbom_read_model_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder.rs
@@ -9,7 +9,7 @@ use super::license_compliance_view::{
     LicenseComplianceSummary, LicenseComplianceView, LicenseViolationView, LicenseWarningView,
 };
 use super::resolution_guide_view::{IntroducedByView, ResolutionEntryView, ResolutionGuideView};
-use super::sbom_read_model::{SbomMetadataView, SbomReadModel};
+use super::sbom_read_model::{MetadataComponentView, SbomMetadataView, SbomReadModel};
 use super::vulnerability_view::{
     SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
 };
@@ -42,6 +42,8 @@ impl SbomReadModelBuilder {
     ///
     /// # Returns
     /// A fully constructed SbomReadModel
+    /// Builds a SbomReadModel without project metadata component (backwards compatible)
+    #[allow(dead_code)]
     pub fn build(
         packages: Vec<EnrichedPackage>,
         metadata: &SbomMetadata,
@@ -49,7 +51,26 @@ impl SbomReadModelBuilder {
         vulnerability_result: Option<&VulnerabilityCheckResult>,
         license_compliance_result: Option<&LicenseComplianceResult>,
     ) -> SbomReadModel {
-        let metadata_view = Self::build_metadata(metadata);
+        Self::build_with_project(
+            packages,
+            metadata,
+            dependency_graph,
+            vulnerability_result,
+            license_compliance_result,
+            None,
+        )
+    }
+
+    /// Builds a SbomReadModel from domain objects with optional project metadata component
+    pub fn build_with_project(
+        packages: Vec<EnrichedPackage>,
+        metadata: &SbomMetadata,
+        dependency_graph: Option<&DependencyGraph>,
+        vulnerability_result: Option<&VulnerabilityCheckResult>,
+        license_compliance_result: Option<&LicenseComplianceResult>,
+        project_component: Option<(&str, &str)>,
+    ) -> SbomReadModel {
+        let metadata_view = Self::build_metadata(metadata, project_component);
         let components = Self::build_components(&packages, dependency_graph);
 
         let dependencies =
@@ -88,12 +109,19 @@ impl SbomReadModelBuilder {
     }
 
     /// Converts domain metadata to view representation
-    fn build_metadata(metadata: &SbomMetadata) -> SbomMetadataView {
+    fn build_metadata(
+        metadata: &SbomMetadata,
+        project_component: Option<(&str, &str)>,
+    ) -> SbomMetadataView {
         SbomMetadataView {
             timestamp: metadata.timestamp().to_string(),
             tool_name: metadata.tool_name().to_string(),
             tool_version: metadata.tool_version().to_string(),
             serial_number: metadata.serial_number().to_string(),
+            component: project_component.map(|(name, version)| MetadataComponentView {
+                name: name.to_string(),
+                version: version.to_string(),
+            }),
         }
     }
 
@@ -138,7 +166,7 @@ impl SbomReadModelBuilder {
                     purl,
                     license,
                     description: enriched.description.clone(),
-                    sha256_hash: None,
+                    sha256_hash: enriched.sha256_hash.clone(),
                     is_direct_dependency: is_direct,
                 }
             })
@@ -389,7 +417,7 @@ mod tests {
     #[test]
     fn test_build_metadata() {
         let metadata = create_test_metadata();
-        let view = SbomReadModelBuilder::build_metadata(&metadata);
+        let view = SbomReadModelBuilder::build_metadata(&metadata, None);
 
         assert_eq!(view.timestamp, "2024-01-15T10:30:00Z");
         assert_eq!(view.tool_name, "uv-sbom");
@@ -398,6 +426,7 @@ mod tests {
             view.serial_number,
             "urn:uuid:12345678-1234-1234-1234-123456789012"
         );
+        assert!(view.component.is_none());
     }
 
     #[test]
@@ -1018,5 +1047,69 @@ mod tests {
 
         // requests is a direct dep, so ResolutionAnalyzer skips it → empty → None
         assert!(read_model.resolution_guide.is_none());
+    }
+
+    // ============================================================
+    // SHA-256 hash wiring tests
+    // ============================================================
+
+    #[test]
+    fn test_build_components_with_sha256_hash() {
+        let mut package = create_test_package("requests", "2.31.0");
+        package.sha256_hash = Some("abc123def456".to_string());
+        let components = SbomReadModelBuilder::build_components(&[package], None);
+
+        assert_eq!(components[0].sha256_hash, Some("abc123def456".to_string()));
+    }
+
+    #[test]
+    fn test_build_components_without_sha256_hash() {
+        let package = create_test_package("requests", "2.31.0");
+        let components = SbomReadModelBuilder::build_components(&[package], None);
+
+        assert!(components[0].sha256_hash.is_none());
+    }
+
+    // ============================================================
+    // Metadata component tests
+    // ============================================================
+
+    #[test]
+    fn test_build_metadata_with_project_component() {
+        let metadata = create_test_metadata();
+        let view = SbomReadModelBuilder::build_metadata(&metadata, Some(("my-project", "1.0.0")));
+
+        assert!(view.component.is_some());
+        let component = view.component.unwrap();
+        assert_eq!(component.name, "my-project");
+        assert_eq!(component.version, "1.0.0");
+    }
+
+    #[test]
+    fn test_build_metadata_without_project_component() {
+        let metadata = create_test_metadata();
+        let view = SbomReadModelBuilder::build_metadata(&metadata, None);
+
+        assert!(view.component.is_none());
+    }
+
+    #[test]
+    fn test_build_with_project_includes_metadata_component() {
+        let packages = vec![create_test_package("requests", "2.31.0")];
+        let metadata = create_test_metadata();
+
+        let read_model = SbomReadModelBuilder::build_with_project(
+            packages,
+            &metadata,
+            None,
+            None,
+            None,
+            Some(("my-project", "1.0.0")),
+        );
+
+        assert!(read_model.metadata.component.is_some());
+        let component = read_model.metadata.component.unwrap();
+        assert_eq!(component.name, "my-project");
+        assert_eq!(component.version, "1.0.0");
     }
 }

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -484,11 +484,14 @@ where
                 .await
             {
                 Ok(license_info) => {
-                    enriched.push(EnrichedPackage::new(
-                        package,
-                        license_info.license_text().map(String::from),
-                        license_info.description().map(String::from),
-                    ));
+                    enriched.push(
+                        EnrichedPackage::new(
+                            package,
+                            license_info.license_text().map(String::from),
+                            license_info.description().map(String::from),
+                        )
+                        .with_sha256_hash(license_info.sha256_hash().map(String::from)),
+                    );
                     successful += 1;
                 }
                 Err(e) => {

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -94,6 +94,7 @@ impl LicenseRepository for MockLicenseRepository {
             None,
             vec![],
             Some("A test package".to_string()),
+            None,
         ))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use application::use_cases::GenerateSbomUseCase;
 use clap::Parser;
 use cli::Args;
 use owo_colors::OwoColorize;
+use ports::outbound::ProjectConfigReader;
 use sbom_generation::domain::license_policy::{LicensePolicy, UnknownLicenseHandling};
 use sbom_generation::domain::vulnerability::Severity;
 use shared::error::ExitCode;
@@ -160,7 +161,7 @@ async fn run(args: Args) -> Result<bool> {
     // Create request using builder pattern
     let include_dependency_info = matches!(merged.format, OutputFormat::Markdown);
     let request = SbomRequest::builder()
-        .project_path(project_path)
+        .project_path(project_path.clone())
         .include_dependency_info(include_dependency_info)
         .exclude_patterns(merged.exclude_patterns)
         .dry_run(args.dry_run)
@@ -183,13 +184,30 @@ async fn run(args: Args) -> Result<bool> {
     // Display progress message
     eprintln!("{}", FormatterFactory::progress_message(merged.format));
 
+    // Determine project component for CycloneDX metadata
+    let project_reader = FileSystemReader::new();
+    let project_component_info = project_reader
+        .read_project_name(&project_path)
+        .ok()
+        .and_then(|name| {
+            let version = response
+                .enriched_packages
+                .iter()
+                .find(|ep| ep.package.name() == name)
+                .map(|ep| ep.package.version().to_string());
+            version.map(|v| (name, v))
+        });
+
     // Build read model first so we can extract package names for verification
-    let read_model = SbomReadModelBuilder::build(
+    let read_model = SbomReadModelBuilder::build_with_project(
         response.enriched_packages,
         &response.metadata,
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        project_component_info
+            .as_ref()
+            .map(|(n, v)| (n.as_str(), v.as_str())),
     );
 
     // Verify PyPI links if requested

--- a/src/ports/outbound/enriched_package.rs
+++ b/src/ports/outbound/enriched_package.rs
@@ -9,6 +9,7 @@ pub struct EnrichedPackage {
     pub package: Package,
     pub license: Option<String>,
     pub description: Option<String>,
+    pub sha256_hash: Option<String>,
 }
 
 impl EnrichedPackage {
@@ -17,6 +18,12 @@ impl EnrichedPackage {
             package,
             license,
             description,
+            sha256_hash: None,
         }
+    }
+
+    pub fn with_sha256_hash(mut self, sha256_hash: Option<String>) -> Self {
+        self.sha256_hash = sha256_hash;
+        self
     }
 }

--- a/src/ports/outbound/license_repository.rs
+++ b/src/ports/outbound/license_repository.rs
@@ -2,8 +2,14 @@ use crate::sbom_generation::domain::LicenseInfo;
 use crate::shared::Result;
 use async_trait::async_trait;
 
-/// Type alias for PyPI metadata: (license, license_expression, classifiers, description)
-pub type PyPiMetadata = (Option<String>, Option<String>, Vec<String>, Option<String>);
+/// Type alias for PyPI metadata: (license, license_expression, classifiers, description, sha256_hash)
+pub type PyPiMetadata = (
+    Option<String>,
+    Option<String>,
+    Vec<String>,
+    Option<String>,
+    Option<String>,
+);
 
 /// LicenseRepository port for fetching license information
 ///
@@ -47,7 +53,7 @@ pub trait LicenseRepository: Send + Sync {
     /// # Returns
     /// A LicenseInfo object with the selected license and description
     async fn enrich_with_license(&self, package_name: &str, version: &str) -> Result<LicenseInfo> {
-        let (license, license_expression, classifiers, description) =
+        let (license, license_expression, classifiers, description, sha256_hash) =
             self.fetch_license_info(package_name, version).await?;
 
         use crate::sbom_generation::policies::LicensePriority;
@@ -56,6 +62,7 @@ pub trait LicenseRepository: Send + Sync {
             license_expression,
             &classifiers,
             description,
-        ))
+        )
+        .with_sha256_hash(sha256_hash))
     }
 }

--- a/src/sbom_generation/domain/license_info.rs
+++ b/src/sbom_generation/domain/license_info.rs
@@ -1,8 +1,9 @@
-/// LicenseInfo value object representing license and description information
+/// LicenseInfo value object representing license, description, and hash information
 #[derive(Debug, Clone, PartialEq)]
 pub struct LicenseInfo {
     license_text: Option<String>,
     description: Option<String>,
+    sha256_hash: Option<String>,
 }
 
 impl LicenseInfo {
@@ -10,7 +11,13 @@ impl LicenseInfo {
         Self {
             license_text,
             description,
+            sha256_hash: None,
         }
+    }
+
+    pub fn with_sha256_hash(mut self, sha256_hash: Option<String>) -> Self {
+        self.sha256_hash = sha256_hash;
+        self
     }
 
     pub fn license_text(&self) -> Option<&str> {
@@ -19,6 +26,10 @@ impl LicenseInfo {
 
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref()
+    }
+
+    pub fn sha256_hash(&self) -> Option<&str> {
+        self.sha256_hash.as_deref()
     }
 }
 
@@ -45,5 +56,19 @@ mod tests {
         let info = LicenseInfo::new(None, None);
         assert_eq!(info.license_text(), None);
         assert_eq!(info.description(), None);
+        assert_eq!(info.sha256_hash(), None);
+    }
+
+    #[test]
+    fn test_license_info_with_sha256_hash() {
+        let info = LicenseInfo::new(Some("MIT".to_string()), None)
+            .with_sha256_hash(Some("abc123".to_string()));
+        assert_eq!(info.sha256_hash(), Some("abc123"));
+    }
+
+    #[test]
+    fn test_license_info_without_sha256_hash() {
+        let info = LicenseInfo::new(Some("MIT".to_string()), None);
+        assert_eq!(info.sha256_hash(), None);
     }
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -570,13 +570,20 @@ fn create_test_license_repository() -> impl LicenseRepository {
             &self,
             package_name: &str,
             version: &str,
-        ) -> Result<(Option<String>, Option<String>, Vec<String>, Option<String>)> {
+        ) -> Result<(
+            Option<String>,
+            Option<String>,
+            Vec<String>,
+            Option<String>,
+            Option<String>,
+        )> {
             let key = format!("{}@{}", package_name, version);
-            Ok(self
+            let base = self
                 .licenses
                 .get(&key)
                 .cloned()
-                .unwrap_or((None, None, vec![], None)))
+                .unwrap_or((None, None, vec![], None));
+            Ok((base.0, base.1, base.2, base.3, None))
         }
     }
 

--- a/tests/test_utilities/mocks/mock_license_repository.rs
+++ b/tests/test_utilities/mocks/mock_license_repository.rs
@@ -31,6 +31,7 @@ impl MockLicenseRepository {
                 None,
                 vec![],
                 Some(description.to_string()),
+                None,
             ),
         );
         self
@@ -62,6 +63,6 @@ impl LicenseRepository for MockLicenseRepository {
             .licenses
             .get(&key)
             .cloned()
-            .unwrap_or((None, None, vec![], None)))
+            .unwrap_or((None, None, vec![], None, None)))
     }
 }


### PR DESCRIPTION
## Summary
- Extract SHA-256 package hashes from PyPI API responses and include them in CycloneDX component output
- Add `metadata.component` field containing the main project being analyzed
- Wire hash and metadata data through the full pipeline (PyPI client → domain → read model → formatter)

## Related Issue
Closes #220

## Changes Made
- **PyPI client**: Add `urls[].digests.sha256` extraction from PyPI JSON API responses
- **Domain layer**: Extend `LicenseInfo` with `sha256_hash` field and builder method
- **Ports layer**: Extend `PyPiMetadata` tuple and `EnrichedPackage` with SHA-256 hash
- **Read model**: Wire `sha256_hash` through `SbomReadModelBuilder` to `ComponentView`
- **CycloneDX formatter**: Add `Hash` struct with `hashes` array on components (omitted when empty)
- **CycloneDX formatter**: Add `MetadataComponent` to `Metadata` struct with project name/version
- **Read model**: Add `MetadataComponentView` to `SbomMetadataView` and `build_with_project()` method
- **main.rs**: Read project name from pyproject.toml and pass to read model builder
- Update all mocks and test fixtures for the extended `PyPiMetadata` tuple

## Test Plan
- [x] `cargo test --all` passes (all 167 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New unit tests for hash deserialization from PyPI response
- [x] New unit tests for CycloneDX hash output (present and absent cases)
- [x] New unit tests for CycloneDX metadata.component output
- [x] New unit tests for read model builder hash wiring and metadata component

---
Generated with [Claude Code](https://claude.com/claude-code)