### PR TITLE
docs: add product vision and output design principles for AI-driven development

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -561,6 +561,35 @@ The hook handles formatting only. Clippy and tests require `/pre-push` skill.
 - Step 10 quality checks are **mandatory upon coding completion**
 - Code is not considered complete unless all these checks pass
 
+## Output Quality Review
+
+When implementing any feature that affects SBOM output (Markdown or JSON), you MUST
+review the change against `.claude/output-design.md` before committing.
+
+### Checklist
+
+- [ ] No section duplicates information already shown in another section
+- [ ] Summary block is present and accurate
+- [ ] Emoji in headings have a space between emoji and text
+- [ ] Table columns follow the canonical order defined in `output-design.md`
+- [ ] New licenses are normalized through `spdx_license_map.rs` before display
+- [ ] The change does not re-introduce any anti-pattern listed in `output-design.md`
+
+### When to consult `product-vision.md`
+
+Read `.claude/product-vision.md` before implementing any of these:
+
+- A new output section or format
+- A new CLI flag that changes what is displayed
+- A change to how dependencies are grouped or labeled
+- Any feature that adds, removes, or reorders information in the output
+
+When in doubt, ask: "Does this help the reader understand their dependency situation
+faster, reduce the steps needed to act, or reduce noise?" If the answer to all three
+is "no", reconsider whether the change belongs in uv-sbom.
+
+---
+
 ## PR Creation and Review Response Checklist
 
 ### Before Creating a Pull Request

