### PR TITLE
docs(examples): add license violation demo to sample-project

### DIFF
--- a/examples/sample-project/config/uv-sbom.config.yml
+++ b/examples/sample-project/config/uv-sbom.config.yml
@@ -1,13 +1,36 @@
 # Sample configuration file for uv-sbom
-# Demonstrates ignore_cves feature with real vulnerability IDs
-# from sample-project dependencies (detected by OSV API)
+# Demonstrates ignore_cves (CVE suppression) and license compliance checking
+# using real vulnerability IDs and license violations from sample-project
+# dependencies (detected by OSV API and PyPI).
 #
-# Usage:
-#   cargo run -- -p examples/sample-project --check-cve -f markdown \
-#     -c examples/sample-project/config/uv-sbom.config.yml
+# License violation demo:
+#   chardet 3.0.4 (transitive dep of requests 2.25.0) uses LGPL-2.1-only,
+#   which is denied by the license_policy below.
+#
+# Usage (CVE + license check):
+#   cargo run -- -p examples/sample-project --check-cve --check-license \
+#     -f markdown -c examples/sample-project/config/uv-sbom.config.yml
 
 check_cve: true
 severity_threshold: medium
+
+check_license: true
+
+license_policy:
+  allow:
+    - "MIT"
+    - "Apache-2.0"
+    - "BSD-2-Clause"
+    - "BSD-3-Clause"
+    - "ISC"
+    - "Python-2.0"
+    - "PSF-2.0"
+    - "MPL-2.0"
+  deny:
+    - "GPL-*"
+    - "LGPL-*"
+    - "AGPL-*"
+  unknown: warn
 
 ignore_cves:
   # pillow 8.3.2 - CRITICAL: buffer overflow in TiffDecode.c

--- a/examples/sample-project/pyproject.toml
+++ b/examples/sample-project/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sample-project"
 version = "0.1.0"
-description = "A sample project for testing uv-sbom with various CVE severity levels"
+description = "A sample project for testing uv-sbom with various CVE severity levels and license violations"
 requires-python = ">=3.11"
 dependencies = [
     # Packages with known vulnerabilities at various severity levels


### PR DESCRIPTION
## Summary

- Add `check_license: true` and a `license_policy` block to the sample-project config to demonstrate uv-sbom's license compliance detection
- `chardet 3.0.4` (already in `uv.lock` as a transitive dep of `requests`) uses LGPL-2.1-only, which is denied by the new GPL-family deny list — no new packages needed
- Update header comment with a combined CVE + license usage command, and update `pyproject.toml` description

## Related Issue

Closes #409

## Changes Made

- `examples/sample-project/config/uv-sbom.config.yml` — added `check_license: true`, `license_policy` (allow: MIT/Apache-2.0/BSD/ISC/PSF/MPL; deny: GPL-*/LGPL-*/AGPL-*; unknown: warn), and updated header comment with new usage command
- `examples/sample-project/pyproject.toml` — updated `description` to mention license violation detection

## Test Plan

- [x] `cargo test --all` passes (1092 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual: `cargo run -- -p examples/sample-project --check-license -c examples/sample-project/config/uv-sbom.config.yml` detects `chardet` as LGPL-2.1-only violation

---
Generated with [Claude Code](https://claude.com/claude-code)