### PR TITLE
ci: add .githooks/pre-push hook and simplify commit/pre-push skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -58,23 +58,11 @@ See .claude/instructions.md for branching guidelines.
 
 ## Pre-flight Checks (MANDATORY)
 
-### 1. Format Code
+> **Note**: `cargo fmt` is handled automatically by the `.githooks/pre-commit` hook.
+> `cargo clippy` and `cargo test` are handled by the `.githooks/pre-push` hook at push time.
+> Run `make setup` once to activate these hooks if you haven't already.
 
-```bash
-cargo fmt --all
-```
-
-This automatically formats all code. Stage any formatting changes.
-
-### 2. Clippy Check
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings
-```
-
-**CRITICAL**: Zero warnings required. Fix all issues before committing.
-
-### 3. Security Check
+### 1. Security Check
 
 Verify no secrets in staged files:
 
@@ -108,10 +96,7 @@ Identify:
 
 ### Step 2: Run Pre-flight Checks
 
-Execute format and clippy checks. If clippy fails:
-
-1. Fix all warnings
-2. Re-run clippy until clean
+Run the security check. If secrets are found, stop immediately.
 
 ### Step 3: Stage Changes
 

--- a/.claude/skills/pre-push/SKILL.md
+++ b/.claude/skills/pre-push/SKILL.md
@@ -9,68 +9,18 @@ Final validation before pushing commits to remote repository.
 
 ## Purpose
 
-Ensure code quality and branch conventions are correct before pushing to prevent CI failures and maintain repository standards.
+Validate branch conventions and push commits to remote. Quality checks (fmt, clippy, tests)
+are delegated to the `.githooks/pre-push` hook, which runs automatically when `git push` executes.
 
-## ⚠️ CRITICAL: Always Use This Skill - Never Bypass
-
-**This skill exists to ensure CI-equivalent checks are run locally.**
-
-### NEVER run these commands directly:
-
-| ❌ Wrong (Missing Flags) | ✅ Correct (Use This Skill) |
-|--------------------------|----------------------------|
-| `cargo clippy --all-targets` | `/pre-push` includes `-D warnings` |
-| `cargo fmt --check` | `/pre-push` includes `--all` flag |
-| `cargo test` | `/pre-push` includes `--all` flag |
-
-### Why This Matters (Issue #59 Incident)
-
-Running `cargo clippy` without `-D warnings` caused a CI failure:
-1. Clippy showed warnings but exit code was 0 (success)
-2. Push proceeded despite warnings
-3. CI failed because it uses `-D warnings` which treats warnings as errors
-
-**Prevention**: Always invoke `/pre-push` instead of running individual commands manually.
-
-### Commands This Skill Runs
-
-This skill ensures the following commands are run with **exact CI-matching flags**:
-
-```bash
-cargo test --all                                           # All tests
-cargo fmt --all -- --check                                 # Format check
-cargo clippy --all-targets --all-features -- -D warnings   # Clippy with warnings as errors
-```
+> **Hook delegation**: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+> and `cargo test --all` are all run by `.githooks/pre-push` on every `git push`.
+> Run `make setup` once to activate the hook if you haven't already.
 
 ## Validation Checklist
 
 All of the following MUST pass before pushing:
 
-### 1. Full Test Suite
-
-```bash
-cargo test --all
-```
-
-**All tests must pass.**
-
-### 2. Format Verification
-
-```bash
-cargo fmt --all -- --check
-```
-
-If this fails, run `cargo fmt --all` and commit the changes.
-
-### 3. Clippy Verification
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings
-```
-
-**Zero warnings required.**
-
-### 4. Branch Naming Convention
+### 1. Branch Naming Convention
 
 ```bash
 git branch --show-current
@@ -93,7 +43,7 @@ Verify branch name follows convention based on **Issue labels** (priority order)
 - `main` - Use PR only
 - `develop` - Use PR only (if applicable)
 
-### 5. Remote Branch Target
+### 2. Remote Branch Target
 
 ```bash
 git remote -v
@@ -107,43 +57,7 @@ Verify:
 
 ## Steps
 
-### Step 1: Run Full Test Suite
-
-```bash
-cargo test --all
-```
-
-If tests fail:
-
-1. Fix the failing tests
-2. Commit the fixes
-3. Re-run tests
-
-### Step 2: Verify Formatting
-
-```bash
-cargo fmt --all -- --check
-```
-
-If formatting issues found:
-
-1. Run `cargo fmt --all`
-2. Commit formatting changes
-3. Re-run check
-
-### Step 3: Run Clippy
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings
-```
-
-If warnings found:
-
-1. Fix all warnings
-2. Commit fixes
-3. Re-run clippy
-
-### Step 4: Check Branch Name
+### Step 1: Check Branch Name
 
 ```bash
 BRANCH=$(git branch --show-current)
@@ -156,7 +70,7 @@ Verify:
 - [ ] Not on `main` or `develop`
 - [ ] Issue number in branch name (if applicable)
 
