### PR TITLE
feat(application): integrate UpgradeAdvisor into GenerateSbomUseCase and add upgrade view model

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter.rs
@@ -433,6 +433,7 @@ mod tests {
             vulnerabilities: None,
             license_compliance: None,
             resolution_guide: None,
+            upgrade_recommendations: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter.rs
@@ -572,6 +572,7 @@ mod tests {
             vulnerabilities: None,
             license_compliance: None,
             resolution_guide: None,
+            upgrade_recommendations: None,
         }
     }
 

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -9,6 +9,7 @@ pub mod license_compliance_view;
 pub mod resolution_guide_view;
 pub mod sbom_read_model;
 pub mod sbom_read_model_builder;
+pub mod upgrade_recommendation_view;
 pub mod vulnerability_view;
 
 #[allow(unused_imports)]
@@ -25,6 +26,8 @@ pub use resolution_guide_view::{IntroducedByView, ResolutionEntryView, Resolutio
 pub use sbom_read_model::{MetadataComponentView, SbomMetadataView, SbomReadModel};
 #[allow(unused_imports)]
 pub use sbom_read_model_builder::SbomReadModelBuilder;
+#[allow(unused_imports)]
+pub use upgrade_recommendation_view::{UpgradeEntryView, UpgradeRecommendationView};
 #[allow(unused_imports)]
 pub use vulnerability_view::{
     SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -7,6 +7,7 @@ use super::component_view::ComponentView;
 use super::dependency_view::DependencyView;
 use super::license_compliance_view::LicenseComplianceView;
 use super::resolution_guide_view::ResolutionGuideView;
+use super::upgrade_recommendation_view::UpgradeRecommendationView;
 use super::vulnerability_view::VulnerabilityReportView;
 
 /// Main read model for SBOM data
@@ -28,6 +29,10 @@ pub struct SbomReadModel {
     /// Resolution guide for vulnerable transitive dependencies
     #[allow(dead_code)]
     pub resolution_guide: Option<ResolutionGuideView>,
+    /// Upgrade recommendations for vulnerable transitive dependencies.
+    /// Populated only when `suggest_fix` was true in the request.
+    #[allow(dead_code)]
+    pub upgrade_recommendations: Option<UpgradeRecommendationView>,
 }
 
 /// View representation of SBOM metadata

--- a/src/application/read_models/sbom_read_model_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder.rs
@@ -10,6 +10,7 @@ use super::license_compliance_view::{
 };
 use super::resolution_guide_view::{IntroducedByView, ResolutionEntryView, ResolutionGuideView};
 use super::sbom_read_model::{MetadataComponentView, SbomMetadataView, SbomReadModel};
+use super::upgrade_recommendation_view::{UpgradeEntryView, UpgradeRecommendationView};
 use super::vulnerability_view::{
     SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
 };
@@ -20,7 +21,7 @@ use crate::sbom_generation::domain::services::{ResolutionAnalyzer, Vulnerability
 use crate::sbom_generation::domain::vulnerability::{
     PackageVulnerabilities, Severity, Vulnerability,
 };
-use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata};
+use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata, UpgradeRecommendation};
 use crate::sbom_generation::policies::spdx_license_map;
 use std::collections::{HashMap, HashSet};
 
@@ -58,6 +59,7 @@ impl SbomReadModelBuilder {
             vulnerability_result,
             license_compliance_result,
             None,
+            None,
         )
     }
 
