### PR TITLE
feat(cli,application): add --suggest-fix flag and extend SbomRequest/SbomResponse DTOs

### DIFF
--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -31,6 +31,10 @@ pub struct SbomRequest {
     pub check_license: bool,
     /// License compliance policy (only used when check_license is true)
     pub license_policy: Option<LicensePolicy>,
+    /// Whether to suggest direct dependency upgrade versions to fix transitive vulnerabilities.
+    /// Only meaningful when `check_cve` is true.
+    #[allow(dead_code)] // Will be used by upgrade advisor use case
+    pub suggest_fix: bool,
 }
 
 impl SbomRequest {
@@ -90,6 +94,7 @@ pub struct SbomRequestBuilder {
     ignore_cves: Vec<IgnoreCve>,
     check_license: bool,
     license_policy: Option<LicensePolicy>,
+    suggest_fix: bool,
 }
 
 impl SbomRequestBuilder {
@@ -115,6 +120,7 @@ impl SbomRequestBuilder {
             ignore_cves: Vec::new(),
             check_license: false,
             license_policy: None,
+            suggest_fix: false,
         }
     }
 
@@ -207,6 +213,12 @@ impl SbomRequestBuilder {
         self
     }
 
+    /// Sets whether to suggest upgrade paths for vulnerable transitive dependencies.
+    pub fn suggest_fix(mut self, suggest: bool) -> Self {
+        self.suggest_fix = suggest;
+        self
+    }
+
     /// Builds the SbomRequest, validating that all required fields are set.
     ///
     /// # Errors
@@ -228,6 +240,7 @@ impl SbomRequestBuilder {
             ignore_cves: self.ignore_cves,
             check_license: self.check_license,
             license_policy: self.license_policy,
+            suggest_fix: self.suggest_fix,
         })
     }
 }

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -2,7 +2,7 @@ use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
 use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
-use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata};
+use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata, UpgradeRecommendation};
 use crate::shared::error::SbomError;
 
 /// SbomResponse - Internal response DTO from SBOM generation use case
@@ -31,6 +31,10 @@ pub struct SbomResponse {
     pub license_compliance_result: Option<LicenseComplianceResult>,
     /// Whether license violations were detected
     pub has_license_violations: bool,
+    /// Upgrade recommendations for vulnerable transitive dependencies.
+    /// Populated only when `suggest_fix` was true in the request.
+    #[allow(dead_code)] // Will be populated by upgrade advisor use case
+    pub upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
 }
 
 impl SbomResponse {
@@ -48,6 +52,7 @@ pub struct SbomResponseBuilder {
     vulnerability_check_result: Option<VulnerabilityCheckResult>,
     license_compliance_result: Option<LicenseComplianceResult>,
     has_license_violations: bool,
+    upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
 }
 
 impl SbomResponseBuilder {
@@ -61,6 +66,7 @@ impl SbomResponseBuilder {
             vulnerability_check_result: None,
             license_compliance_result: None,
             has_license_violations: false,
+            upgrade_recommendations: None,
         }
     }
 
@@ -110,6 +116,12 @@ impl SbomResponseBuilder {
         self
     }
 
+    #[allow(dead_code)] // Will be used by upgrade advisor use case
+    pub fn upgrade_recommendations(mut self, recommendations: Vec<UpgradeRecommendation>) -> Self {
+        self.upgrade_recommendations = Some(recommendations);
+        self
+    }
+
     pub fn build(self) -> Result<SbomResponse, SbomError> {
         let metadata = self.metadata.ok_or_else(|| SbomError::Validation {
             message: "metadata is required".into(),
@@ -124,6 +136,7 @@ impl SbomResponseBuilder {
             vulnerability_check_result: self.vulnerability_check_result,
             license_compliance_result: self.license_compliance_result,
             has_license_violations: self.has_license_violations,
+            upgrade_recommendations: self.upgrade_recommendations,
         })
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[arg(long, value_parser = parse_cvss_threshold, group = "threshold", requires = "check_cve")]
     pub cvss_threshold: Option<f32>,
 
+    /// Suggest upgrade paths for vulnerable transitive dependencies (requires --check-cve)
+    #[arg(long, requires = "check_cve")]
+    pub suggest_fix: bool,
+
     /// Verify PyPI links exist before generating hyperlinks (requires network access, Markdown format only)
     #[arg(long)]
     pub verify_links: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ async fn run(args: Args) -> Result<bool> {
         .ignore_cves(merged.ignore_cves)
         .check_license(merged.check_license)
         .license_policy(merged.license_policy)
+        .suggest_fix(args.suggest_fix)
         .build()?;
 
     // Execute use case


### PR DESCRIPTION
## Summary

- Add `--suggest-fix` CLI flag that requires `--check-cve` (enforced by clap)
- Extend `SbomRequest` DTO with `suggest_fix: bool` field and builder method
- Extend `SbomResponse` DTO with `upgrade_recommendations: Option<Vec<UpgradeRecommendation>>` field and builder method

## Related Issue

Closes #253

## Changes Made

- `src/cli.rs`: Add `suggest_fix: bool` field with `#[arg(long, requires = "check_cve")]`
- `src/application/dto/sbom_request.rs`: Add `suggest_fix` field, builder field, `new()` default, `suggest_fix()` builder method, and `build()` mapping
- `src/application/dto/sbom_response.rs`: Import `UpgradeRecommendation`, add `upgrade_recommendations` field, builder field, `new()` default, `upgrade_recommendations()` builder method, and `build()` mapping
- `src/main.rs`: Pass `args.suggest_fix` to `SbomRequest` builder

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `cargo run -- --suggest-fix` (without `--check-cve`) correctly prints a clap error

---
Generated with [Claude Code](https://claude.com/claude-code)