### PR TITLE
feat(cli): add --lang flag and propagate Locale through pipeline

### DIFF
--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -1,4 +1,5 @@
 use crate::config::IgnoreCve;
+use crate::i18n::Locale;
 use crate::sbom_generation::domain::license_policy::LicensePolicy;
 use crate::sbom_generation::domain::vulnerability::Severity;
 use crate::shared::error::SbomError;
@@ -35,6 +36,8 @@ pub struct SbomRequest {
     /// Only meaningful when `check_cve` is true.
     #[allow(dead_code)] // Will be used by upgrade advisor use case
     pub suggest_fix: bool,
+    /// Output locale for human-readable formats
+    pub locale: Locale,
 }
 
 impl SbomRequest {
@@ -95,6 +98,7 @@ pub struct SbomRequestBuilder {
     check_license: bool,
     license_policy: Option<LicensePolicy>,
     suggest_fix: bool,
+    locale: Locale,
 }
 
 impl SbomRequestBuilder {
@@ -121,6 +125,7 @@ impl SbomRequestBuilder {
             check_license: false,
             license_policy: None,
             suggest_fix: false,
+            locale: Locale::default(),
         }
     }
 
@@ -219,6 +224,12 @@ impl SbomRequestBuilder {
         self
     }
 
+    /// Sets the output locale for human-readable formats.
+    pub fn locale(mut self, locale: Locale) -> Self {
+        self.locale = locale;
+        self
+    }
+
     /// Builds the SbomRequest, validating that all required fields are set.
     ///
     /// # Errors
@@ -241,6 +252,7 @@ impl SbomRequestBuilder {
             check_license: self.check_license,
             license_policy: self.license_policy,
             suggest_fix: self.suggest_fix,
+            locale: self.locale,
         })
     }
 }

--- a/src/application/factories/formatter_factory.rs
+++ b/src/application/factories/formatter_factory.rs
@@ -1,5 +1,6 @@
 use crate::adapters::outbound::formatters::{CycloneDxFormatter, MarkdownFormatter};
 use crate::application::dto::OutputFormat;
+use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::SbomFormatter;
 use std::collections::HashSet;
 
@@ -18,6 +19,7 @@ impl FormatterFactory {
     pub fn create(
         format: OutputFormat,
         verified_packages: Option<HashSet<String>>,
+        _locale: Locale,
     ) -> Box<dyn SbomFormatter> {
         match format {
             OutputFormat::Json => Box::new(CycloneDxFormatter::new()),
@@ -28,11 +30,12 @@ impl FormatterFactory {
         }
     }
 
-    /// Returns the progress message for the specified output format
-    pub fn progress_message(format: OutputFormat) -> &'static str {
+    /// Returns the locale-aware progress message for the specified output format
+    pub fn progress_message(format: OutputFormat, locale: Locale) -> &'static str {
+        let msgs = Messages::for_locale(locale);
         match format {
-            OutputFormat::Json => "📝 Generating CycloneDX JSON format output...",
-            OutputFormat::Markdown => "📝 Generating Markdown format output...",
+            OutputFormat::Json => msgs.progress_generating_json,
+            OutputFormat::Markdown => msgs.progress_generating_markdown,
         }
     }
 }
