### PR TITLE
fix(config): make --suggest-fix configurable via config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,9 @@ const CONFIG_TEMPLATE: &str = r#"# uv-sbom configuration file
 #     - "AGPL-*"
 #     - "GPL-*"
 #   unknown: warn
+
+# Suggest upgrade paths to fix vulnerable transitive dependencies (requires check_cve: true)
+# suggest_fix: false
 "#;
 
 /// Generate a config template file in the specified directory.
@@ -94,6 +97,7 @@ pub struct ConfigFile {
     pub ignore_cves: Option<Vec<IgnoreCve>>,
     pub check_license: Option<bool>,
     pub license_policy: Option<LicensePolicyConfig>,
+    pub suggest_fix: Option<bool>,
     /// Captures unknown fields for warnings.
     #[serde(flatten)]
     pub unknown_fields: HashMap<String, serde_yaml_ng::Value>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ async fn run(args: Args) -> Result<bool> {
     );
 
     // Pre-flight check for --suggest-fix
-    let suggest_fix = resolve_suggest_fix(args.suggest_fix, &project_path);
+    let suggest_fix = resolve_suggest_fix(merged.suggest_fix, &project_path);
 
     // Create request using builder pattern
     let include_dependency_info = matches!(merged.format, OutputFormat::Markdown);
@@ -271,6 +271,7 @@ struct MergedConfig {
     ignore_cves: Vec<IgnoreCve>,
     check_license: bool,
     license_policy: Option<LicensePolicy>,
+    suggest_fix: bool,
 }
 
 /// Load a config file from an explicit path or via auto-discovery.
@@ -333,6 +334,7 @@ fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
                     .collect(),
                 check_license: args.check_license,
                 license_policy,
+                suggest_fix: args.suggest_fix,
             };
         }
     };
@@ -430,6 +432,9 @@ fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
         None
     };
 
+    // suggest_fix: CLI flag takes priority over config value
+    let suggest_fix = args.suggest_fix || config.suggest_fix.unwrap_or(false);
+
     MergedConfig {
         format,
         exclude_patterns,
@@ -439,6 +444,7 @@ fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
         ignore_cves,
         check_license,
         license_policy,
+        suggest_fix,
     }
 }
 
@@ -807,6 +813,55 @@ mod tests {
         });
         let result = merge_config(&args, &config);
         assert_eq!(result.cvss_threshold, Some(6.0));
+    }
+
+    // --- suggest_fix merge tests ---
+
+    #[test]
+    fn test_merge_config_suggest_fix_from_config() {
+        // suggest_fix: true in config, no CLI flag → merged value is true
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            suggest_fix: Some(true),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.suggest_fix);
+    }
+
+    #[test]
+    fn test_merge_config_suggest_fix_cli_flag() {
+        // suggest_fix: true via CLI flag (requires --check-cve) → merged value is true
+        let args = Args::parse_from(["uv-sbom", "--check-cve", "--suggest-fix"]);
+        let config = Some(ConfigFile {
+            suggest_fix: Some(true),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.suggest_fix);
+    }
+
+    #[test]
+    fn test_merge_config_suggest_fix_cli_wins_over_config_false() {
+        // suggest_fix: false in config, --suggest-fix CLI flag → CLI wins, merged value is true
+        let args = Args::parse_from(["uv-sbom", "--check-cve", "--suggest-fix"]);
+        let config = Some(ConfigFile {
+            suggest_fix: Some(false),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.suggest_fix);
+    }
+
+    #[test]
+    fn test_merge_config_suggest_fix_default_false() {
+        // No CLI flag, no config → default false
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(!result.suggest_fix);
     }
 
     // --- resolve_suggest_fix tests ---


### PR DESCRIPTION
## Summary
- Add `suggest_fix` field to `ConfigFile` struct so it can be set in `uv-sbom.config.yml`
- Add `suggest_fix: false` commented-out entry to the config template generated by `--init`
- Wire `suggest_fix` through `MergedConfig` with CLI > config > default priority

## Related Issue
Closes #278

## Changes Made
- `src/config.rs`: Add `suggest_fix: Option<bool>` to `ConfigFile` struct and `suggest_fix: false` entry to `CONFIG_TEMPLATE`
- `src/main.rs`: Add `suggest_fix: bool` to `MergedConfig`, handle merge logic in `merge_config()`, pass `merged.suggest_fix` to `resolve_suggest_fix()` instead of raw `args.suggest_fix`
- `src/main.rs`: Add 4 unit tests covering all priority combinations (config only, CLI only, CLI wins over config, default false)

## Test Plan
- [x] `cargo test --all` passes (all 909+ tests pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)