### PR TITLE
chore(release): prepare v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-03-15
+
+### Breaking Changes
+- **CVE check is now enabled by default**: Previously opt-in via `--check-cve`; now opt-out via `--no-check-cve` (#307)
+
+### Added
+
+#### Internationalization (--lang)
+- **`--lang` CLI flag**: Switch output language between English (`en`) and Japanese (`ja`) (#293)
+- **`Locale` enum and `Messages` struct**: Foundation for multilingual support (#292)
+- **Localized `MarkdownFormatter`**: All Markdown output respects the selected locale (#294, #309)
+- **Localized stderr progress and warning messages**: Progress output in `GenerateSbomUseCase` respects locale (#295, #308)
+- **Localized transitive deps sub-header and vulnerability summary line** (#318)
+- **E2E tests for `--lang` option** (#306, #319)
+- **Integration tests and README docs for `--lang` option** (#296, #303)
+
+### Changed
+- **`--no-check-cve` flag**: Added as opt-out replacement; CVE check runs by default (#307)
+
 ## [1.3.0] - 2026-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "1.3.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "1.3.0"
+version = "2.0.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "1.3.0"
+UV_SBOM_VERSION = "2.0.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v2.0.0
- Update version numbers in all required files
- Update CHANGELOG with release date and breaking changes

## Version Files Updated
- `Cargo.toml`: version = "2.0.0"
- `python-wrapper/pyproject.toml`: version = "2.0.0"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "2.0.0"

## CHANGELOG
- Converted [Unreleased] to [2.0.0] - 2026-03-15
- Added empty [Unreleased] section
- Documented breaking changes (CVE check enabled by default) and i18n additions

## Why v2.0.0 (Major Version Bump)
- **Breaking**: CVE check is now enabled by default; users must now pass `--no-check-cve` to skip
- **Major feature**: Full i18n support via `--lang` flag (ja/en)

## Test Plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] All version strings are consistent (2.0.0)

## Post-Merge Manual Steps
After merging this PR into `develop`:
1. Open a PR: `develop` → `main`
2. Merge the PR to main
3. Create tag: `git tag v2.0.0`
4. Push tag: `git push origin v2.0.0`
5. Verify CI release workflow completes successfully

Closes #320

---
Generated with [Claude Code](https://claude.com/claude-code)