@@ -69,6 +71,7 @@ impl SbomReadModelBuilder {
         vulnerability_result: Option<&VulnerabilityCheckResult>,
         license_compliance_result: Option<&LicenseComplianceResult>,
         project_component: Option<(&str, &str)>,
+        upgrade_recommendations: Option<&[UpgradeRecommendation]>,
     ) -> SbomReadModel {
         let metadata_view = Self::build_metadata(metadata, project_component);
         let components = Self::build_components(&packages, dependency_graph);
@@ -98,6 +101,9 @@ impl SbomReadModelBuilder {
             _ => None,
         };
 
+        let upgrade_recommendations =
+            upgrade_recommendations.map(Self::build_upgrade_recommendations);
+
         SbomReadModel {
             metadata: metadata_view,
             components,
@@ -105,6 +111,7 @@ impl SbomReadModelBuilder {
             vulnerabilities,
             license_compliance,
             resolution_guide,
+            upgrade_recommendations,
         }
     }
 
@@ -361,6 +368,50 @@ impl SbomReadModelBuilder {
         ResolutionGuideView {
             entries: entry_views,
         }
+    }
+
+    /// Maps a slice of domain UpgradeRecommendation to an UpgradeRecommendationView
+    fn build_upgrade_recommendations(
+        recommendations: &[UpgradeRecommendation],
+    ) -> UpgradeRecommendationView {
+        let entries = recommendations
+            .iter()
+            .map(|rec| match rec {
+                UpgradeRecommendation::Upgradable {
+                    direct_dep_name,
+                    direct_dep_current_version,
+                    direct_dep_target_version,
+                    transitive_dep_name,
+                    transitive_resolved_version,
+                    vulnerability_id,
+                } => UpgradeEntryView::Upgradable {
+                    direct_dep: direct_dep_name.clone(),
+                    current_version: direct_dep_current_version.clone(),
+                    target_version: direct_dep_target_version.clone(),
+                    transitive_dep: transitive_dep_name.clone(),
+                    resolved_version: transitive_resolved_version.clone(),
+                    vulnerability_id: vulnerability_id.clone(),
+                },
+                UpgradeRecommendation::Unresolvable {
+                    direct_dep_name,
+                    reason,
+                    vulnerability_id,
+                } => UpgradeEntryView::Unresolvable {
+                    direct_dep: direct_dep_name.clone(),
+                    reason: reason.clone(),
+                    vulnerability_id: vulnerability_id.clone(),
+                },
+                UpgradeRecommendation::SimulationFailed {
+                    direct_dep_name,
+                    error,
+                } => UpgradeEntryView::SimulationFailed {
+                    direct_dep: direct_dep_name.clone(),
+                    error: error.clone(),
+                },
+            })
+            .collect();
+
+        UpgradeRecommendationView { entries }
     }
 
     /// Converts a single domain ResolutionEntry to a view
@@ -1105,6 +1156,7 @@ mod tests {
             None,
             None,
             Some(("my-project", "1.0.0")),
+            None,
         );
 
         assert!(read_model.metadata.component.is_some());

--- a/src/application/read_models/upgrade_recommendation_view.rs
+++ b/src/application/read_models/upgrade_recommendation_view.rs
@@ -1,0 +1,34 @@
+//! Upgrade recommendation view model for query operations
+//!
+//! This module provides view-optimized structs for rendering upgrade recommendations
+//! produced by the UpgradeAdvisor domain service.
+
+/// View model aggregating all upgrade recommendation entries
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct UpgradeRecommendationView {
+    pub entries: Vec<UpgradeEntryView>,
+}
+
+/// Individual upgrade recommendation entry view
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum UpgradeEntryView {
+    /// Upgrading the direct dependency resolves the vulnerability
+    Upgradable {
+        direct_dep: String,
+        current_version: String,
+        target_version: String,
+        transitive_dep: String,
+        resolved_version: String,
+        vulnerability_id: String,
+    },
+    /// Upgrading the direct dependency does NOT resolve the vulnerability
+    Unresolvable {
+        direct_dep: String,
+        reason: String,
+        vulnerability_id: String,
+    },
+    /// Simulation could not be performed for this dependency
+    SimulationFailed { direct_dep: String, error: String },
+}

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -1,3 +1,4 @@
+use crate::adapters::outbound::uv::UvLockAdapter;
 use crate::application::dto::{SbomRequest, SbomResponse};
 use crate::application::use_cases::CheckVulnerabilitiesUseCase;
 use crate::ports::outbound::{
@@ -6,9 +7,10 @@ use crate::ports::outbound::{
 };
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::{
-    LicenseComplianceChecker, ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker,
+    LicenseComplianceChecker, ResolutionAnalyzer, ThresholdConfig, UpgradeAdvisor,
+    VulnerabilityCheckResult, VulnerabilityChecker,
 };
-use crate::sbom_generation::domain::{Package, PackageName};
+use crate::sbom_generation::domain::{Package, PackageName, UpgradeRecommendation};
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -114,13 +116,24 @@ where
         let license_compliance_result =
             self.check_license_compliance_if_requested(&request, &enriched_packages);
 
-        // Step 8: Build and return response
+        // Step 8: Upgrade advisor if requested
+        let upgrade_recommendations = self
+            .advise_upgrades_if_requested(
+                &request,
+                dependency_graph.as_ref(),
+                vulnerability_report.as_deref(),
+                &enriched_packages,
+            )
+            .await;
+
+        // Step 9: Build and return response
         Ok(self.build_response(
             enriched_packages,
             dependency_graph,
             vulnerability_report,
             vulnerability_check_result,
             license_compliance_result,
+            upgrade_recommendations,
         ))
     }
 
@@ -338,6 +351,37 @@ where
         }
     }
 
