### PR TITLE
feat(ci): add Dependabot cooldown policy to prevent supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      semver-major-days: 30   # Wait 30 days for major version bumps
+      semver-minor-days: 7    # Wait 7 days for minor version bumps
+      semver-patch-days: 3    # Wait 3 days for patch version bumps
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7         # Wait 7 days (semver not always applicable)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,21 @@
 - **Scope**: All dependencies in `Cargo.toml` / `Cargo.lock`
 - **Response Policy**: All alerts are reviewed and addressed as a matter of principle
 
+#### Supply Chain Attack Mitigation (Cooldown Policy)
+
+To reduce the risk of supply chain attacks via newly published malicious package versions,
+a cooldown period is configured before Dependabot opens version update PRs:
+
+| Update Type              | Cooldown Period |
+|--------------------------|-----------------|
+| Cargo semver-major       | 30 days         |
+| Cargo semver-minor       | 7 days          |
+| Cargo semver-patch       | 3 days          |
+| GitHub Actions (default) | 7 days          |
+
+**Note**: This cooldown applies only to **version updates**.
+Security updates triggered by CVE/GHSA alerts bypass the cooldown and are created immediately.
+
 ### Static Code Analysis (CodeQL)
 
 - **Trigger**: All pull requests


### PR DESCRIPTION
## Summary

- Add `cooldown` configuration to `.github/dependabot.yml` for both `cargo` and `github-actions` ecosystems
- Introduce waiting periods before Dependabot opens version update PRs to reduce supply chain attack risk
- Document the cooldown policy in `SECURITY.md` under the Dependency Scanning section

## Related Issue

Closes #365

## Changes Made

- `.github/dependabot.yml`: Added `cooldown` block to `cargo` entry (major: 30d, minor: 7d, patch: 3d) and `github-actions` entry (default: 7d)
- `SECURITY.md`: Added "Supply Chain Attack Mitigation (Cooldown Policy)" subsection with a cooldown table and note that security updates bypass the cooldown

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] No Rust source changes — only YAML and Markdown files modified

## Notes

The `cooldown` option applies only to **version updates**. Security updates (CVE/GHSA-triggered PRs) are unaffected and continue to be created immediately.

---
Generated with [Claude Code](https://claude.com/claude-code)