### PR TITLE
feat(domain): define UpgradeRecommendation enum for upgrade simulation results

### DIFF
--- a/src/sbom_generation/domain/mod.rs
+++ b/src/sbom_generation/domain/mod.rs
@@ -5,6 +5,7 @@ pub mod package;
 pub mod resolution_guide;
 pub mod sbom_metadata;
 pub mod services;
+pub mod upgrade_recommendation;
 pub mod vulnerability;
 
 pub use dependency_graph::DependencyGraph;
@@ -26,6 +27,9 @@ pub use services::ResolutionAnalyzer;
 // Note: These will be used in subsequent subtasks (Issue #94, #95)
 #[allow(unused_imports)]
 pub use services::{ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker};
+// Note: These will be used in subsequent subtasks (Subtask 2-8)
+#[allow(unused_imports)]
+pub use upgrade_recommendation::UpgradeRecommendation;
 // Note: These will be used in subsequent subtasks (Subtask 2-8)
 #[allow(unused_imports)]
 pub use vulnerability::{CvssScore, PackageVulnerabilities, Severity, Vulnerability};

--- a/src/sbom_generation/domain/upgrade_recommendation.rs
+++ b/src/sbom_generation/domain/upgrade_recommendation.rs
@@ -1,0 +1,33 @@
+/// Result of analyzing whether upgrading a direct dep fixes a transitive vulnerability
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum UpgradeRecommendation {
+    /// Upgrading the direct dep resolves the vulnerability
+    Upgradable {
+        /// Direct dependency to upgrade (e.g., "requests")
+        direct_dep_name: String,
+        /// Current version of the direct dependency (e.g., "2.31.0")
+        direct_dep_current_version: String,
+        /// Recommended version to upgrade to (e.g., "2.32.3")
+        direct_dep_target_version: String,
+        /// Vulnerable transitive dep name (e.g., "urllib3")
+        transitive_dep_name: String,
+        /// Version of transitive dep after upgrade (e.g., "2.2.1")
+        transitive_resolved_version: String,
+        /// Vulnerability ID (e.g., "CVE-2024-XXXXX")
+        vulnerability_id: String,
+    },
+    /// Upgrading the direct dep does NOT resolve the vulnerability
+    Unresolvable {
+        direct_dep_name: String,
+        /// Why upgrade doesn't help (e.g., "latest httpx still pins idna < 3.7")
+        reason: String,
+        vulnerability_id: String,
+    },
+    /// Simulation could not be performed (uv not available, timeout, etc.)
+    SimulationFailed {
+        direct_dep_name: String,
+        /// Error description
+        error: String,
+    },
+}


### PR DESCRIPTION
## Summary
- Add `UpgradeRecommendation` domain enum representing three possible outcomes of upgrade simulation analysis
- Export the enum from `src/sbom_generation/domain/mod.rs` for use by `UpgradeAdvisor` service

## Related Issue
Closes #251

## Changes Made
- **New file**: `src/sbom_generation/domain/upgrade_recommendation.rs` — defines `UpgradeRecommendation` enum with three variants:
  - `Upgradable`: upgrading the direct dep resolves the vulnerability
  - `Unresolvable`: upgrading the direct dep does NOT resolve the vulnerability
  - `SimulationFailed`: simulation could not be performed (uv unavailable, timeout, etc.)
- **Modified**: `src/sbom_generation/domain/mod.rs` — added `pub mod upgrade_recommendation` and re-export of `UpgradeRecommendation`

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)