### PR TITLE
refactor(adapters): extract data helpers to helpers.rs [#305-4/7]

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/helpers.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/helpers.rs
@@ -1,1 +1,117 @@
+use crate::application::read_models::{
+    IntroducedByView, UpgradeEntryView, UpgradeRecommendationView, VulnerabilityView,
+};
+use crate::i18n::Messages;
 
+/// Counts unique affected packages from a list of vulnerability views
+pub(super) fn count_unique_packages(vulns: &[VulnerabilityView]) -> usize {
+    let unique: std::collections::HashSet<&str> = vulns
+        .iter()
+        .map(|v| v.affected_component.as_str())
+        .collect();
+    unique.len().max(1)
+}
+
+/// Finds the recommended action text for a resolution entry from upgrade recommendations.
+///
+/// Matches by `vulnerability_id` for `Upgradable`/`Unresolvable` variants, and falls back
+/// to matching by direct dependency name for `SimulationFailed`.
+pub(super) fn find_upgrade_action(
+    messages: &'static Messages,
+    recommendations: &UpgradeRecommendationView,
+    vulnerability_id: &str,
+    introduced_by: &[IntroducedByView],
+) -> String {
+    for rec in &recommendations.entries {
+        match rec {
+            UpgradeEntryView::Upgradable {
+                direct_dep,
+                target_version,
+                transitive_dep,
+                resolved_version,
+                vulnerability_id: vid,
+                ..
+            } if vid == vulnerability_id => {
+                return Messages::format(
+                    messages.action_upgrade,
+                    &[direct_dep, target_version, transitive_dep, resolved_version],
+                );
+            }
+            UpgradeEntryView::Unresolvable {
+                reason,
+                vulnerability_id: vid,
+                ..
+            } if vid == vulnerability_id => {
+                return Messages::format(messages.action_cannot_resolve, &[reason]);
+            }
+            _ => {}
+        }
+    }
+
+    let introduced_names: Vec<&str> = introduced_by
+        .iter()
+        .map(|ib| ib.package_name.as_str())
+        .collect();
+    for rec in &recommendations.entries {
+        if let UpgradeEntryView::SimulationFailed { direct_dep, error } = rec {
+            if introduced_names.contains(&direct_dep.as_str()) {
+                return Messages::format(messages.action_could_not_analyze, &[error]);
+            }
+        }
+    }
+
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::{SeverityView, VulnerabilityView};
+
+    #[test]
+    fn test_count_unique_packages() {
+        let vulns = vec![
+            VulnerabilityView {
+                bom_ref: "v1".to_string(),
+                id: "CVE-1".to_string(),
+                affected_component: "pkg:pypi/a@1.0".to_string(),
+                affected_component_name: "a".to_string(),
+                affected_version: "1.0".to_string(),
+                cvss_score: None,
+                cvss_vector: None,
+                severity: SeverityView::High,
+                fixed_version: None,
+                description: None,
+                source_url: None,
+            },
+            VulnerabilityView {
+                bom_ref: "v2".to_string(),
+                id: "CVE-2".to_string(),
+                affected_component: "pkg:pypi/a@1.0".to_string(),
+                affected_component_name: "a".to_string(),
+                affected_version: "1.0".to_string(),
+                cvss_score: None,
+                cvss_vector: None,
+                severity: SeverityView::Medium,
+                fixed_version: None,
+                description: None,
+                source_url: None,
+            },
+            VulnerabilityView {
+                bom_ref: "v3".to_string(),
+                id: "CVE-3".to_string(),
+                affected_component: "pkg:pypi/b@2.0".to_string(),
+                affected_component_name: "b".to_string(),
+                affected_version: "2.0".to_string(),
+                cvss_score: None,
+                cvss_vector: None,
+                severity: SeverityView::Low,
+                fixed_version: None,
+                description: None,
+                source_url: None,
+            },
+        ];
+
+        assert_eq!(count_unique_packages(&vulns), 2);
+    }
+}

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -5,9 +5,8 @@ mod table;
 mod vuln_render;
 
 use crate::application::read_models::{
-    ComponentView, DependencyView, IntroducedByView, LicenseComplianceView, ResolutionGuideView,
-    SbomReadModel, UpgradeEntryView, UpgradeRecommendationView, VulnerabilityReportView,
-    VulnerabilitySummary, VulnerabilityView,
+    ComponentView, DependencyView, LicenseComplianceView, ResolutionGuideView, SbomReadModel,
+    UpgradeRecommendationView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
 };
 use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::SbomFormatter;
@@ -239,7 +238,7 @@ impl MarkdownFormatter {
     /// Renders the warning section for actionable vulnerabilities
     fn render_actionable_vulnerabilities(&self, output: &mut String, vulns: &[VulnerabilityView]) {
         let total_vulns = vulns.len();
-        let unique_packages = Self::count_unique_packages(vulns);
+        let unique_packages = helpers::count_unique_packages(vulns);
         let vuln_word = if total_vulns == 1 {
             self.messages.label_vulnerability_singular
         } else {
@@ -282,7 +281,7 @@ impl MarkdownFormatter {
         vulns: &[VulnerabilityView],
     ) {
         let total_vulns = vulns.len();
-        let unique_packages = Self::count_unique_packages(vulns);
+        let unique_packages = helpers::count_unique_packages(vulns);
         let vuln_word = if total_vulns == 1 {
             self.messages.label_vulnerability_singular
         } else {
@@ -314,15 +313,6 @@ impl MarkdownFormatter {
         for vuln in sorted_vulns {
             self.render_vulnerability_row(output, vuln);
         }
-    }
-
-    /// Counts unique affected packages from a list of vulnerability views
-    fn count_unique_packages(vulns: &[VulnerabilityView]) -> usize {
-        let unique: std::collections::HashSet<&str> = vulns
-            .iter()
-            .map(|v| v.affected_component.as_str())
-            .collect();
-        unique.len().max(1)
     }
 
     /// Renders the license compliance section
@@ -486,7 +476,7 @@ impl MarkdownFormatter {
                 .join(", ");
 
             if let Some(recommendations) = upgrade_recommendations {
-                let action = Self::find_upgrade_action(
+                let action = helpers::find_upgrade_action(
                     self.messages,
                     recommendations,
                     &entry.vulnerability_id,
@@ -517,57 +507,6 @@ impl MarkdownFormatter {
             }
         }
         output.push('\n');
-    }
-
-    /// Finds the recommended action text for a resolution entry from upgrade recommendations.
-    ///
-    /// Matches by `vulnerability_id` for `Upgradable`/`Unresolvable` variants, and falls back
-    /// to matching by direct dependency name for `SimulationFailed`.
-    fn find_upgrade_action(
-        messages: &'static Messages,
-        recommendations: &UpgradeRecommendationView,
-        vulnerability_id: &str,
-        introduced_by: &[IntroducedByView],
-    ) -> String {
-        for rec in &recommendations.entries {
-            match rec {
-                UpgradeEntryView::Upgradable {
-                    direct_dep,
-                    target_version,
-                    transitive_dep,
-                    resolved_version,
-                    vulnerability_id: vid,
-                    ..
-                } if vid == vulnerability_id => {
-                    return Messages::format(
-                        messages.action_upgrade,
-                        &[direct_dep, target_version, transitive_dep, resolved_version],
-                    );
-                }
-                UpgradeEntryView::Unresolvable {
-                    reason,
-                    vulnerability_id: vid,
-                    ..
-                } if vid == vulnerability_id => {
-                    return Messages::format(messages.action_cannot_resolve, &[reason]);
-                }
-                _ => {}
-            }
-        }
-
-        let introduced_names: Vec<&str> = introduced_by
-            .iter()
-            .map(|ib| ib.package_name.as_str())
-            .collect();
-        for rec in &recommendations.entries {
-            if let UpgradeEntryView::SimulationFailed { direct_dep, error } = rec {
-                if introduced_names.contains(&direct_dep.as_str()) {
-                    return Messages::format(messages.action_could_not_analyze, &[error]);
-                }
-            }
-        }
-
-        String::new()
     }
 
     /// Renders a single vulnerability row
@@ -1007,53 +946,6 @@ mod tests {
         formatter.render_actionable_vulnerabilities(&mut output, &vulns);
 
         assert!(output.contains("### ⚠️Warning Found 2 vulnerabilities in 2 packages."));
-    }
-
-    #[test]
-    fn test_count_unique_packages() {
-        let vulns = vec![
-            VulnerabilityView {
-                bom_ref: "v1".to_string(),
-                id: "CVE-1".to_string(),
-                affected_component: "pkg:pypi/a@1.0".to_string(),
-                affected_component_name: "a".to_string(),
-                affected_version: "1.0".to_string(),
-                cvss_score: None,
-                cvss_vector: None,
-                severity: SeverityView::High,
-                fixed_version: None,
-                description: None,
-                source_url: None,
-            },
-            VulnerabilityView {
-                bom_ref: "v2".to_string(),
-                id: "CVE-2".to_string(),
-                affected_component: "pkg:pypi/a@1.0".to_string(),
-                affected_component_name: "a".to_string(),
-                affected_version: "1.0".to_string(),
-                cvss_score: None,
-                cvss_vector: None,
-                severity: SeverityView::Medium,
-                fixed_version: None,
-                description: None,
-                source_url: None,
-            },
-            VulnerabilityView {
-                bom_ref: "v3".to_string(),
-                id: "CVE-3".to_string(),
-                affected_component: "pkg:pypi/b@2.0".to_string(),
-                affected_component_name: "b".to_string(),
-                affected_version: "2.0".to_string(),
-                cvss_score: None,
-                cvss_vector: None,
-                severity: SeverityView::Low,
-                fixed_version: None,
-                description: None,
-                source_url: None,
-            },
-        ];
-
-        assert_eq!(MarkdownFormatter::count_unique_packages(&vulns), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extract `count_unique_packages` and `find_upgrade_action` as `pub(super)` free functions into `helpers.rs`
- Move `test_count_unique_packages` test to `helpers.rs`
- Update `mod.rs` call sites to use `helpers::` prefix and remove now-unused imports

## Related Issue
Closes #326

## Changes Made
- `helpers.rs`: Added `count_unique_packages`, `find_upgrade_action`, and `test_count_unique_packages`
- `mod.rs`: Replaced `Self::count_unique_packages` → `helpers::count_unique_packages` (2 sites)
- `mod.rs`: Replaced `Self::find_upgrade_action` → `helpers::find_upgrade_action`
- `mod.rs`: Removed extracted method definitions and test
- `mod.rs`: Removed unused `IntroducedByView` and `UpgradeEntryView` from top-level imports

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)