### PR TITLE
refactor(domain): move is_above_threshold onto ThresholdConfig as a value object method

### DIFF
--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -12,6 +12,23 @@ pub enum ThresholdConfig {
     Cvss(f32),
 }
 
+impl ThresholdConfig {
+    /// Returns true if the vulnerability meets or exceeds this threshold
+    pub fn is_above_threshold(&self, vuln: &Vulnerability) -> bool {
+        match self {
+            ThresholdConfig::None => true,
+            ThresholdConfig::Severity(min_severity) => vuln.severity() >= *min_severity,
+            ThresholdConfig::Cvss(min_cvss) => {
+                // N/A CVSS scores are excluded from threshold evaluation
+                match vuln.cvss_score() {
+                    Some(score) => score.value() >= *min_cvss,
+                    None => false,
+                }
+            }
+        }
+    }
+}
+
 /// Result of vulnerability threshold check
 #[derive(Debug, Clone)]
 pub struct VulnerabilityCheckResult {
@@ -91,7 +108,16 @@ impl VulnerabilityChecker {
         let mut below_threshold = Vec::new();
 
         for pkg_vulns in filtered {
-            let (above, below) = Self::partition_vulnerabilities(&pkg_vulns, &threshold);
+            let mut above = Vec::new();
+            let mut below = Vec::new();
+
+            for vuln in pkg_vulns.vulnerabilities() {
+                if threshold.is_above_threshold(vuln) {
+                    above.push(vuln.clone());
+                } else {
+                    below.push(vuln.clone());
+                }
+            }
 
             if !above.is_empty() {
                 above_threshold.push(PackageVulnerabilities::new(
@@ -182,40 +208,6 @@ impl VulnerabilityChecker {
         }
 
         result
-    }
-
-    /// Partitions vulnerabilities into above and below threshold
-    fn partition_vulnerabilities(
-        pkg_vulns: &PackageVulnerabilities,
-        threshold: &ThresholdConfig,
-    ) -> (Vec<Vulnerability>, Vec<Vulnerability>) {
-        let mut above = Vec::new();
-        let mut below = Vec::new();
-
-        for vuln in pkg_vulns.vulnerabilities() {
-            if Self::is_above_threshold(vuln, threshold) {
-                above.push(vuln.clone());
-            } else {
-                below.push(vuln.clone());
-            }
-        }
-
-        (above, below)
-    }
-
-    /// Determines if a vulnerability is above the specified threshold
-    fn is_above_threshold(vuln: &Vulnerability, threshold: &ThresholdConfig) -> bool {
-        match threshold {
-            ThresholdConfig::None => true,
-            ThresholdConfig::Severity(min_severity) => vuln.severity() >= *min_severity,
-            ThresholdConfig::Cvss(min_cvss) => {
-                // N/A CVSS scores are excluded from threshold evaluation
-                match vuln.cvss_score() {
-                    Some(score) => score.value() >= *min_cvss,
-                    None => false,
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `ThresholdConfig::is_above_threshold` as a public method so the value object owns its own evaluation logic
- Remove `VulnerabilityChecker::is_above_threshold` and `VulnerabilityChecker::partition_vulnerabilities` private methods
- Inline the partition loop directly in `VulnerabilityChecker::check` using `threshold.is_above_threshold(vuln)`

## Related Issue
Closes #399

## Changes Made
- `ThresholdConfig` now implements `is_above_threshold(&self, vuln: &Vulnerability) -> bool`
- `VulnerabilityChecker::is_above_threshold` private method removed
- `VulnerabilityChecker::partition_vulnerabilities` private method removed; logic inlined in `check`
- Pure structural refactor — no behavioral changes

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)