### PR TITLE
docs: add Architecture Overview to CLAUDE.md and conditional update step to implement skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,3 +55,51 @@ When updating README.md, check if the following files also need updates:
   - Basic usage examples
   - New user-facing features (brief mention)
   - Version/badge updates
+
+## Architecture Overview
+
+### Design Pattern
+Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
+
+### Module Structure
+
+| Path | Responsibility |
+|------|----------------|
+| `src/cli/` | CLI entrypoint, argument parsing, config resolution |
+| `src/cli/config_resolver.rs` | Merges CLI args / env vars / config file into `MergedConfig` |
+| `src/application/` | Use cases, DTOs, factories, read models |
+| `src/sbom_generation/` | Pure domain logic (no I/O dependencies) |
+| `src/ports/` | Trait definitions for infrastructure (inbound/outbound) |
+| `src/ports/inbound/` | Inbound port traits (e.g. use case interfaces) |
+| `src/ports/outbound/` | Outbound port traits (e.g. repository, network interfaces) |
+| `src/adapters/inbound/` | Inbound adapter implementations |
+| `src/adapters/outbound/network/` | PyPI and OSV HTTP clients |
+| `src/adapters/outbound/formatters/` | CycloneDX and Markdown output formatters |
+| `src/adapters/outbound/filesystem/` | File read/write adapters |
+| `src/adapters/outbound/uv/` | uv.lock file parsing |
+| `src/adapters/outbound/console/` | Console/progress reporter adapter |
+| `src/shared/` | Common error types and utilities |
+| `src/config.rs` | `ConfigFile` struct (deserialized from TOML config) |
+| `src/i18n/` | Locale and message catalog |
+
+### Key Types
+
+| Type | Location | Role |
+|------|----------|------|
+| `MergedConfig` | `src/cli/config_resolver.rs` | Final resolved config (CLI > env > file > default) |
+| `ConfigFile` | `src/config.rs` | Raw deserialized config file struct |
+| `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
+| `GenerateSbomUseCase` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation |
+| `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
+
+### Important Invariants
+
+- **Config resolution order**: CLI args > environment variables > config file > defaults.
+  This order is enforced in `config_resolver.rs` and must not be changed without updating tests.
+- **Domain layer has no I/O**: `src/sbom_generation/` must never import from `adapters` or `ports`.
+- **All GitHub artifacts (commits, PRs, Issues) must be in English** — enforced by skills in `.claude/skills/`.
+
+### Files NOT to touch unless their issue explicitly targets them
+
+- `src/adapters/outbound/network/` — HTTP client internals (unrelated to most refactors)
+- `src/i18n/` — Locale catalogs (separate concern)

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -77,7 +77,23 @@ Invoke `/pr` skill with:
 - Base branch: `develop`
 - Reference to issue: `Closes #<issue-number>`
 
-### Step 7: Report Completion
+### Step 7: Update Architecture Overview (conditional)
+
+After implementation is complete, evaluate whether the changes affected the project architecture:
+
+**Update `.claude/CLAUDE.md` → `## Architecture Overview` if any of the following changed:**
+- A new module or subdirectory was added/removed under `src/`
+- A key type was renamed, added, or removed
+- A new invariant or constraint was introduced
+- The config resolution order or config struct changed
+
+**Skip this step if:**
+- The change was purely internal (renamed a private function, fixed a bug, adjusted formatting)
+- No module boundaries, public APIs, or key types were affected
+
+When updating, keep descriptions concise. Do **not** include function signatures, argument lists, or file-level details — only module-level roles, key public types, and design constraints.
+
+### Step 8: Report Completion
 
 Output:
 - Branch name created


### PR DESCRIPTION
## Summary
- Add `## Architecture Overview` section to `.claude/CLAUDE.md` with module structure table, key types table, and important invariants
- Add conditional Step 7 to `.claude/skills/implement/SKILL.md` to keep the overview up-to-date after architectural changes
- Verify module paths against the actual `src/` directory structure (added `src/adapters/inbound/` and `src/adapters/outbound/console/` which were missing from the issue proposal)

## Related Issue
Closes #361

## Changes Made
- `.claude/CLAUDE.md`: Appended `## Architecture Overview` section describing hexagonal architecture design pattern, all module paths under `src/`, key public types with locations, and important invariants
- `.claude/skills/implement/SKILL.md`: Added conditional Step 7 defining when to update the Architecture Overview; renamed old Step 7 to Step 8

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] No `.rs` files modified
- [x] Module paths verified against actual `src/` directory structure

---
Generated with [Claude Code](https://claude.com/claude-code)