### PR TITLE
fix(deps): update aws-lc-sys to 0.39.0 to fix GHSA-394x-vwmw-crm3 and GHSA-9f94-5g5w-gf6r

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary

- Update `aws-lc-sys` from v0.38.0 to v0.39.0 (via `aws-lc-rs` v1.16.1 → v1.16.2)
- Fixes two high-severity vulnerabilities in certificate validation logic

## Security Fix

### Advisory 1: GHSA-394x-vwmw-crm3
- **Package**: aws-lc-sys
- **Severity**: High
- **Fixed Version**: 0.39.0
- **Summary**: X.509 Name Constraints Bypass via Wildcard/Unicode CN — a logic error in `cn2dnsid` allows wildcard or raw UTF-8 Unicode CN values to bypass name constraints enforcement while still being accepted by `X509_check_host`.

### Advisory 2: GHSA-9f94-5g5w-gf6r
- **Package**: aws-lc-sys
- **Severity**: High
- **Fixed Version**: 0.39.0
- **Summary**: CRL Distribution Point Scope Check Logic Error — a logic error in CRL distribution point matching allows a revoked certificate to bypass revocation checks when using partitioned CRLs with IDP extensions.

## Changes Made

- Updated `Cargo.lock`: `aws-lc-rs` v1.16.1 → v1.16.2, `aws-lc-sys` v0.38.0 → v0.39.0

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (1046 tests, 0 failures)

---
Generated with [Claude Code](https://claude.com/claude-code)