--- a/.claude/output-design.md
+++ b/.claude/output-design.md
@@ -1,0 +1,220 @@
+# Output Design Standards: uv-sbom
+
+This document defines concrete, actionable standards for evaluating and designing
+uv-sbom output. It applies to both Markdown and JSON output formats.
+
+**Before implementing any feature that affects output**, read this document and verify
+your changes against the Anti-Patterns section.
+
+---
+
+## Core Output Principle
+
+Every section of the output must answer one of these questions for the reader:
+
+1. **What do I have?** (inventory: packages, versions, licenses)
+2. **Is there a problem?** (vulnerabilities, license violations)
+3. **What should I do?** (resolution guide, upgrade advisor)
+
+Sections that answer the same question must be **merged**, not duplicated.
+
+---
+
+## Required Document Structure
+
+Markdown output MUST follow this top-to-bottom order:
+
+1. **Document title** — `# Software Bill of Materials (SBOM)`
+2. **Summary block** — Key counts at a glance (packages, vulnerabilities, license violations)
+3. **Direct Dependencies** — Packages explicitly declared in `pyproject.toml`
+4. **Transitive Dependencies** — Grouped by which direct dependency introduces them
+5. **Vulnerability Report** — Only when `--check-cve` is used
+6. **Vulnerability Resolution Guide** — Only for transitive vulnerabilities
+7. **License Compliance Report** — Only when `--check-license` is used
+
+**REMOVED**: `## Component Inventory` section is deprecated. It was a full duplicate
+of Direct + Transitive sections combined. Do **not** re-introduce it.
+
+---
+
+## Summary Block Specification
+
+The summary block MUST appear immediately after the document title.
+It provides a scannable overview before the reader commits to reading detail sections.
+
+### Required format
+
+```markdown
+## Summary
+
+| Item | Count |
+|------|-------|
+| Direct dependencies | 5 |
+| Transitive dependencies | 23 |
+| Vulnerabilities (actionable) | 2 |
+| Vulnerabilities (informational) | 1 |
+| License violations | 0 |
+```
+
+Show only rows that are relevant:
+- Omit vulnerability rows if `--check-cve` was not used.
+- Omit license violation row if `--check-license` was not used.
+
+### Placement rule
+
+The summary block is the **second section** of every Markdown SBOM document.
+No content (except the document title) should appear before it.
+
+---
+
+## Heading and Emoji Formatting Rules
+
+### Emoji in headings
+
+- Always include a **space between emoji and text**: `### ⚠️ Warning` not `### ⚠️Warning`
+- Use emoji only at the H3 level and below; H1 and H2 headings must **not** contain emoji
+- Emoji are for visual scanning aid only; the text must be self-explanatory without them
+
+### Severity emoji mapping (canonical)
+
+| Severity | Emoji |
+|----------|-------|
+| CRITICAL  | 🔴 |
+| HIGH      | 🟠 |
+| MEDIUM    | 🟡 |
+| LOW       | 🟢 |
+| NONE/N/A  | ⚪ |
+
+These must remain **consistent** across all output sections (vulnerability tables,
+resolution guide, upgrade advisor). Do not introduce new emoji for severity levels.
+
+### Heading level conventions
+
+| Section Type | Level |
+|-------------|-------|
+| Document title | H1 (`#`) |
+| Major sections (Summary, Direct Dependencies, etc.) | H2 (`##`) |
+| Subsections (individual packages, severity groups) | H3 (`###`) |
+| Details within a subsection | H4 (`####`) |
+
+---
+
+## Table Design Rules
+
+### Column order for vulnerability tables
+
+Always present columns in this order (omit columns not applicable):
+
+`Package | Version | Fixed Version | CVSS | Severity | CVE ID`
+
+**Rationale**: Readers scan left-to-right. "What package" and "what version I have"
+must come before "how bad is it" (CVSS/Severity) and "where can I learn more" (CVE ID).
+
+**Example**:
+
+```markdown
+| Package | Version | Fixed Version | CVSS | Severity | CVE ID |
+|---------|---------|--------------|------|----------|--------|
+| urllib3 | 1.26.5  | 2.0.7        | 7.5  | HIGH     | CVE-2023-45803 |
+| requests | 2.28.0 | 2.32.0       | 6.1  | MEDIUM   | CVE-2023-32681 |
+```
+
+### Column order for dependency tables
+
+| Package | Version | License |
+|---------|---------|---------|
+
+For transitive dependency tables, group rows by which direct dependency introduces them.
+
+### License display
+
+- Always normalize license strings before display
+- Prefer SPDX identifiers (e.g., `MIT`, `Apache-2.0`, `GPL-3.0-only`) over raw PyPI strings
+- When normalization is impossible, display the raw string with an `*` suffix and add a
+  footnote explaining that the license could not be normalized
+- Normalization is performed via `spdx_license_map.rs`
+
+**Example of inconsistent raw strings that MUST be normalized**:
+
+| Raw PyPI String | Normalized SPDX |
+|----------------|----------------|
+| `MIT` | `MIT` |
+| `MIT License` | `MIT` |
+| `MIT license` | `MIT` |
+| `Apache Software License` | `Apache-2.0` |
+| `BSD License` | `BSD-3-Clause` (if verifiable) |
+
+---
+
+## Anti-Patterns
+
+The following patterns existed in earlier versions and must **NOT** be reintroduced.
+
+### ❌ Duplicated inventory sections
+
+**Problem**: Having both `## Component Inventory` (all packages) and separate
+`## Direct Dependencies` / `## Transitive Dependencies` sections causes readers
+to see the same package listed 2–3 times.
+
+**Where this existed**: `render_components()` and `render_dependencies()` in
+`markdown_formatter.rs` both output package lists.
+
+**Rule**: Each package must appear **exactly once** in the inventory portion of the document.
+Use `## Direct Dependencies` and `## Transitive Dependencies` as the only inventory sections.
+
+---
+
+### ❌ Missing top-level summary
+
+**Problem**: Without a summary block, readers must scroll through the entire document
+to understand the overall picture (e.g., "do I have any vulnerabilities?").
+
+**Where this existed**: `render_header()` in `markdown_formatter.rs` — the header only
+renders project metadata, not statistics.
+
+**Rule**: Always render the summary block as the second section of the document,
+immediately after the document title (`#` heading).
+
+---
+
+### ❌ Emoji adjacent to text without space
+
+**Problem**: `### ⚠️Warning` renders poorly in some Markdown viewers and is hard to scan.
+
+**Where this existed**: `render_actionable_vulnerabilities()` and
+`render_informational_vulnerabilities()` in `markdown_formatter.rs`.
+
+**Rule**: Always write `### ⚠️ Warning` with a space between the emoji and the text.
+Apply this rule to ALL emoji in headings, not just warning icons.
+
+---
+
+### ❌ Raw inconsistent license strings
+
+**Problem**: PyPI returns inconsistent license strings (`MIT`, `MIT License`, `MIT license`,
+`Apache Software License`). Displaying these raw strings makes the license column noisy,
+unprofessional, and hard to use for compliance review.
+
+**Where this existed**: `render_components()` in `markdown_formatter.rs` — the license
+field is rendered directly from the PyPI API response.
+
+**Rule**: Normalize through `spdx_license_map.rs` before display. Fall back to the
+raw string with an `*` suffix only if no mapping exists.
+
+---
+
+## Checklist for Output Feature Implementation
+
+When implementing a feature that affects SBOM output (Markdown or JSON), verify:
+
+- [ ] No section duplicates information already shown in another section
+- [ ] Summary block is present and accurate (all counts reflect the actual output)
+- [ ] Emoji in headings have a space between emoji and text
+- [ ] Table columns follow the canonical order defined in this document
+- [ ] New licenses are normalized through `spdx_license_map.rs` before display
+- [ ] The change does not re-introduce any anti-pattern listed above
+- [ ] H1 and H2 headings contain no emoji
+
+---
+
+Last Updated: 2026-03-07 (Issue #283)

--- a/.claude/product-vision.md
+++ b/.claude/product-vision.md
@@ -1,0 +1,133 @@
+# Product Vision: uv-sbom
+
+This document provides the "why" behind every design decision in uv-sbom.
+It is intended to be read by AI agents and developers before implementing any feature
+that affects output format, structure, or user experience.
+
+---
+
+## Project Identity
+
+uv-sbom's core differentiator is **human readability**.
+
+Unlike general-purpose SBOM tools (Syft, cyclonedx-python, pip-audit) that prioritize
+machine-readable formats and comprehensive coverage, uv-sbom is designed to produce output
+that a developer or security engineer can read, understand, and act on immediately — without
+needing a separate viewer or parser.
+
+The name reflects this focus: it is built specifically for **uv-managed Python projects**,
+with deep understanding of the `uv.lock` format and uv's dependency resolution model.
+
+---
+
+## Target Users
+
+### 1. Python Developers using uv
+
+**Goal**: Quickly understand what packages their project depends on, and whether any
+license or vulnerability issues exist.
+
+**What they need**:
+- A clear, readable summary of direct and transitive dependencies
+- License information in a normalized, consistent format
+- A way to quickly check if anything needs attention before shipping
+
+**What they do NOT need**:
+- Machine-readable SBOM formats (they use human-readable Markdown)
+- Exhaustive lists of every installed package (they care about what they explicitly chose)
+
+### 2. Security Engineers reviewing Python projects
+
+**Goal**: Identify vulnerabilities in a project's dependency tree and determine what
+action to take.
+
+**What they need**:
+- A prioritized list of vulnerabilities (not just a dump)
+- Actionable guidance: which package to upgrade, to what version
+- Clear distinction between direct and transitive vulnerabilities
+
+**What they do NOT need**:
+- Raw CVE data without context
+- Identical information repeated across multiple sections
+
+### 3. Compliance Reviewers checking license compatibility
+
+**Goal**: Verify that all dependencies use licenses compatible with the project's
+license policy.
+
+**What they need**:
+- Normalized SPDX license identifiers (not raw PyPI strings)
+- A clear list of which packages have which licenses
+- Immediate identification of potentially incompatible licenses
+
+---
+
+## Competitive Positioning
+
+| Aspect | uv-sbom | cyclonedx-python | pip-audit | Syft |
+|--------|---------|-----------------|-----------|------|
+| Primary format | Human-readable Markdown | CycloneDX JSON | Terminal text | Multiple formats |
+| Data source | `uv.lock` (locked deps) | `.venv` (all installed) | pip/requirements | Installed env |
+| Actionability | Resolution Guide + Upgrade Advisor | None | None | None |
+| uv support | Native | Not supported (as of v7.2.1) | Indirect | Limited |
+| Target audience | Developers & security engineers | Security toolchains | Quick CLI scans | Enterprise SBOM pipelines |
+
+### What we intentionally do differently
+
+**vs. cyclonedx-python**: We produce Markdown first, machine-readable JSON second.
+A developer running `uv-sbom` should be able to read the output without a viewer.
+
+**vs. pip-audit**: We read from `uv.lock`, not the installed environment. This means
+we report what the project *declares*, not what happens to be installed. We also
+provide upgrade paths, not just vulnerability lists.
+
+**vs. Syft**: We are purpose-built for uv. We understand uv's lock file format and
+can accurately distinguish direct from transitive dependencies. Syft treats all
+installed packages as equal.
+
+---
+
+## Feature Prioritization Principle
+
+When evaluating a proposed feature, ask:
+
+1. **Does it help the reader understand their dependency situation faster?**
+   - Example: A summary block at the top answers this — readers get the overall picture immediately.
+
+2. **Does it reduce the steps needed to act on the information?**
+   - Example: The Upgrade Advisor shows `requests 2.28.0 → 2.32.0` — readers don't need
+     to look up the fixed version themselves.
+
+3. **Does it reduce noise (irrelevant data for the reader's use case)?**
+   - Example: Showing only transitive vulnerabilities in the Resolution Guide (not direct ones,
+     which the user can upgrade directly) reduces noise.
+
+If the answer to all three is "no", reconsider whether the feature belongs in uv-sbom.
+
+### Anti-features to avoid
+
+- **Completeness for its own sake**: Adding every possible SBOM field when readers don't
+  need it (e.g., package hashes, build timestamps in Markdown output).
+- **Duplication**: Showing the same package in three different sections (Component Inventory,
+  Direct Dependencies, Transitive Dependencies) to appear more comprehensive.
+- **Raw data dumps**: Exposing internal data structures or unprocessed API responses
+  (e.g., raw PyPI license strings) instead of normalized, reader-friendly output.
+
+---
+
+## Design Philosophy: "Actionable over Exhaustive"
+
+uv-sbom prioritizes actionability over exhaustiveness. This means:
+
+- If a reader sees a vulnerability, they should also see what to do about it.
+- If a reader sees a license, it should be in a format they recognize (SPDX), not
+  whatever string PyPI happened to return.
+- If a reader sees a dependency list, it should be organized by relationship
+  (direct vs. transitive), not alphabetically dumped.
+
+When in doubt, ask: **"What does the reader do next?"** The output should make that
+next step obvious.
+
+---
+
+Last Updated: 2026-03-07 (Issue #283)

--- a/.claude/project-context.md
+++ b/.claude/project-context.md
@@ -165,6 +165,8 @@ The tool supports configurable vulnerability thresholds for CI/CD integration:
 - `README.md`: User guide
 - `.claude/instructions.md`: Instructions for Claude Code
 - `.claude/skills/`: Agent Skills for Git workflows (`/issue`, `/pr`, `/commit`, `/pre-push`)
+- `.claude/product-vision.md`: Product vision and competitive positioning
+- `.claude/output-design.md`: Output structure rules, anti-patterns, and formatting standards
 
 ### External References
 - [CycloneDX 1.6 Specification](https://cyclonedx.org/docs/1.6/)


### PR DESCRIPTION
## Summary

- Add `.claude/product-vision.md` documenting project identity, target users, competitive positioning, and feature prioritization principles
- Add `.claude/output-design.md` defining output structure rules, summary block spec, heading/emoji formatting, table design rules, and anti-patterns to avoid
- Update `.claude/instructions.md` with a new `## Output Quality Review` section and checklist for output-affecting changes
- Update `.claude/project-context.md` Resources section to reference the two new context files

## Related Issue

Closes #283

## Changes Made

- **New**: `.claude/product-vision.md` — "why" behind every design decision; documents the core differentiator (human readability), three target user personas, competitive positioning vs. Syft/cyclonedx-python/pip-audit, and the feature prioritization principle
- **New**: `.claude/output-design.md` — concrete output standards including required document structure (7-section order), summary block specification, canonical emoji/severity mapping, table column order for vulnerability and dependency tables, license normalization rules, and 4 documented anti-patterns with file-level references
- **Updated**: `.claude/instructions.md` — new `## Output Quality Review` section with a 6-item pre-commit checklist and guidance on when to consult `product-vision.md`
- **Updated**: `.claude/project-context.md` — two new entries in the `## Resources` section

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Documentation-only change: no code changes required

---
Generated with [Claude Code](https://claude.com/claude-code)