### PR TITLE
docs(split): add 200-line PR size guideline to guard rails

### DIFF
--- a/.claude/skills/split/SKILL.md
+++ b/.claude/skills/split/SKILL.md
@@ -47,6 +47,7 @@ Identify subtask boundaries using these dimensions:
 **Guard rails**:
 - If the issue is already small enough for one PR → report "No split needed. This issue is already scoped for a single PR." Do NOT create any subtask Issues.
 - If decomposition yields more than 7 subtasks → flag over-decomposition and suggest grouping before proceeding.
+- **Line-count target**: Aim for ≤ 200 changed lines per subtask PR. If a subtask is estimated to exceed this, consider splitting it further. This is a guideline, not a hard limit.
 
 Present the proposed subtasks to the user in this format:
 


### PR DESCRIPTION
## Summary
- Add a quantitative line-count target (≤ 200 changed lines) to the `/split` skill's guard rails

## Related Issue
Closes #386

## Changes Made
- **Modified**: `.claude/skills/split/SKILL.md` — added line-count target bullet to Guard rails section

## Background
The `/split` skill previously defined subtask granularity using only qualitative boundaries (module, concern, dependency, risk). In practice, PRs are kept to ~200 lines of changes to reduce reviewer cognitive load. This change aligns the skill with that established practice by adding an explicit guideline.

## Test Plan
- [ ] Guard rails section includes the ≤ 200-line target
- [ ] Wording is clear that this is a guideline, not a hard limit

---
Generated with [Claude Code](https://claude.com/claude-code)