### PR TITLE
feat(adapters): add i18n strings and render_summary() for Markdown executive summary

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -50,6 +50,13 @@ impl SbomFormatter for MarkdownFormatter {
         let mut output = String::new();
 
         section::render_header(self.messages, &mut output);
+        section::render_summary(
+            self.messages,
+            &mut output,
+            &model.components,
+            model.vulnerabilities.as_ref(),
+            model.license_compliance.as_ref(),
+        );
         section::render_components(
             self.messages,
             self.verified_packages.as_ref(),

--- a/src/adapters/outbound/formatters/markdown_formatter/section.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/section.rs
@@ -50,7 +50,7 @@ pub(super) fn render_summary(
 
     // Vulnerability rows
     let mut has_critical = false;
-    let mut has_high_or_medium = false;
+    let mut has_warning = false;
     if let Some(vuln_report) = vulnerabilities {
         let counts = vuln_report.counts_by_severity();
         let critical_status = if counts.critical > 0 {
@@ -60,18 +60,23 @@ pub(super) fn render_summary(
             "✅"
         };
         let high_status = if counts.high > 0 {
-            has_high_or_medium = true;
+            has_warning = true;
             "⚠️"
         } else {
             "✅"
         };
         let medium_status = if counts.medium > 0 {
-            has_high_or_medium = true;
+            has_warning = true;
             "⚠️"
         } else {
             "✅"
         };
-        let low_status = if counts.low > 0 { "⚠️" } else { "✅" };
+        let low_status = if counts.low > 0 {
+            has_warning = true;
+            "⚠️"
+        } else {
+            "✅"
+        };
         output.push_str(&format!(
             "| {} | {} | {} |\n",
             messages.label_vuln_critical, counts.critical, critical_status
@@ -111,7 +116,7 @@ pub(super) fn render_summary(
     output.push('\n');
     let overall = if has_critical {
         messages.overall_action_required
-    } else if has_high_or_medium {
+    } else if has_warning {
         messages.overall_attention_recommended
     } else {
         messages.overall_no_issues
@@ -884,5 +889,21 @@ mod tests {
 
         assert!(markdown.contains("Direct dependencies | 1 | ✅"));
         assert!(markdown.contains("Transitive dependencies | 1 | ✅"));
+    }
+
+    #[test]
+    fn test_render_summary_low_only_vuln_en() {
+        // Low-only vulnerabilities should show ⚠️ per-row but overall is "Attention recommended"
+        let mut model = create_test_read_model();
+        model.vulnerabilities = Some(make_vuln_report(0, 0, 0, 2));
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("Vulnerabilities (CRITICAL) | 0 | ✅"));
+        assert!(markdown.contains("Vulnerabilities (HIGH) | 0 | ✅"));
+        assert!(markdown.contains("Vulnerabilities (MEDIUM) | 0 | ✅"));
+        assert!(markdown.contains("Vulnerabilities (LOW) | 2 | ⚠️"));
+        assert!(markdown.contains("**Overall: Attention recommended**"));
+        assert!(!markdown.contains("**Overall: Action required**"));
     }
 }

--- a/src/adapters/outbound/formatters/markdown_formatter/section.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/section.rs
@@ -1,6 +1,6 @@
 use crate::application::read_models::{
     ComponentView, DependencyView, LicenseComplianceView, ResolutionGuideView,
-    UpgradeRecommendationView,
+    UpgradeRecommendationView, VulnerabilityReportView,
 };
 use crate::i18n::Messages;
 use std::collections::{HashMap, HashSet};
@@ -8,6 +8,115 @@ use std::collections::{HashMap, HashSet};
 /// Renders the header section
 pub(super) fn render_header(messages: &'static Messages, output: &mut String) {
     output.push_str(messages.section_sbom_title);
+    output.push_str("\n\n");
+}
+
+/// Renders the executive summary section
+pub(super) fn render_summary(
+    messages: &'static Messages,
+    output: &mut String,
+    components: &[ComponentView],
+    vulnerabilities: Option<&VulnerabilityReportView>,
+    license_compliance: Option<&LicenseComplianceView>,
+) {
+    output.push_str(messages.section_summary);
+    output.push_str("\n\n");
+
+    // Table header
+    output.push_str(&format!(
+        "| {} | {} | {} |\n",
+        messages.col_item, messages.col_count, messages.col_status
+    ));
+    output.push_str(&super::table::make_separator(&[
+        messages.col_item,
+        messages.col_count,
+        messages.col_status,
+    ]));
+
+    // Package count rows
+    let direct_count = components.iter().filter(|c| c.is_direct_dependency).count();
+    let transitive_count = components
+        .iter()
+        .filter(|c| !c.is_direct_dependency)
+        .count();
+    output.push_str(&format!(
+        "| {} | {} | ✅ |\n",
+        messages.label_direct_deps, direct_count
+    ));
+    output.push_str(&format!(
+        "| {} | {} | ✅ |\n",
+        messages.label_transitive_deps, transitive_count
+    ));
+
+    // Vulnerability rows
+    let mut has_critical = false;
+    let mut has_high_or_medium = false;
+    if let Some(vuln_report) = vulnerabilities {
+        let counts = vuln_report.counts_by_severity();
+        let critical_status = if counts.critical > 0 {
+            has_critical = true;
+            "❌"
+        } else {
+            "✅"
+        };
+        let high_status = if counts.high > 0 {
+            has_high_or_medium = true;
+            "⚠️"
+        } else {
+            "✅"
+        };
+        let medium_status = if counts.medium > 0 {
+            has_high_or_medium = true;
+            "⚠️"
+        } else {
+            "✅"
+        };
+        let low_status = if counts.low > 0 { "⚠️" } else { "✅" };
+        output.push_str(&format!(
+            "| {} | {} | {} |\n",
+            messages.label_vuln_critical, counts.critical, critical_status
+        ));
+        output.push_str(&format!(
+            "| {} | {} | {} |\n",
+            messages.label_vuln_high, counts.high, high_status
+        ));
+        output.push_str(&format!(
+            "| {} | {} | {} |\n",
+            messages.label_vuln_medium, counts.medium, medium_status
+        ));
+        output.push_str(&format!(
+            "| {} | {} | {} |\n",
+            messages.label_vuln_low, counts.low, low_status
+        ));
+    } else {
+        output.push_str(&format!("\n{}\n", messages.label_vuln_check_skipped));
+    }
+
+    // License violations row
+    let violation_count = license_compliance
+        .map(|lc| lc.summary.violation_count)
+        .unwrap_or(0);
+    let license_status = if violation_count > 0 {
+        has_critical = true;
+        "❌"
+    } else {
+        "✅"
+    };
+    output.push_str(&format!(
+        "| {} | {} | {} |\n",
+        messages.label_license_violations, violation_count, license_status
+    ));
+
+    // Overall line
+    output.push('\n');
+    let overall = if has_critical {
+        messages.overall_action_required
+    } else if has_high_or_medium {
+        messages.overall_attention_recommended
+    } else {
+        messages.overall_no_issues
+    };
+    output.push_str(overall);
     output.push_str("\n\n");
 }
 
@@ -618,5 +727,162 @@ mod tests {
 
         assert!(!markdown.contains("Recommended Action"));
         assert!(markdown.contains("## Vulnerability Resolution Guide"));
+    }
+
+    // ===== Tests for render_summary() =====
+
+    fn make_vuln_report(
+        critical: usize,
+        high: usize,
+        medium: usize,
+        low: usize,
+    ) -> crate::application::read_models::VulnerabilityReportView {
+        use crate::application::read_models::{
+            SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
+        };
+        let mut actionable = Vec::new();
+        let mut informational = Vec::new();
+        let make = |id: &str, sev: SeverityView| VulnerabilityView {
+            bom_ref: id.to_string(),
+            id: id.to_string(),
+            affected_component: "pkg".to_string(),
+            affected_component_name: "pkg".to_string(),
+            affected_version: "1.0".to_string(),
+            cvss_score: None,
+            cvss_vector: None,
+            severity: sev,
+            fixed_version: None,
+            description: None,
+            source_url: None,
+        };
+        for i in 0..critical {
+            actionable.push(make(&format!("CRIT-{i}"), SeverityView::Critical));
+        }
+        for i in 0..high {
+            actionable.push(make(&format!("HIGH-{i}"), SeverityView::High));
+        }
+        for i in 0..medium {
+            actionable.push(make(&format!("MED-{i}"), SeverityView::Medium));
+        }
+        for i in 0..low {
+            informational.push(make(&format!("LOW-{i}"), SeverityView::Low));
+        }
+        VulnerabilityReportView {
+            actionable,
+            informational,
+            threshold_exceeded: critical > 0 || high > 0 || medium > 0,
+            summary: VulnerabilitySummary {
+                total_count: critical + high + medium + low,
+                actionable_count: critical + high + medium,
+                informational_count: low,
+                affected_package_count: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn test_render_summary_all_clear_en() {
+        let model = create_test_read_model();
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("## Summary"));
+        assert!(markdown.contains("Direct dependencies"));
+        assert!(markdown.contains("Transitive dependencies"));
+        assert!(markdown.contains("**Overall: No issues found** ✅"));
+    }
+
+    #[test]
+    fn test_render_summary_all_clear_ja() {
+        let model = create_test_read_model();
+        let formatter = super::super::MarkdownFormatter::new(Locale::Ja);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("## サマリー"));
+        assert!(markdown.contains("直接依存パッケージ"));
+        assert!(markdown.contains("間接依存パッケージ"));
+        assert!(markdown.contains("**総合判定: 問題なし** ✅"));
+    }
+
+    #[test]
+    fn test_render_summary_critical_vuln_en() {
+        let mut model = create_test_read_model();
+        model.vulnerabilities = Some(make_vuln_report(1, 0, 0, 0));
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("Vulnerabilities (CRITICAL) | 1 | ❌"));
+        assert!(markdown.contains("**Overall: Action required**"));
+    }
+
+    #[test]
+    fn test_render_summary_high_medium_vuln_en() {
+        let mut model = create_test_read_model();
+        model.vulnerabilities = Some(make_vuln_report(0, 1, 1, 0));
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("Vulnerabilities (HIGH) | 1 | ⚠️"));
+        assert!(markdown.contains("Vulnerabilities (MEDIUM) | 1 | ⚠️"));
+        assert!(markdown.contains("**Overall: Attention recommended**"));
+    }
+
+    #[test]
+    fn test_render_summary_license_violation_en() {
+        use crate::application::read_models::{
+            LicenseComplianceSummary, LicenseComplianceView, LicenseViolationView,
+        };
+        let mut model = create_test_read_model();
+        model.license_compliance = Some(LicenseComplianceView {
+            has_violations: true,
+            violations: vec![LicenseViolationView {
+                package_name: "badpkg".to_string(),
+                package_version: "1.0".to_string(),
+                license: "GPL-3.0".to_string(),
+                reason: "Copyleft".to_string(),
+                matched_pattern: None,
+            }],
+            warnings: vec![],
+            summary: LicenseComplianceSummary {
+                violation_count: 1,
+                warning_count: 0,
+            },
+        });
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("License violations | 1 | ❌"));
+        assert!(markdown.contains("**Overall: Action required**"));
+    }
+
+    #[test]
+    fn test_render_summary_vuln_skipped_en() {
+        let model = create_test_read_model();
+        // vulnerabilities is None → skipped note shown
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("_Vulnerability check skipped._"));
+        assert!(!markdown.contains("Vulnerabilities (CRITICAL)"));
+    }
+
+    #[test]
+    fn test_render_summary_vuln_skipped_ja() {
+        let model = create_test_read_model();
+        let formatter = super::super::MarkdownFormatter::new(Locale::Ja);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("_脆弱性チェックはスキップされました。_"));
+    }
+
+    #[test]
+    fn test_render_summary_package_counts() {
+        // create_test_read_model has 1 direct (requests) and 1 transitive (urllib3)
+        let model = create_test_read_model();
+        let formatter = super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("Direct dependencies | 1 | ✅"));
+        assert!(markdown.contains("Transitive dependencies | 1 | ✅"));
     }
 }

--- a/src/application/read_models/component_view.rs
+++ b/src/application/read_models/component_view.rs
@@ -20,7 +20,6 @@ pub struct ComponentView {
     /// SHA256 hash of the component
     pub sha256_hash: Option<String>,
     /// Whether this is a direct dependency
-    #[allow(dead_code)]
     pub is_direct_dependency: bool,
 }
 

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -30,5 +30,6 @@ pub use sbom_read_model_builder::SbomReadModelBuilder;
 pub use upgrade_recommendation_view::{UpgradeEntryView, UpgradeRecommendationView};
 #[allow(unused_imports)]
 pub use vulnerability_view::{
-    SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
+    SeverityView, VulnerabilityCountsBySeverity, VulnerabilityReportView, VulnerabilitySummary,
+    VulnerabilityView,
 };

--- a/src/application/read_models/vulnerability_view.rs
+++ b/src/application/read_models/vulnerability_view.rs
@@ -24,7 +24,6 @@ impl VulnerabilityReportView {
     /// Returns vulnerability counts broken down by severity level.
     ///
     /// Aggregates counts across both `actionable` and `informational` vectors.
-    #[allow(dead_code)]
     pub fn counts_by_severity(&self) -> VulnerabilityCountsBySeverity {
         let all = self.actionable.iter().chain(self.informational.iter());
         let mut counts = VulnerabilityCountsBySeverity::default();
@@ -43,7 +42,6 @@ impl VulnerabilityReportView {
 
 /// Vulnerability counts broken down by severity level
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct VulnerabilityCountsBySeverity {
     /// Number of CRITICAL severity vulnerabilities
     pub critical: usize,

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -129,6 +129,23 @@ pub struct Messages {
 
     // Vulnerability summary line (4 placeholders: count, unit, count, unit)
     pub summary_vuln_found: &'static str,
+
+    // Executive summary section
+    pub section_summary: &'static str,
+    pub col_item: &'static str,
+    pub col_count: &'static str,
+    pub col_status: &'static str,
+    pub label_direct_deps: &'static str,
+    pub label_transitive_deps: &'static str,
+    pub label_vuln_critical: &'static str,
+    pub label_vuln_high: &'static str,
+    pub label_vuln_medium: &'static str,
+    pub label_vuln_low: &'static str,
+    pub label_license_violations: &'static str,
+    pub label_vuln_check_skipped: &'static str,
+    pub overall_action_required: &'static str,
+    pub overall_attention_recommended: &'static str,
+    pub overall_no_issues: &'static str,
 }
 
 impl Messages {
@@ -260,6 +277,23 @@ static EN_MESSAGES: Messages = Messages {
 
     // Vulnerability summary line
     summary_vuln_found: "**Found {} {} in {} {}.**",
+
+    // Executive summary section
+    section_summary: "## Summary",
+    col_item: "Item",
+    col_count: "Count",
+    col_status: "Status",
+    label_direct_deps: "Direct dependencies",
+    label_transitive_deps: "Transitive dependencies",
+    label_vuln_critical: "Vulnerabilities (CRITICAL)",
+    label_vuln_high: "Vulnerabilities (HIGH)",
+    label_vuln_medium: "Vulnerabilities (MEDIUM)",
+    label_vuln_low: "Vulnerabilities (LOW)",
+    label_license_violations: "License violations",
+    label_vuln_check_skipped: "_Vulnerability check skipped._",
+    overall_action_required: "**Overall: Action required**",
+    overall_attention_recommended: "**Overall: Attention recommended**",
+    overall_no_issues: "**Overall: No issues found** ✅",
 };
 
 static JA_MESSAGES: Messages = Messages {
@@ -361,6 +395,23 @@ static JA_MESSAGES: Messages = Messages {
 
     // Vulnerability summary line
     summary_vuln_found: "**{}{}が{}{}で見つかりました。**",
+
+    // Executive summary section
+    section_summary: "## サマリー",
+    col_item: "項目",
+    col_count: "件数",
+    col_status: "状態",
+    label_direct_deps: "直接依存パッケージ",
+    label_transitive_deps: "間接依存パッケージ",
+    label_vuln_critical: "脆弱性 (CRITICAL)",
+    label_vuln_high: "脆弱性 (HIGH)",
+    label_vuln_medium: "脆弱性 (MEDIUM)",
+    label_vuln_low: "脆弱性 (LOW)",
+    label_license_violations: "ライセンス違反",
+    label_vuln_check_skipped: "_脆弱性チェックはスキップされました。_",
+    overall_action_required: "**総合判定: 対応が必要です**",
+    overall_attention_recommended: "**総合判定: 注意が必要です**",
+    overall_no_issues: "**総合判定: 問題なし** ✅",
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add 15 new i18n message keys to `Messages` struct (EN + JA) for the executive summary section
- Implement `render_summary()` in `markdown_formatter/section.rs` rendering package counts, per-severity vulnerability counts, license violation count, and an overall verdict line
- Wire `render_summary()` into `MarkdownFormatter::format()` immediately after the document header

## Related Issue

Closes #377

## Changes Made

- `src/i18n/mod.rs`: Add `section_summary`, `col_item`, `col_count`, `col_status`, `label_direct_deps`, `label_transitive_deps`, `label_vuln_{critical,high,medium,low}`, `label_license_violations`, `label_vuln_check_skipped`, `overall_{action_required,attention_recommended,no_issues}` to `Messages` struct, `EN_MESSAGES`, and `JA_MESSAGES`
- `src/application/read_models/component_view.rs`: Remove `#[allow(dead_code)]` from `is_direct_dependency` field
- `src/application/read_models/vulnerability_view.rs`: Remove `#[allow(dead_code)]` from `VulnerabilityCountsBySeverity` and `counts_by_severity()`
- `src/application/read_models/mod.rs`: Export `VulnerabilityCountsBySeverity` via `pub use`
- `src/adapters/outbound/formatters/markdown_formatter/section.rs`: Implement `render_summary()` with status logic (❌/⚠️/✅) and add 8 unit tests
- `src/adapters/outbound/formatters/markdown_formatter/mod.rs`: Call `render_summary()` after `render_header()`

## Test Plan

- [x] `cargo test --all` passes (all 8 new `render_summary` tests pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)