### PR TITLE
feat(application): report progress during --suggest-fix upgrade simulations

### DIFF
--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -375,9 +375,62 @@ where
             return Some(vec![]);
         }
 
+        let unique_dep_count = entries
+            .iter()
+            .flat_map(|e| e.introduced_by())
+            .map(|i| i.package_name())
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        self.progress_reporter.report(&format!(
+            "🔍 Analyzing upgrade paths for {} direct dependenc{}...",
+            unique_dep_count,
+            if unique_dep_count == 1 { "y" } else { "ies" },
+        ));
+
         let simulator = UvLockAdapter::new();
         let recommendations =
             UpgradeAdvisor::advise(&simulator, &entries, &request.project_path).await;
+
+        for rec in &recommendations {
+            match rec {
+                UpgradeRecommendation::Upgradable {
+                    direct_dep_name,
+                    direct_dep_target_version,
+                    transitive_dep_name,
+                    transitive_resolved_version,
+                    vulnerability_id,
+                    ..
+                } => {
+                    self.progress_reporter.report(&format!(
+                        "  ✓ Upgrade {} → {} resolves {} to {} ({})",
+                        direct_dep_name,
+                        direct_dep_target_version,
+                        transitive_dep_name,
+                        transitive_resolved_version,
+                        vulnerability_id,
+                    ));
+                }
+                UpgradeRecommendation::Unresolvable {
+                    direct_dep_name,
+                    reason,
+                    vulnerability_id,
+                } => {
+                    self.progress_reporter.report(&format!(
+                        "  ✗ Cannot resolve via {}: {} ({})",
+                        direct_dep_name, reason, vulnerability_id,
+                    ));
+                }
+                UpgradeRecommendation::SimulationFailed {
+                    direct_dep_name,
+                    error,
+                } => {
+                    self.progress_reporter.report(&format!(
+                        "  ❓ Simulation failed for {}: {}",
+                        direct_dep_name, error,
+                    ));
+                }
+            }
+        }
 
         Some(recommendations)
     }


### PR DESCRIPTION
## Summary

- Add a header progress line before upgrade simulations start, showing the number of unique direct dependencies to analyze
- Print per-recommendation result lines after `UpgradeAdvisor::advise` returns, with distinct `✓` / `✗` / `❓` prefixes for Upgradable / Unresolvable / SimulationFailed variants
- Keep progress reporting in the application layer; domain service (`UpgradeAdvisor`) and adapter (`UvLockAdapter`) remain pure

## Related Issue

Closes #284
Parent feature: #222

## Changes Made

- `src/application/use_cases/generate_sbom/mod.rs`: Added progress reporting in `advise_upgrades_if_requested` — header line counting unique direct deps, followed by per-recommendation result lines

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo test --all` passes (918 tests, 0 failures)

---
Generated with [Claude Code](https://claude.com/claude-code)