### PR TITLE
feat(application): add VulnerabilityCountsBySeverity and counts_by_severity()

### DIFF
--- a/src/application/read_models/vulnerability_view.rs
+++ b/src/application/read_models/vulnerability_view.rs
@@ -20,6 +20,41 @@ pub struct VulnerabilityReportView {
     pub summary: VulnerabilitySummary,
 }
 
+impl VulnerabilityReportView {
+    /// Returns vulnerability counts broken down by severity level.
+    ///
+    /// Aggregates counts across both `actionable` and `informational` vectors.
+    #[allow(dead_code)]
+    pub fn counts_by_severity(&self) -> VulnerabilityCountsBySeverity {
+        let all = self.actionable.iter().chain(self.informational.iter());
+        let mut counts = VulnerabilityCountsBySeverity::default();
+        for v in all {
+            match v.severity {
+                SeverityView::Critical => counts.critical += 1,
+                SeverityView::High => counts.high += 1,
+                SeverityView::Medium => counts.medium += 1,
+                SeverityView::Low => counts.low += 1,
+                SeverityView::None => {}
+            }
+        }
+        counts
+    }
+}
+
+/// Vulnerability counts broken down by severity level
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct VulnerabilityCountsBySeverity {
+    /// Number of CRITICAL severity vulnerabilities
+    pub critical: usize,
+    /// Number of HIGH severity vulnerabilities
+    pub high: usize,
+    /// Number of MEDIUM severity vulnerabilities
+    pub medium: usize,
+    /// Number of LOW severity vulnerabilities
+    pub low: usize,
+}
+
 /// View representation of a single vulnerability
 #[derive(Debug, Clone)]
 pub struct VulnerabilityView {
@@ -133,5 +168,83 @@ mod tests {
     #[test]
     fn test_severity_view_default() {
         assert_eq!(SeverityView::default(), SeverityView::None);
+    }
+
+    fn make_vuln(severity: SeverityView) -> VulnerabilityView {
+        VulnerabilityView {
+            bom_ref: String::new(),
+            id: String::new(),
+            affected_component: String::new(),
+            affected_component_name: String::new(),
+            affected_version: String::new(),
+            cvss_score: None,
+            cvss_vector: None,
+            severity,
+            fixed_version: None,
+            description: None,
+            source_url: None,
+        }
+    }
+
+    #[test]
+    fn test_counts_by_severity_all_zero() {
+        let report = VulnerabilityReportView::default();
+        let counts = report.counts_by_severity();
+        assert_eq!(counts.critical, 0);
+        assert_eq!(counts.high, 0);
+        assert_eq!(counts.medium, 0);
+        assert_eq!(counts.low, 0);
+    }
+
+    #[test]
+    fn test_counts_by_severity_only_actionable() {
+        let report = VulnerabilityReportView {
+            actionable: vec![
+                make_vuln(SeverityView::Critical),
+                make_vuln(SeverityView::High),
+                make_vuln(SeverityView::High),
+                make_vuln(SeverityView::Medium),
+            ],
+            ..Default::default()
+        };
+        let counts = report.counts_by_severity();
+        assert_eq!(counts.critical, 1);
+        assert_eq!(counts.high, 2);
+        assert_eq!(counts.medium, 1);
+        assert_eq!(counts.low, 0);
+    }
+
+    #[test]
+    fn test_counts_by_severity_only_informational() {
+        let report = VulnerabilityReportView {
+            informational: vec![
+                make_vuln(SeverityView::Low),
+                make_vuln(SeverityView::Low),
+                make_vuln(SeverityView::None),
+            ],
+            ..Default::default()
+        };
+        let counts = report.counts_by_severity();
+        assert_eq!(counts.critical, 0);
+        assert_eq!(counts.high, 0);
+        assert_eq!(counts.medium, 0);
+        assert_eq!(counts.low, 2);
+    }
+
+    #[test]
+    fn test_counts_by_severity_mixed() {
+        let report = VulnerabilityReportView {
+            actionable: vec![
+                make_vuln(SeverityView::Critical),
+                make_vuln(SeverityView::Medium),
+            ],
+            informational: vec![make_vuln(SeverityView::Low), make_vuln(SeverityView::None)],
+            ..Default::default()
+        };
+        let counts = report.counts_by_severity();
+        assert_eq!(counts.critical, 1);
+        assert_eq!(counts.high, 0);
+        assert_eq!(counts.medium, 1);
+        assert_eq!(counts.low, 1);
     }
 }


### PR DESCRIPTION
## Summary
- Add `VulnerabilityCountsBySeverity` struct with `critical`, `high`, `medium`, `low` fields (all `usize`), deriving `Debug`, `Clone`, `Default`
- Add `counts_by_severity()` method on `VulnerabilityReportView` that aggregates counts across both `actionable` and `informational` vectors
- Add unit tests covering all-zero, only-actionable, only-informational, and mixed scenarios

## Related Issue
Closes #376

## Changes Made
- `src/application/read_models/vulnerability_view.rs`: Added `VulnerabilityCountsBySeverity` struct and `counts_by_severity()` method on `VulnerabilityReportView`
- Both items are marked `#[allow(dead_code)]` as they are staged for use in the executive summary feature (#291)

## Test Plan
- [x] `cargo test --all` passes (8 tests in vulnerability_view module, 468 total)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)