### PR TITLE
docs: separate user-facing and developer-facing content in README

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -24,8 +24,6 @@
 - 💾 標準出力またはファイルへ出力
 - 🛡️ 堅牢なエラーハンドリングと親切なエラーメッセージ・提案
 - 📈 ライセンス情報取得時の進捗表示
-- 🏗️ **ヘキサゴナルアーキテクチャ**（ポート＆アダプター）+ **ドメイン駆動設計**による保守性とテスタビリティ
-- ✅ 包括的なテストカバレッジ（ユニット、統合、E2E）
 
 ## スコープとCycloneDXとの主な違い
 
@@ -138,16 +136,6 @@ cd uv-sbom
 cargo build --release
 cargo install --path .
 ```
-
-#### 開発環境のセットアップ
-
-クローン後、gitフックを有効化してください：
-
-```bash
-make setup
-```
-
-これにより `.githooks/` の `pre-commit`（自動フォーマット）と `pre-push`（フォーマット確認・clippy・テスト）フックが有効になり、すべてのコントリビュータに対してコード品質チェックが自動的に実行されます。
 
 ### インストールの確認
 
@@ -1022,22 +1010,37 @@ uv.lock file not found: /path/to/project/uv.lock
 ### ネットワークの問題
 プロキシやファイアウォールの内側にいる場合は、`https://pypi.org`にアクセスできることを確認してください。ツールはAPIリクエストに10秒のタイムアウトを使用します。
 
-## ドキュメント
+## 開発者向け
 
-### ユーザー向け
-- [README-JP.md](README-JP.md) - ユーザードキュメント
-- [LICENSE](LICENSE) - MITライセンス
+### アーキテクチャ
 
-### 開発者向け
-- [DEVELOPMENT.md](DEVELOPMENT.md) - 開発ガイド
-- [ARCHITECTURE-JP.md](ARCHITECTURE-JP.md) - **ヘキサゴナルアーキテクチャ + DDD実装**（レイヤー、ポート、アダプター、テスト戦略、ADR）
-- [CHANGELOG.md](CHANGELOG.md) - 変更履歴
+uv-sbomは保守性とテスタビリティのために**ヘキサゴナルアーキテクチャ**（ポート＆アダプター）+ **ドメイン駆動設計（DDD）**で実装されています。
 
-### Claude Codeユーザー向け
-- [.claude/project-context.md](.claude/project-context.md) - Claude Code用の完全なプロジェクトコンテキスト
-- [.claude/instructions.md](.claude/instructions.md) - Claude Code用のコーディングガイドラインと指示
+レイヤー、ポート、アダプター、アーキテクチャ決定記録（ADR）の詳細は[ARCHITECTURE-JP.md](ARCHITECTURE-JP.md)を参照してください。
 
