### PR TITLE
test(adapters): add unit test for license name fallback when spdx_id is None

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -794,4 +794,28 @@ mod tests {
         assert!(markdown.contains("**2件の脆弱性が1個のパッケージで見つかりました。**"));
         assert!(!markdown.contains("**Found"));
     }
+
+    #[test]
+    fn test_format_license_falls_back_to_name_when_spdx_id_is_none() {
+        let mut model = create_test_read_model();
+        model.components.push(ComponentView {
+            bom_ref: "pkg:pypi/somelib@1.0.0".to_string(),
+            name: "somelib".to_string(),
+            version: "1.0.0".to_string(),
+            purl: "pkg:pypi/somelib@1.0.0".to_string(),
+            license: Some(LicenseView {
+                spdx_id: None,
+                name: "Some Custom License".to_string(),
+                url: None,
+            }),
+            description: None,
+            sha256_hash: None,
+            is_direct_dependency: false,
+        });
+
+        let formatter = MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("Some Custom License"));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a unit test that sets `spdx_id: None` and asserts that `LicenseView.name` appears in the rendered Markdown output
- Completes the missing acceptance criterion from issue #311

## Related Issue
Closes #397

## Changes Made
- Added `test_format_license_falls_back_to_name_when_spdx_id_is_none` test in `src/adapters/outbound/formatters/markdown_formatter/mod.rs`

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)