### PR TITLE
chore(release): prepare v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-03-21
+
+### Security
+- Updated `aws-lc-sys` to 0.39.0 to fix GHSA-394x-vwmw-crm3 and GHSA-9f94-5g5w-gf6r
+
 ## [2.0.0] - 2026-03-15
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.0.0"
+UV_SBOM_VERSION = "2.0.1"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v2.0.1 (security patch)
- Update version numbers in all required files
- Update CHANGELOG with release date and security fixes

## Version Files Updated
- `Cargo.toml`: version = "2.0.1"
- `python-wrapper/pyproject.toml`: version = "2.0.1"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "2.0.1"

## CHANGELOG
- Added [2.0.1] - 2026-03-21 entry with security fixes
- Kept empty [Unreleased] section above

## Security Fixes
- **GHSA-394x-vwmw-crm3**: Fixed by updating `aws-lc-sys` to 0.39.0
- **GHSA-9f94-5g5w-gf6r**: Fixed by updating `aws-lc-sys` to 0.39.0

## Test Plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] All version strings are consistent

## Post-Merge Manual Steps
After merging this PR into `develop`:
1. Open a PR: `develop` → `main`
   ```
   gh pr create --base main --head develop \
     --title "chore(release): v2.0.1" \
     --body "Merge release v2.0.1 from develop into main."
   ```
2. Merge the develop → main PR
3. Create and push the tag:
   ```
   git checkout main
   git pull origin main
   git tag v2.0.1
   git push origin v2.0.1
   ```
4. Verify the release:
   - Check GitHub Actions release workflow
   - Verify GitHub Release was created
   - Check crates.io publication
   - Check PyPI publication

Closes #348

---
Generated with [Claude Code](https://claude.com/claude-code)