### PR TITLE
feat(ports): define UvLockSimulator outbound port

### DIFF
--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -9,6 +9,7 @@ pub mod lockfile_reader;
 pub mod output_presenter;
 pub mod progress_reporter;
 pub mod project_config_reader;
+pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 
 pub use enriched_package::EnrichedPackage;
@@ -18,6 +19,9 @@ pub use lockfile_reader::{LockfileParseResult, LockfileReader};
 pub use output_presenter::OutputPresenter;
 pub use progress_reporter::{ProgressCallback, ProgressReporter};
 pub use project_config_reader::ProjectConfigReader;
+// Note: This will be used in a subsequent subtask for uv lock simulation
+#[allow(unused_imports)]
+pub use uv_lock_simulator::{SimulationResult, UvLockSimulator};
 // Note: This will be used in subsequent subtasks (Subtask 3-8)
 #[allow(unused_imports)]
 pub use vulnerability_repository::VulnerabilityRepository;

--- a/src/ports/outbound/uv_lock_simulator.rs
+++ b/src/ports/outbound/uv_lock_simulator.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use std::collections::HashMap;
+
+/// Represents the result of a `uv lock --upgrade-package` simulation
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct SimulationResult {
+    /// The direct package that was upgraded
+    pub upgraded_package: String,
+    /// The version it was upgraded to
+    pub upgraded_to_version: String,
+    /// Map of transitive package name → resolved version after upgrade
+    pub resolved_versions: HashMap<String, String>,
+}
+
+/// Port for simulating dependency resolution with package upgrades
+#[allow(dead_code)]
+#[async_trait::async_trait]
+pub trait UvLockSimulator: Send + Sync {
+    /// Simulate upgrading a specific package and return the resolved dependency versions.
+    ///
+    /// Runs `uv lock --upgrade-package <package_name>` (or equivalent) and parses
+    /// the resulting lock file to determine what versions would be resolved.
+    ///
+    /// # Arguments
+    /// * `package_name` - The direct dependency to upgrade
+    /// * `project_path` - Path to the project directory containing pyproject.toml
+    async fn simulate_upgrade(
+        &self,
+        package_name: &str,
+        project_path: &std::path::Path,
+    ) -> Result<SimulationResult>;
+}


### PR DESCRIPTION
## Summary
- Add `UvLockSimulator` trait as the outbound port abstraction for simulating `uv lock --upgrade-package` execution
- Add `SimulationResult` struct to represent the result of a lock simulation
- Export both types from `src/ports/outbound/mod.rs`

## Related Issue
Closes #249

## Changes Made
- `src/ports/outbound/uv_lock_simulator.rs` (new): Defines `SimulationResult` struct and `UvLockSimulator` async trait
- `src/ports/outbound/mod.rs`: Adds `pub mod uv_lock_simulator` and re-exports `SimulationResult` and `UvLockSimulator` with `#[allow(unused_imports)]` until adapter implementations are added

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)