### PR TITLE
test(domain): add unit tests for CveFilter domain service

### DIFF
--- a/src/sbom_generation/domain/services/cve_filter.rs
+++ b/src/sbom_generation/domain/services/cve_filter.rs
@@ -69,3 +69,122 @@ impl CveFilter {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::IgnoreCve;
+    use crate::sbom_generation::domain::vulnerability::{
+        PackageVulnerabilities, Severity, Vulnerability,
+    };
+
+    fn make_vuln(id: &str) -> Vulnerability {
+        Vulnerability::new(id.to_string(), None, Severity::High, None, None).unwrap()
+    }
+
+    fn make_pkg(name: &str, vulns: Vec<Vulnerability>) -> PackageVulnerabilities {
+        PackageVulnerabilities::new(name.to_string(), "1.0.0".to_string(), vulns)
+    }
+
+    fn ignore(id: &str) -> IgnoreCve {
+        IgnoreCve {
+            id: id.to_string(),
+            reason: None,
+        }
+    }
+
+    fn ignore_with_reason(id: &str, reason: &str) -> IgnoreCve {
+        IgnoreCve {
+            id: id.to_string(),
+            reason: Some(reason.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_empty_ignore_list_returns_input_unchanged() {
+        let pkg = make_pkg("pkg-a", vec![make_vuln("CVE-2024-001")]);
+        let result = CveFilter::apply(vec![pkg], &[]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vulnerabilities().len(), 1);
+        assert_eq!(result[0].vulnerabilities()[0].id(), "CVE-2024-001");
+    }
+
+    #[test]
+    fn test_matching_cve_is_removed() {
+        let pkg = make_pkg(
+            "pkg-a",
+            vec![make_vuln("CVE-2024-001"), make_vuln("CVE-2024-002")],
+        );
+        let result = CveFilter::apply(vec![pkg], &[ignore("CVE-2024-001")]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vulnerabilities().len(), 1);
+        assert_eq!(result[0].vulnerabilities()[0].id(), "CVE-2024-002");
+    }
+
+    #[test]
+    fn test_non_matching_cve_is_kept() {
+        let pkg = make_pkg("pkg-a", vec![make_vuln("CVE-2024-001")]);
+        let result = CveFilter::apply(vec![pkg], &[ignore("CVE-9999-999")]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vulnerabilities()[0].id(), "CVE-2024-001");
+    }
+
+    #[test]
+    fn test_matching_is_case_sensitive() {
+        let pkg = make_pkg("pkg-a", vec![make_vuln("CVE-2024-001")]);
+        // Lowercase should NOT match
+        let result = CveFilter::apply(vec![pkg], &[ignore("cve-2024-001")]);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vulnerabilities()[0].id(), "CVE-2024-001");
+    }
+
+    #[test]
+    fn test_package_with_all_cves_ignored_is_dropped() {
+        let pkg = make_pkg(
+            "pkg-a",
+            vec![make_vuln("CVE-2024-001"), make_vuln("CVE-2024-002")],
+        );
+        let result = CveFilter::apply(vec![pkg], &[ignore("CVE-2024-001"), ignore("CVE-2024-002")]);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_cve_ignored_across_multiple_packages() {
+        let pkg1 = make_pkg("pkg-a", vec![make_vuln("CVE-2024-001")]);
+        let pkg2 = make_pkg(
+            "pkg-b",
+            vec![make_vuln("CVE-2024-001"), make_vuln("CVE-2024-002")],
+        );
+        let result = CveFilter::apply(vec![pkg1, pkg2], &[ignore("CVE-2024-001")]);
+
+        // pkg-a had only CVE-2024-001 → dropped entirely
+        // pkg-b retains CVE-2024-002
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].package_name(), "pkg-b");
+        assert_eq!(result[0].vulnerabilities()[0].id(), "CVE-2024-002");
+    }
+
+    #[test]
+    fn test_ignore_with_reason_does_not_panic() {
+        let pkg = make_pkg("pkg-a", vec![make_vuln("CVE-2024-001")]);
+        let result = CveFilter::apply(
+            vec![pkg],
+            &[ignore_with_reason("CVE-2024-001", "False positive")],
+        );
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_without_reason_does_not_panic() {
+        let pkg = make_pkg("pkg-a", vec![make_vuln("CVE-2024-001")]);
+        let result = CveFilter::apply(vec![pkg], &[ignore("CVE-2024-001")]);
+
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add 8 direct unit tests for `CveFilter::apply` in `cve_filter.rs`
- Tests cover all documented behaviors independently of `VulnerabilityChecker`

## Related Issue
Closes #406

## Changes Made
- Added `#[cfg(test)] mod tests` block to `src/sbom_generation/domain/services/cve_filter.rs`
- Tests cover: empty ignore list, CVE removal, no-match retention, case-sensitivity, full-package drop, cross-package filtering, reason/no-reason smoke tests

## Dependencies
- Depends on #405 (PR that introduced `CveFilter`)
- Base branch set to `refactor/400-extract-cve-filter-domain-service` — retarget to `develop` after #405 merges

## Test Plan
- [x] `cargo test --all` passes (8 new tests added)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)