-これらのファイルは、Claude Codeを使用したAI支援開発のための包括的なコンテキストを提供します。
+### テストカバレッジ
+
+テストスイートはユニット、統合、エンドツーエンドの各シナリオをカバーしています。
+
+テストの実行方法やコントリビュート方法については[DEVELOPMENT.md](DEVELOPMENT.md)を参照してください。
+
+### 開発環境のセットアップ
+
+リポジトリをクローンした後、gitフックを有効化してください：
+
+```bash
+make setup
+```
+
+これにより `.githooks/` の `pre-commit`（自動フォーマット）と `pre-push`（フォーマット確認・clippy・テスト）フックが有効になり、すべてのコントリビュータに対してコード品質チェックが自動的に実行されます。
+
+### リファレンス
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) — 開発ガイド
+- [ARCHITECTURE-JP.md](ARCHITECTURE-JP.md) — ヘキサゴナルアーキテクチャ + DDD実装の詳細
+- [CHANGELOG.md](CHANGELOG.md) — 変更履歴
+- [.claude/project-context.md](.claude/project-context.md) — Claude Code用の完全なプロジェクトコンテキスト
+- [.claude/instructions.md](.claude/instructions.md) — Claude Code用のコーディングガイドラインと指示
 
 ## 帰属表示
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Generate SBOMs (Software Bill of Materials) for Python projects managed by [uv](
 - 💾 Output to stdout or file
 - 🛡️ Robust error handling with helpful error messages and suggestions
 - 📈 Progress tracking during license information retrieval
-- 🏗️ Built with **Hexagonal Architecture** (Ports and Adapters) + **Domain-Driven Design** for maintainability and testability
-- ✅ Comprehensive test coverage (Unit, Integration, E2E)
 
 ## Scope and Key Differences from CycloneDX
 
@@ -139,17 +137,6 @@ cd uv-sbom
 cargo build --release
 cargo install --path .
 ```
-
-#### Development Setup
-
-After cloning, activate the git hooks:
-
-```bash
-make setup
-```
-
-This enables `pre-commit` (auto-format) and `pre-push` (fmt check, clippy, tests) hooks
-from `.githooks/`, ensuring code quality checks run automatically for all contributors.
 
 ### Verify Installation
 
@@ -1023,22 +1010,37 @@ Some packages may fail to retrieve license information from PyPI. The tool will:
 ### Network issues
 If you're behind a proxy or firewall, ensure that you can access `https://pypi.org`. The tool uses a 10-second timeout for API requests.
 
-## Documentation
+## For Developers
 
-### For Users
-- [README.md](README.md) - User documentation
-- [LICENSE](LICENSE) - MIT License
+### Architecture
 
-### For Developers
-- [DEVELOPMENT.md](DEVELOPMENT.md) - Development guide
-- [ARCHITECTURE.md](ARCHITECTURE.md) - **Hexagonal Architecture + DDD implementation** (layers, ports, adapters, test strategy, ADRs)
-- [CHANGELOG.md](CHANGELOG.md) - Change history
+uv-sbom is built with **Hexagonal Architecture** (Ports and Adapters) + **Domain-Driven Design (DDD)** for maintainability and testability.
 
-### For Claude Code Users
-- [.claude/project-context.md](.claude/project-context.md) - Complete project context for Claude Code
-- [.claude/instructions.md](.claude/instructions.md) - Coding guidelines and instructions for Claude Code
+See [ARCHITECTURE.md](ARCHITECTURE.md) for a full breakdown of layers, ports, adapters, and architectural decision records (ADRs).
 
-These files provide comprehensive context for AI-assisted development with Claude Code.
+### Test Coverage
+
+The test suite covers Unit, Integration, and End-to-End scenarios.
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for how to run tests and contribute.
+
+### Development Setup
+
+After cloning the repository, activate the git hooks:
+
+```bash
+make setup
+```
+
+This enables `pre-commit` (auto-format) and `pre-push` (fmt check, clippy, tests) hooks from `.githooks/`, ensuring code quality checks run automatically for all contributors.
+
+### Reference
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) — Development guide
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Hexagonal Architecture + DDD implementation details
+- [CHANGELOG.md](CHANGELOG.md) — Change history
+- [.claude/project-context.md](.claude/project-context.md) — Complete project context for Claude Code
+- [.claude/instructions.md](.claude/instructions.md) — Coding guidelines and instructions for Claude Code
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

- Remove developer-facing bullets ("Built with Hexagonal Architecture" and "Comprehensive test coverage") from `## Features` section
- Remove `Development Setup` block from `### From Source` installation section
- Replace `## Documentation` with a new `## For Developers` section that consolidates architecture overview, test coverage info, development setup, and reference links
- Apply identical changes (translated) to `README-JP.md`

## Related Issue

Closes #421

## Changes Made

- `README.md`: Remove 2 developer-facing bullets from `## Features`; remove `Development Setup` from Installation; replace `## Documentation` with `## For Developers`
- `README-JP.md`: Mirror all changes with Japanese translations

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (488 tests)
- [x] Documentation-only change; no behavior changes

---
Generated with [Claude Code](https://claude.com/claude-code)