@@ -43,33 +46,46 @@ mod tests {
 
     #[test]
     fn test_create_json_formatter() {
-        let formatter = FormatterFactory::create(OutputFormat::Json, None);
+        let formatter = FormatterFactory::create(OutputFormat::Json, None, Locale::En);
         assert!(std::mem::size_of_val(&formatter) > 0);
     }
 
     #[test]
     fn test_create_markdown_formatter() {
-        let formatter = FormatterFactory::create(OutputFormat::Markdown, None);
+        let formatter = FormatterFactory::create(OutputFormat::Markdown, None, Locale::En);
         assert!(std::mem::size_of_val(&formatter) > 0);
     }
 
     #[test]
-    fn test_progress_message_json() {
-        let message = FormatterFactory::progress_message(OutputFormat::Json);
+    fn test_progress_message_json_en() {
+        let message = FormatterFactory::progress_message(OutputFormat::Json, Locale::En);
         assert_eq!(message, "📝 Generating CycloneDX JSON format output...");
     }
 
     #[test]
-    fn test_progress_message_markdown() {
-        let message = FormatterFactory::progress_message(OutputFormat::Markdown);
+    fn test_progress_message_markdown_en() {
+        let message = FormatterFactory::progress_message(OutputFormat::Markdown, Locale::En);
         assert_eq!(message, "📝 Generating Markdown format output...");
+    }
+
+    #[test]
+    fn test_progress_message_json_ja() {
+        let message = FormatterFactory::progress_message(OutputFormat::Json, Locale::Ja);
+        assert_eq!(message, "📝 CycloneDX JSON形式で出力を生成中...");
+    }
+
+    #[test]
+    fn test_progress_message_markdown_ja() {
+        let message = FormatterFactory::progress_message(OutputFormat::Markdown, Locale::Ja);
+        assert_eq!(message, "📝 Markdown形式で出力を生成中...");
     }
 
     #[test]
     fn test_create_with_verified_packages() {
         let mut verified = HashSet::new();
         verified.insert("requests".to_string());
-        let formatter = FormatterFactory::create(OutputFormat::Markdown, Some(verified));
+        let formatter =
+            FormatterFactory::create(OutputFormat::Markdown, Some(verified), Locale::En);
         assert!(std::mem::size_of_val(&formatter) > 0);
     }
 
@@ -77,7 +93,7 @@ mod tests {
     fn test_create_json_ignores_verified_packages() {
         let mut verified = HashSet::new();
         verified.insert("requests".to_string());
-        let formatter = FormatterFactory::create(OutputFormat::Json, Some(verified));
+        let formatter = FormatterFactory::create(OutputFormat::Json, Some(verified), Locale::En);
         assert!(std::mem::size_of_val(&formatter) > 0);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 use crate::application::dto::OutputFormat;
+use crate::i18n::Locale;
 use crate::sbom_generation::domain::vulnerability::Severity;
 
 /// Generate SBOMs for Python projects managed by uv
@@ -78,6 +79,15 @@ pub struct Args {
     /// Generate a uv-sbom.config.yml template file
     #[arg(long)]
     pub init: bool,
+
+    /// Output language for human-readable formats: en (default) or ja
+    #[arg(long, default_value = "en", value_parser = parse_lang)]
+    pub lang: Locale,
+}
+
+fn parse_lang(s: &str) -> Result<Locale, String> {
+    Locale::from_str(s)
+        .ok_or_else(|| format!("Invalid language: '{}'. Supported languages: en, ja", s))
 }
 
 fn parse_severity_threshold(s: &str) -> Result<Severity, String> {
@@ -107,6 +117,27 @@ fn parse_cvss_threshold(s: &str) -> Result<f32, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_lang_valid() {
+        assert_eq!(parse_lang("en").unwrap(), Locale::En);
+        assert_eq!(parse_lang("ja").unwrap(), Locale::Ja);
+    }
+
+    #[test]
+    fn test_parse_lang_invalid() {
+        let result = parse_lang("fr");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Invalid language: 'fr'. Supported languages: en, ja"));
+
+        let result = parse_lang("EN");
+        assert!(result.is_err());
+
+        let result = parse_lang("");
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_parse_severity_threshold_valid() {

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -30,6 +30,7 @@ impl Locale {
 }
 
 /// All translatable strings used in formatted output.
+#[allow(dead_code)] // Fields will be used by formatter implementations in subsequent PRs
 pub struct Messages {
     // Section headers
     pub section_sbom_report: &'static str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod adapters;
 mod application;
 mod cli;
+mod i18n;
 mod ports;
 mod sbom_generation;
 mod shared;
@@ -175,7 +176,10 @@ async fn run(args: Args) -> Result<bool> {
         .check_license(merged.check_license)
         .license_policy(merged.license_policy)
         .suggest_fix(suggest_fix)
+        .locale(args.lang)
         .build()?;
+
+    let locale = request.locale;
 
     // Execute use case
     let response = use_case.execute(request).await?;
@@ -186,7 +190,10 @@ async fn run(args: Args) -> Result<bool> {
     }
 
     // Display progress message
-    eprintln!("{}", FormatterFactory::progress_message(merged.format));
+    eprintln!(
+        "{}",
+        FormatterFactory::progress_message(merged.format, locale)
+    );
 
     // Determine project component for CycloneDX metadata
     let project_reader = FileSystemReader::new();
@@ -230,7 +237,7 @@ async fn run(args: Args) -> Result<bool> {
     };
 
     // Create formatter using factory with optional verified packages
-    let formatter = FormatterFactory::create(merged.format, verified_packages);
+    let formatter = FormatterFactory::create(merged.format, verified_packages, locale);
     let formatted_output = formatter.format(&read_model)?;
 
     // Create presenter using factory


### PR DESCRIPTION
## Summary
- Add `--lang <LANG>` CLI option (en/ja) to select output language
- Wire `Locale` through `SbomRequest`, `main.rs`, and `FormatterFactory`
- Add locale-aware progress messages via `Messages::for_locale()`

## Related Issue
Closes #293
Depends on #292 (includes #292 changes: Locale enum and Messages struct)

## Changes Made
- `src/cli.rs`: Add `--lang` arg with `parse_lang()` value parser; unit tests for valid/invalid inputs
- `src/application/dto/sbom_request.rs`: Add `locale: Locale` field and `.locale()` builder method with default `Locale::En`
- `src/application/factories/formatter_factory.rs`: Update `create()` and `progress_message()` to accept `Locale` parameter; locale-aware progress message output
- `src/main.rs`: Declare `mod i18n`; pass `args.lang` to request builder; propagate locale to `FormatterFactory`
- `src/i18n/mod.rs`: Add `Locale` enum, `Messages` struct with EN/JA translations, and `#[allow(dead_code)]` for fields used in subsequent PRs

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `uv-sbom --lang en` accepted (no regression)
- [x] `uv-sbom --lang ja` accepted without error
- [x] `uv-sbom --lang fr` produces clear error: `Invalid language: 'fr'. Supported languages: en, ja`

---
Generated with [Claude Code](https://claude.com/claude-code)