### PR TITLE
feat(adapters): implement UvLockAdapter for uv lock simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1776,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ anyhow = "1.0"
 thiserror = "2.0"
 reqwest = { version = "0.13", features = ["json", "blocking"] }
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros", "process"] }
+tempfile = "3.25"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.21", features = ["v4", "serde"] }
 urlencoding = "2.1"
@@ -38,7 +39,6 @@ owo-colors = "4.1"
 futures = "0.3"
 
 [dev-dependencies]
-tempfile = "3.25"
 assert_cmd = "2.0"
 predicates = "3"
 

--- a/src/adapters/outbound/mod.rs
+++ b/src/adapters/outbound/mod.rs
@@ -3,3 +3,4 @@ pub mod console;
 pub mod filesystem;
 pub mod formatters;
 pub mod network;
+pub mod uv;

--- a/src/adapters/outbound/uv/mod.rs
+++ b/src/adapters/outbound/uv/mod.rs
@@ -1,0 +1,6 @@
+/// uv CLI adapters for lock file simulation
+mod uv_lock_adapter;
+
+// Note: Will be used in a subsequent subtask for uv lock simulation
+#[allow(unused_imports)]
+pub use uv_lock_adapter::UvLockAdapter;

--- a/src/adapters/outbound/uv/uv_lock_adapter.rs
+++ b/src/adapters/outbound/uv/uv_lock_adapter.rs
@@ -1,0 +1,186 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+use tokio::time::timeout;
+
+use crate::ports::outbound::uv_lock_simulator::{SimulationResult, UvLockSimulator};
+
+/// Adapter that implements [`UvLockSimulator`] by shelling out to the `uv` CLI.
+///
+/// Uses a temporary directory strategy: copies `pyproject.toml` and `uv.lock`
+/// to a temp dir, runs `uv lock --upgrade-package <pkg>`, then parses the
+/// resulting lock file to determine resolved versions.
+#[allow(dead_code)]
+pub struct UvLockAdapter;
+
+#[allow(dead_code)]
+impl UvLockAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Parse a uv.lock TOML content and return a map of package name → version.
+    fn parse_versions(content: &str) -> Result<HashMap<String, String>> {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct UvLock {
+            package: Vec<UvPackage>,
+        }
+
+        #[derive(Deserialize)]
+        struct UvPackage {
+            name: String,
+            version: String,
+        }
+
+        let lockfile: UvLock =
+            toml::from_str(content).map_err(|e| anyhow!("Failed to parse uv.lock: {}", e))?;
+
+        Ok(lockfile
+            .package
+            .into_iter()
+            .map(|p| (p.name, p.version))
+            .collect())
+    }
+}
+
+impl Default for UvLockAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl UvLockSimulator for UvLockAdapter {
+    async fn simulate_upgrade(
+        &self,
+        package_name: &str,
+        project_path: &Path,
+    ) -> Result<SimulationResult> {
+        // 1. Verify uv is available in PATH
+        let uv_available = tokio::process::Command::new("uv")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+
+        if !uv_available {
+            return Err(anyhow!(
+                "`uv` CLI not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+            ));
+        }
+
+        // 2. Verify required files exist in project_path
+        let pyproject_src = project_path.join("pyproject.toml");
+        let lockfile_src = project_path.join("uv.lock");
+
+        if !pyproject_src.exists() {
+            return Err(anyhow!(
+                "pyproject.toml not found in: {}",
+                project_path.display()
+            ));
+        }
+        if !lockfile_src.exists() {
+            return Err(anyhow!("uv.lock not found in: {}", project_path.display()));
+        }
+
+        // 3. Create temp directory and copy files into it
+        let temp_dir = tempfile::TempDir::new()
+            .map_err(|e| anyhow!("Failed to create temp directory: {}", e))?;
+
+        std::fs::copy(&pyproject_src, temp_dir.path().join("pyproject.toml"))
+            .map_err(|e| anyhow!("Failed to copy pyproject.toml to temp dir: {}", e))?;
+        std::fs::copy(&lockfile_src, temp_dir.path().join("uv.lock"))
+            .map_err(|e| anyhow!("Failed to copy uv.lock to temp dir: {}", e))?;
+
+        // 4. Run: uv lock --upgrade-package <package_name> with 60-second timeout
+        let run_output = timeout(
+            Duration::from_secs(60),
+            tokio::process::Command::new("uv")
+                .args(["lock", "--upgrade-package", package_name])
+                .current_dir(temp_dir.path())
+                .output(),
+        )
+        .await
+        .map_err(|_| anyhow!("uv lock command timed out after 60 seconds"))?
+        .map_err(|e| anyhow!("Failed to run uv lock: {}", e))?;
+
+        if !run_output.status.success() {
+            let stderr = String::from_utf8_lossy(&run_output.stderr);
+            return Err(anyhow!("uv lock --upgrade-package failed: {}", stderr));
+        }
+
+        // 5. Parse the resulting uv.lock
+        let new_content = std::fs::read_to_string(temp_dir.path().join("uv.lock"))
+            .map_err(|e| anyhow!("Failed to read resulting uv.lock: {}", e))?;
+        let new_versions = Self::parse_versions(&new_content)?;
+
+        // 6. Find the upgraded version (case-insensitive lookup for robustness)
+        let package_name_lower = package_name.to_lowercase();
+        let upgraded_to_version = new_versions
+            .iter()
+            .find(|(k, _)| k.to_lowercase() == package_name_lower)
+            .map(|(_, v)| v.clone())
+            .ok_or_else(|| anyhow!("Package '{}' not found in resulting uv.lock", package_name))?;
+
+        // 7. Return result (temp_dir is dropped here, cleaning up automatically)
+        Ok(SimulationResult {
+            upgraded_package: package_name.to_string(),
+            upgraded_to_version,
+            resolved_versions: new_versions,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_versions_success() {
+        let content = r#"
+version = 1
+revision = 2
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+"#;
+        let versions = UvLockAdapter::parse_versions(content).unwrap();
+        assert_eq!(versions.get("requests").map(|s| s.as_str()), Some("2.31.0"));
+        assert_eq!(versions.get("urllib3").map(|s| s.as_str()), Some("2.0.7"));
+    }
+
+    #[test]
+    fn test_parse_versions_invalid_toml() {
+        let content = "invalid [[[ toml content";
+        let result = UvLockAdapter::parse_versions(content);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse uv.lock"));
+    }
+
+    #[test]
+    fn test_parse_versions_empty_packages() {
+        let content = r#"
+version = 1
+
+[[package]]
+name = "mypackage"
+version = "0.1.0"
+"#;
+        let versions = UvLockAdapter::parse_versions(content).unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions.get("mypackage").map(|s| s.as_str()), Some("0.1.0"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `UvLockAdapter` that shells out to the `uv` CLI to simulate dependency upgrades
- Uses a temp directory strategy to avoid modifying the original `uv.lock`
- Adds `process` feature to tokio and moves `tempfile` to production dependencies

## Related Issue
Closes #250

## Changes Made
- `src/adapters/outbound/uv/uv_lock_adapter.rs` — New adapter implementing `UvLockSimulator` port
- `src/adapters/outbound/uv/mod.rs` — New module definition for uv adapters
- `src/adapters/outbound/mod.rs` — Register `uv` sub-module
- `Cargo.toml` — Add `process` feature to tokio; move `tempfile` to `[dependencies]`

## Implementation Details
- Verifies `uv` is available in PATH; returns actionable error message if not found
- Copies `pyproject.toml` and `uv.lock` to a `tempfile::TempDir` before running
- Executes `uv lock --upgrade-package <pkg>` with a 60-second `tokio::time::timeout`
- Parses resulting `uv.lock` TOML to extract `HashMap<String, String>` of resolved versions
- Uses case-insensitive package name lookup for robustness
- `TempDir` is automatically cleaned up when dropped

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (12 unit tests + 5 doc tests)
- [x] Unit tests added for `parse_versions` (success, invalid TOML, empty packages)

---
Generated with [Claude Code](https://claude.com/claude-code)