+    /// Runs the UpgradeAdvisor when `suggest_fix` is true and the required context is available
+    ///
+    /// Returns `None` when `suggest_fix` is false (no overhead).
+    /// Returns `Some(vec)` when the advisor runs, even if the vector is empty.
+    async fn advise_upgrades_if_requested(
+        &self,
+        request: &SbomRequest,
+        dependency_graph: Option<&crate::sbom_generation::domain::DependencyGraph>,
+        vulnerability_report: Option<&[crate::sbom_generation::domain::PackageVulnerabilities]>,
+        enriched_packages: &[EnrichedPackage],
+    ) -> Option<Vec<UpgradeRecommendation>> {
+        if !request.suggest_fix {
+            return None;
+        }
+
+        let (Some(graph), Some(vuln_report)) = (dependency_graph, vulnerability_report) else {
+            return Some(vec![]);
+        };
+
+        let entries = ResolutionAnalyzer::analyze(graph, vuln_report, enriched_packages);
+        if entries.is_empty() {
+            return Some(vec![]);
+        }
+
+        let simulator = UvLockAdapter::new();
+        let recommendations =
+            UpgradeAdvisor::advise(&simulator, &entries, &request.project_path).await;
+
+        Some(recommendations)
+    }
+
     /// Checks license compliance if requested
     fn check_license_compliance_if_requested(
         &self,
@@ -391,6 +435,7 @@ where
         vulnerability_report: Option<Vec<crate::sbom_generation::domain::PackageVulnerabilities>>,
         vulnerability_check_result: Option<VulnerabilityCheckResult>,
         license_compliance_result: Option<LicenseComplianceResult>,
+        upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
     ) -> SbomResponse {
         let metadata = SbomGenerator::generate_default_metadata();
 
@@ -422,6 +467,9 @@ where
         }
         if let Some(result) = license_compliance_result {
             builder = builder.license_compliance_result(result);
+        }
+        if let Some(recommendations) = upgrade_recommendations {
+            builder = builder.upgrade_recommendations(recommendations);
         }
 
         builder.build().expect("response build should not fail")

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -520,7 +520,7 @@ fn test_build_response() {
         Some("Test description".to_string()),
     )];
 
-    let response = use_case.build_response(enriched_packages.clone(), None, None, None, None);
+    let response = use_case.build_response(enriched_packages.clone(), None, None, None, None, None);
 
     assert_eq!(response.enriched_packages.len(), 1);
     assert!(response.dependency_graph.is_none());
@@ -722,7 +722,14 @@ fn test_build_response_with_threshold_exceeded() {
         threshold_exceeded: true,
     };
 
-    let response = use_case.build_response(enriched_packages, None, None, Some(check_result), None);
+    let response = use_case.build_response(
+        enriched_packages,
+        None,
+        None,
+        Some(check_result),
+        None,
+        None,
+    );
 
     assert!(response.has_vulnerabilities_above_threshold);
     assert!(response.vulnerability_check_result.is_some());
@@ -778,7 +785,14 @@ fn test_build_response_with_threshold_not_exceeded() {
         threshold_exceeded: false,
     };
 
-    let response = use_case.build_response(enriched_packages, None, None, Some(check_result), None);
+    let response = use_case.build_response(
+        enriched_packages,
+        None,
+        None,
+        Some(check_result),
+        None,
+        None,
+    );
 
     assert!(!response.has_vulnerabilities_above_threshold);
     assert!(response.vulnerability_check_result.is_some());

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,7 @@ async fn run(args: Args) -> Result<bool> {
         project_component_info
             .as_ref()
             .map(|(n, v)| (n.as_str(), v.as_str())),
+        response.upgrade_recommendations.as_deref(),
     );
 
     // Verify PyPI links if requested

--- a/src/sbom_generation/domain/services/mod.rs
+++ b/src/sbom_generation/domain/services/mod.rs
@@ -5,4 +5,5 @@ pub mod vulnerability_checker;
 
 pub use license_compliance_checker::LicenseComplianceChecker;
 pub use resolution_analyzer::ResolutionAnalyzer;
+pub use upgrade_advisor::UpgradeAdvisor;
 pub use vulnerability_checker::{ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker};


### PR DESCRIPTION
## Summary

- Wire `UpgradeAdvisor::advise()` into `GenerateSbomUseCase`, called only when `request.suggest_fix` is `true`
- Add `UpgradeRecommendationView` / `UpgradeEntryView` read models and implement the domain-to-view mapper in `SbomReadModelBuilder`
- Propagate upgrade recommendations through the response DTO and `SbomReadModel`

## Related Issue

Closes #254

## Changes Made

- **`src/application/read_models/upgrade_recommendation_view.rs`** (new): `UpgradeRecommendationView` struct and `UpgradeEntryView` enum with `Upgradable`, `Unresolvable`, and `SimulationFailed` variants
- **`src/application/read_models/sbom_read_model.rs`**: add `upgrade_recommendations: Option<UpgradeRecommendationView>` field
- **`src/application/read_models/sbom_read_model_builder.rs`**: add `build_upgrade_recommendations` mapper and extend `build_with_project` signature with the new optional param
- **`src/application/use_cases/generate_sbom/mod.rs`**: add `advise_upgrades_if_requested` async helper; call `ResolutionAnalyzer` then `UpgradeAdvisor`; extend `build_response` to accept and set `upgrade_recommendations`
- **`src/sbom_generation/domain/services/mod.rs`**: re-export `UpgradeAdvisor` for cleaner imports
- **`src/main.rs`**: pass `response.upgrade_recommendations.as_deref()` to `build_with_project`
- Formatter test fixtures updated with `upgrade_recommendations: None`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (all tests green)

---
Generated with [Claude Code](https://claude.com/claude-code)