### PR TITLE
refactor(domain): extract CveFilter as a separate domain service

### DIFF
--- a/src/sbom_generation/domain/services/cve_filter.rs
+++ b/src/sbom_generation/domain/services/cve_filter.rs
@@ -1,0 +1,71 @@
+use super::super::vulnerability::PackageVulnerabilities;
+use crate::config::IgnoreCve;
+
+/// Domain service for filtering ignored CVEs from vulnerability results
+pub struct CveFilter;
+
+impl CveFilter {
+    /// Filters out ignored CVEs from vulnerability results
+    ///
+    /// Removes vulnerabilities whose IDs match the ignore list (exact, case-sensitive).
+    /// Logs each ignored CVE to stderr for transparency.
+    ///
+    /// # Arguments
+    /// * `vulnerabilities` - List of package vulnerabilities to filter
+    /// * `ignore_cves` - List of CVE entries to ignore
+    ///
+    /// # Returns
+    /// Filtered list with ignored CVEs removed (packages with no remaining vulns are dropped)
+    pub fn apply(
+        vulnerabilities: Vec<PackageVulnerabilities>,
+        ignore_cves: &[IgnoreCve],
+    ) -> Vec<PackageVulnerabilities> {
+        if ignore_cves.is_empty() {
+            return vulnerabilities;
+        }
+
+        let ignore_ids: std::collections::HashSet<&str> =
+            ignore_cves.iter().map(|c| c.id.as_str()).collect();
+
+        let mut result = Vec::new();
+
+        for pkg_vulns in vulnerabilities {
+            let mut kept = Vec::new();
+
+            for vuln in pkg_vulns.vulnerabilities() {
+                if ignore_ids.contains(vuln.id()) {
+                    let reason = ignore_cves
+                        .iter()
+                        .find(|c| c.id == vuln.id())
+                        .and_then(|c| c.reason());
+
+                    match reason {
+                        Some(r) => eprintln!(
+                            "⚠ Ignored {} for package {} (reason: {})",
+                            vuln.id(),
+                            pkg_vulns.package_name(),
+                            r
+                        ),
+                        None => eprintln!(
+                            "⚠ Ignored {} for package {} (no reason provided)",
+                            vuln.id(),
+                            pkg_vulns.package_name()
+                        ),
+                    }
+                } else {
+                    kept.push(vuln.clone());
+                }
+            }
+
+            if !kept.is_empty() {
+                result.push(PackageVulnerabilities::new(
+                    pkg_vulns.package_name().to_string(),
+                    pkg_vulns.current_version().to_string(),
+                    kept,
+                ));
+            }
+        }
+
+        result
+    }
+}

--- a/src/sbom_generation/domain/services/mod.rs
+++ b/src/sbom_generation/domain/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod cve_filter;
 pub mod license_compliance_checker;
 pub mod resolution_analyzer;
 pub mod upgrade_advisor;

--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -1,4 +1,5 @@
 use super::super::vulnerability::{PackageVulnerabilities, Severity, Vulnerability};
+use super::cve_filter::CveFilter;
 use crate::config::IgnoreCve;
 
 /// Configuration for threshold evaluation
@@ -101,7 +102,7 @@ impl VulnerabilityChecker {
         ignore_cves: &[IgnoreCve],
     ) -> VulnerabilityCheckResult {
         // Step 1: Filter out ignored CVEs
-        let filtered = Self::filter_ignored_cves(vulnerabilities, ignore_cves);
+        let filtered = CveFilter::apply(vulnerabilities, ignore_cves);
 
         // Step 2: Apply threshold evaluation
         let mut above_threshold = Vec::new();
@@ -143,71 +144,6 @@ impl VulnerabilityChecker {
             below_threshold,
             threshold_exceeded,
         }
-    }
-
-    /// Filters out ignored CVEs from vulnerability results
-    ///
-    /// Removes vulnerabilities whose IDs match the ignore list (exact, case-sensitive).
-    /// Logs each ignored CVE to stderr for transparency.
-    ///
-    /// # Arguments
-    /// * `vulnerabilities` - List of package vulnerabilities to filter
-    /// * `ignore_cves` - List of CVE entries to ignore
-    ///
-    /// # Returns
-    /// Filtered list with ignored CVEs removed (packages with no remaining vulns are dropped)
-    fn filter_ignored_cves(
-        vulnerabilities: Vec<PackageVulnerabilities>,
-        ignore_cves: &[IgnoreCve],
-    ) -> Vec<PackageVulnerabilities> {
-        if ignore_cves.is_empty() {
-            return vulnerabilities;
-        }
-
-        let ignore_ids: std::collections::HashSet<&str> =
-            ignore_cves.iter().map(|c| c.id.as_str()).collect();
-
-        let mut result = Vec::new();
-
-        for pkg_vulns in vulnerabilities {
-            let mut kept = Vec::new();
-
-            for vuln in pkg_vulns.vulnerabilities() {
-                if ignore_ids.contains(vuln.id()) {
-                    // Find the matching ignore entry to get the reason
-                    let reason = ignore_cves
-                        .iter()
-                        .find(|c| c.id == vuln.id())
-                        .and_then(|c| c.reason());
-
-                    match reason {
-                        Some(r) => eprintln!(
-                            "⚠ Ignored {} for package {} (reason: {})",
-                            vuln.id(),
-                            pkg_vulns.package_name(),
-                            r
-                        ),
-                        None => eprintln!(
-                            "⚠ Ignored {} for package {} (no reason provided)",
-                            vuln.id(),
-                            pkg_vulns.package_name()
-                        ),
-                    }
-                } else {
-                    kept.push(vuln.clone());
-                }
-            }
-
-            if !kept.is_empty() {
-                result.push(PackageVulnerabilities::new(
-                    pkg_vulns.package_name().to_string(),
-                    pkg_vulns.current_version().to_string(),
-                    kept,
-                ));
-            }
-        }
-
-        result
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract CVE-filtering logic from `VulnerabilityChecker` into a new independent domain service `CveFilter`
- `VulnerabilityChecker::check` now delegates to `CveFilter::apply` for the filtering step
- `filter_ignored_cves` private method removed from `VulnerabilityChecker`

## Related Issue
Closes #400

## Changes Made
- Created `src/sbom_generation/domain/services/cve_filter.rs` with `CveFilter` struct and `apply` method
- Updated `src/sbom_generation/domain/services/vulnerability_checker.rs` to delegate to `CveFilter::apply`
- Added `pub mod cve_filter;` to `src/sbom_generation/domain/services/mod.rs`

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Pure structural refactor — no behavioral changes

---
Generated with [Claude Code](https://claude.com/claude-code)