-### Step 5: Verify Unpushed Commits
+### Step 2: Verify Unpushed Commits
 
 ```bash
 git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null || git log --oneline -5
@@ -164,56 +78,34 @@ git log origin/$(git branch --show-current)..HEAD --oneline 2>/dev/null || git l
 
 Review what will be pushed.
 
-### Step 6: Final Confirmation
+### Step 3: Final Confirmation
 
 Before pushing, confirm:
 
-- [ ] All tests pass
-- [ ] Formatting is clean
-- [ ] No clippy warnings
 - [ ] Branch name is correct
 - [ ] Commits are reviewed
+- [ ] `.githooks/pre-push` hook is active (`make setup` has been run)
 
-### Step 7: Push
+### Step 4: Push
 
 ```bash
 git push -u origin $(git branch --show-current)
 ```
 
+The `.githooks/pre-push` hook will automatically run `cargo fmt --all -- --check`,
+`cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all`
+before the push completes.
+
 ## Error Handling
 
-### Test Failures
+### Hook Failures (fmt / clippy / test)
 
-```
-STOP: Tests are failing. Fix all test failures before pushing.
-```
+If the `.githooks/pre-push` hook reports a failure:
 
-1. Identify failing tests
-2. Debug and fix
-3. Commit fixes
+1. Read the hook output to identify which check failed
+2. Fix the issue (format error, clippy warning, or test failure)
+3. Commit the fix
 4. Re-run `/pre-push`
-
-### Format Failures
-
-```
-STOP: Code formatting issues detected. Running cargo fmt...
-```
-
-1. Run `cargo fmt --all`
-2. Review changes
-3. Commit formatting
-4. Continue with push
-
-### Clippy Warnings
-
-```
-STOP: Clippy warnings detected. Fix all warnings before pushing.
-```
-
-1. Read each warning
-2. Fix the issues
-3. Commit fixes
-4. Re-run clippy
 
 ### Wrong Branch
 
@@ -232,32 +124,38 @@ git checkout -b feature/<issue>-<description> origin/develop
 2. Push the feature branch
 3. Create a PR targeting `develop`
 
+### Hook Not Active
+
+If the hook does not run (no `[pre-push]` output during push):
+
+```bash
+make setup
+```
+
+Then re-run the push.
+
 ## Example Usage
 
 User: "pushする前にチェックして"
 
 Claude executes /pre-push skill:
 
-1. Runs `cargo test --all` - PASS
-2. Runs `cargo fmt --all -- --check` - PASS
-3. Runs `cargo clippy --all-targets --all-features -- -D warnings` - PASS
-4. Checks branch: `feature/84-agent-skills` - VALID
-5. Reviews unpushed commits
-6. Reports: "All checks passed. Ready to push."
-7. If user confirms, executes `git push -u origin feature/84-agent-skills`
+1. Checks branch: `feature/84-agent-skills` - VALID
+2. Reviews unpushed commits
+3. Reports: "Branch and commits look good. Pushing now (hook will run quality checks)."
+4. Executes `git push -u origin feature/84-agent-skills`
+5. `.githooks/pre-push` runs fmt/clippy/test automatically
 
 ## Summary Output
 
-After all checks pass, output:
+After push completes successfully, output:
 
 ```
-Pre-push Validation Complete
-============================
-[PASS] Tests: All X tests passed
-[PASS] Format: Code is properly formatted
-[PASS] Clippy: No warnings
+Pre-push Complete
+=================
 [PASS] Branch: feature/84-agent-skills (valid naming)
-[INFO] Commits to push: X commits
+[PASS] Hook: cargo fmt, clippy, tests passed
+[INFO] Commits pushed: X commits
 
-Ready to push to origin/feature/84-agent-skills
+Pushed to origin/feature/84-agent-skills
 ```

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Pre-push hook: Run quality checks before pushing to remote.
+# Enforces CI-equivalent checks for all contributors.
+#
+# To activate this hook, run:
+#   make setup
+# or:
+#   git config core.hooksPath .githooks
+
+set -e
+
+echo "[pre-push] Running cargo fmt check..."
+cargo fmt --all -- --check
+
+echo "[pre-push] Running cargo clippy..."
+cargo clippy --all-targets --all-features -- -D warnings
+
+echo "[pre-push] Running cargo test..."
+cargo test --all
+
+echo "[pre-push] All checks passed."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: setup
+setup:
+	git config core.hooksPath .githooks
+	@echo "Git hooks activated. .githooks/pre-push will run quality checks on every push."

--- a/README-JP.md
+++ b/README-JP.md
@@ -139,6 +139,16 @@ cargo build --release
 cargo install --path .
 ```
 
+#### 開発環境のセットアップ
+
+クローン後、gitフックを有効化してください：
+
+```bash
+make setup
+```
+
+これにより `.githooks/` の `pre-commit`（自動フォーマット）と `pre-push`（フォーマット確認・clippy・テスト）フックが有効になり、すべてのコントリビュータに対してコード品質チェックが自動的に実行されます。
+
 ### インストールの確認
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ cargo build --release
 cargo install --path .
 ```
 
+#### Development Setup
+
+After cloning, activate the git hooks:
+
+```bash
+make setup
+```
+
+This enables `pre-commit` (auto-format) and `pre-push` (fmt check, clippy, tests) hooks
+from `.githooks/`, ensuring code quality checks run automatically for all contributors.
+
 ### Verify Installation
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `.githooks/pre-push` hook that runs `cargo fmt --check`, `cargo clippy`, and `cargo test` on every push, enforcing CI-equivalent quality checks for all contributors (not just Claude Code users)
- Add `Makefile` with a `setup` target so contributors can activate hooks in one command
- Simplify `/commit` and `/pre-push` skills to remove redundant check steps now delegated to the hook

## Related Issue

Closes #418

## Changes Made

- `.githooks/pre-push` (new): runs `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` on every `git push`
- `Makefile` (new): `make setup` runs `git config core.hooksPath .githooks`
- `.claude/skills/commit/SKILL.md`: removed `cargo fmt` and `cargo clippy` from pre-flight checks; added note that hooks handle these
- `.claude/skills/pre-push/SKILL.md`: removed test/fmt/clippy steps; skill now focuses on branch validation and push only
- `README.md` / `README-JP.md`: added Development Setup section instructing contributors to run `make setup`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] `.githooks/pre-push` is executable (`chmod +x` applied)
- [x] `make setup` sets `core.hooksPath = .githooks`

---
Generated with [Claude Code](https://claude.com/claude-code)