### PR TITLE
fix(deps): update aws-lc-rs to fix GHSA-hfpc-8r3f-gw53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary
- Update `aws-lc-rs` from v1.15.3 to v1.16.1 to resolve a high-severity security vulnerability
- `aws-lc-sys` is bumped from v0.36.0 to v0.38.0 as a transitive dependency
- Fixes PKCS7_verify signature validation bypass in AWS-LC

## Security Advisory
- **Advisory**: GHSA-hfpc-8r3f-gw53
- **CVE**: N/A (not yet assigned)
- **Package**: `aws-lc-sys` (via `aws-lc-rs`)
- **Severity**: High (CVSS 7.5)
- **Fixed Version**: aws-lc-sys 0.38.0
- **Summary**: AWS-LC has PKCS7_verify Signature Validation Bypass

## Changes Made
- Updated `Cargo.lock`: `aws-lc-rs` v1.15.3 → v1.16.1, `aws-lc-sys` v0.36.0 → v0.38.0

## Dependency Chain
```
uv-sbom → reqwest → rustls → aws-lc-rs → aws-lc-sys
```

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (428 tests)

---
Generated with [Claude Code](https://claude.com/claude-code)