### PR TITLE
chore(release): prepare v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-04-05
+
+### Added
+- **Markdown executive summary**: A new summary section is rendered at the top of Markdown output before the report header, providing an at-a-glance overview of the SBOM result (#388, #394)
+
+### Fixed
+- **Markdown formatter now prefers SPDX ID**: License names in Markdown output now use the canonical SPDX identifier instead of the raw license string when available (#395)
+- **License violation count summary line translation**: The violation count line in the license compliance section was not translated; now properly localized for both `en` and `ja` (#412)
+
+### Changed
+- **SPDX ID mapping improvements**: Added missing BSD variants (`BSD-2-Clause-Patent`, `BSD-4-Clause`), corrected `LGPLv2`/`LGPLv2.1` mappings, and added fuzzy suffix normalization to handle edge cases in license string matching (#396)
+
 ## [2.0.1] - 2026-03-21
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.0.1"
+version = "2.1.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.0.1"
+UV_SBOM_VERSION = "2.1.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v2.1.0
- Update version numbers in all required files
- Update CHANGELOG with release date and user-facing changes

## Version Files Updated
- `Cargo.toml`: version = "2.1.0"
- `python-wrapper/pyproject.toml`: version = "2.1.0"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "2.1.0"

## CHANGELOG
- Converted [Unreleased] to [2.1.0] - 2026-04-05
- Added empty [Unreleased] section
- Includes: Markdown executive summary, SPDX ID improvements, bug fixes (#388, #394, #395, #396, #412)

## Test Plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] All version strings are consistent (2.1.0)

## Post-Merge Manual Steps
After merging this PR into `develop`:
1. Open a PR: `develop` → `main`
   ```
   gh pr create --base main --head develop \
     --title "chore(release): v2.1.0" \
     --body "Merge release v2.1.0 from develop into main."
   ```
2. Merge the `develop` → `main` PR
3. Create and push the tag:
   ```
   git checkout main
   git pull origin main
   git tag v2.1.0
   git push origin v2.1.0
   ```
4. Verify CI release workflow completes successfully
5. Verify GitHub Release, crates.io, and PyPI publication

Closes #413

---
Generated with [Claude Code](https://claude.com/claude-code)