### PR TITLE
refactor(adapters): extract build_vulnerability_properties helper in cyclonedx_formatter.rs

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter.rs
@@ -331,6 +331,29 @@ impl CycloneDxFormatter {
             vector: vuln.cvss_vector.clone(),
         }]);
 
+        let properties =
+            self.build_vulnerability_properties(vuln, resolution_guide, upgrade_recommendations);
+
+        Vulnerability {
+            bom_ref: vuln.bom_ref.clone(),
+            id: vuln.id.clone(),
+            description: vuln.description.clone(),
+            source,
+            ratings,
+            affects: vec![Affect {
+                bom_ref: vuln.affected_component.clone(),
+            }],
+            properties,
+        }
+    }
+
+    /// Build vulnerability properties from resolution guide and upgrade recommendations
+    fn build_vulnerability_properties(
+        &self,
+        vuln: &VulnerabilityView,
+        resolution_guide: Option<&ResolutionGuideView>,
+        upgrade_recommendations: Option<&UpgradeRecommendationView>,
+    ) -> Option<Vec<Property>> {
         // Build introduced-by properties from resolution guide
         let mut properties: Vec<Property> = resolution_guide
             .and_then(|guide| {
@@ -388,22 +411,10 @@ impl CycloneDxFormatter {
             }
         }
 
-        let properties = if properties.is_empty() {
+        if properties.is_empty() {
             None
         } else {
             Some(properties)
-        };
-
-        Vulnerability {
-            bom_ref: vuln.bom_ref.clone(),
-            id: vuln.id.clone(),
-            description: vuln.description.clone(),
-            source,
-            ratings,
-            affects: vec![Affect {
-                bom_ref: vuln.affected_component.clone(),
-            }],
-            properties,
         }
     }
 


### PR DESCRIPTION
## Summary
- Extract the `properties` construction block from `build_vulnerability` into a dedicated private method `build_vulnerability_properties`
- `build_vulnerability` now delegates to `build_vulnerability_properties` via a single method call
- Pure structural refactor with no behavioral changes

## Related Issue
Closes #359

## Changes Made
- Added private method `build_vulnerability_properties(&self, vuln, resolution_guide, upgrade_recommendations) -> Option<Vec<Property>>` to `CycloneDxFormatter`
- Replaced the ~60-line `properties` block in `build_vulnerability` with a single delegating call

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)