### PR TITLE
feat(skills): add /code-review skill with Agent Teams iterative review loop

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,6 +46,7 @@ When the user requests any of the following operations, ALWAYS invoke the corres
 | Sync CLI options to config | /sync-config | Audit `ConfigFile`, `MergedConfig`, `CONFIG_TEMPLATE` for gaps |
 | Split Issue into subtasks | /split | Confirm decomposition before creating Issues; all Issues in English |
 | Propose or evaluate a feature idea | /ideate | Run triage, competitive analysis, draft Issue |
+| Review code quality before commit | /code-review | Spawn Reviewer Agent; do not recheck CI concerns (fmt/clippy) |
 
 ### Why This Rule Exists
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: code-review
+description: Spawn a Reviewer Agent to evaluate code changes against architecture, design, and quality criteria
+---
+
+# /code-review - Code Review Skill
+
+Spawns a dedicated Reviewer Agent to evaluate the current `git diff HEAD` against
+architectural, design, and quality criteria specific to uv-sbom.
+
+This skill does NOT re-run CI checks (cargo fmt, clippy). Those are enforced by the
+`/commit` skill and the CI pipeline.
+
+## Invocation
+
+**Standalone**: Invoke at any time to review uncommitted changes.
+**Integrated**: Called automatically by `/implement` Step 4.5 before `/commit`.
+
+## Workflow
+
+```
+Step 1: Collect diff
+Step 2: Spawn Reviewer Agent (foreground)
+Step 3: Parse result (PASS / FAIL)
+  └── PASS → report success, return control to caller
+  └── FAIL → apply fixes, increment counter, return to Step 1
+             (max 3 iterations; halt and report if still failing)
+```
+
+## Steps
+
+### Step 1: Collect Diff and File Content
+
+```bash
+git diff HEAD --name-only   # list changed files
+git diff HEAD               # full diff for the reviewer
+```
+
+For each file listed by `--name-only`, also read its **full current content**.
+This is required for file-size checks and documentation coverage checks.
+
+If `git diff HEAD` is empty, report "Nothing to review — no uncommitted changes."
+and exit.
+
+### Step 2: Spawn Reviewer Agent
+
+Use the `Agent` tool with `subagent_type: "general-purpose"`, run **foreground**.
+
+Pass the following prompt, substituting `<diff>` and `<file_contents>`:
+
+---
+
+```
+You are a senior Rust engineer and software architect reviewing a code change for the
+uv-sbom project. Evaluate ONLY the criteria listed below.
+Do NOT check formatting or linting — those are handled by CI.
+
+## Diff to Review
+<diff>
+
+## Full File Content (for each modified file)
+<file_contents>
+
+---
+
+## Review Criteria
+
+### 1. Hexagonal Architecture Compliance
+
+Layer boundary violations (🔴 MUST FIX if any):
+- Does src/sbom_generation/ import from src/adapters/ or src/ports/?
+- Does new I/O logic (file, network, console) exist outside src/adapters/?
+- Is a domain object (Package, Vulnerability, etc.) passed across a layer boundary
+  without being converted to a DTO first?
+
+Port/Adapter structure:
+- Are new port traits placed under src/ports/outbound/ or src/ports/inbound/?
+- Are new adapters placed under the correct src/adapters/outbound/ subdirectory?
+- Does every new async trait method have #[async_trait] and Send + Sync bounds?
+
+Config resolution:
+- Is MergedConfig only constructed in src/cli/config_resolver.rs?
+- Is the priority order (CLI > env vars > config file > defaults) maintained?
+
+### 2. Separation of Concerns
+
+Single Responsibility Principle:
+- Does any single struct or impl block carry more than one distinct responsibility
+  (e.g., data retrieval AND formatting)?
+- Does the application layer (src/application/) perform domain logic rather than
+  orchestration only?
+- Does any adapter contain business rules (e.g., "should this vulnerability be reported?")?
+
+Layer-appropriate logic:
+- Is threshold/severity judgment delegated to ThresholdConfig in src/sbom_generation/services/?
+  Do not reimplement match on Severity outside the domain services.
+- Is license compliance checking done in LicenseComplianceChecker, not in formatters?
+- Is read model construction (SbomReadModel) done in the application layer, not in adapters?
+
+### 3. DRY Principle
+
+General duplication:
+- Is there duplicated logic (>3 identical lines) across multiple functions or files?
+- Is license string normalization duplicated across adapters?
+
+uv-sbom-specific DRY violations:
+- Is i18n message formatting done via i18n::format() rather than inline format!()?
+- Is severity comparison done via ThresholdConfig::is_above_threshold() rather than
+  hand-written match blocks?
+- Is file security validation done via src/shared/security.rs rather than inline fs calls?
+
+### 4. Domain-Driven Design
+
+Value object usage:
+- Are raw String / f32 / u32 used where a value object exists
+  (PackageName, Version, CvssScore, Severity)?
+- Does a new domain concept lack a value object or enum that would prevent invalid states?
+- Does a value object constructor (::new()) perform complete validation and return Result<T>?
+  After construction, is the inner value accessed directly (e.g., .0) without re-validation?
+
+Entity and aggregate integrity:
+- Is Vulnerability always identified by its CVE ID (never by index or raw string comparison)?
+- Is DependencyGraph or PackageVulnerabilities accessed directly on its inner collection,
+  bypassing the aggregate root's methods?
+
+Business logic placement:
+- Is any business rule (vulnerability filtering, license policy evaluation, upgrade path
+  computation) implemented in src/adapters/ or src/cli/ instead of
+  src/sbom_generation/services/?
+
+Error handling (🔴 MUST FIX if any):
+- Is unwrap() or expect() used on a Result or Option that could fail at runtime?
+- Is a SbomError variant available but ignored in favor of a generic anyhow::bail!?
+- Is error context lost (e.g., .map_err(|_| ...))?
+
+### 5. GoF Design Pattern Applicability
+
+Flag only if applying the pattern would concretely simplify the code in the diff.
+Do not flag patterns for hypothetical future use.
+
+- **Strategy**: Is conditional logic switching between algorithms expressed as a
+  match/if-else instead of a trait object or enum dispatch?
+- **Factory / Builder**: Is a complex object constructed inline with many fields rather
+  than via a dedicated builder?
+- **Observer / Callback**: Is progress reporting coupled to a concrete type instead of
+  the ProgressReporter port trait?
+- **Decorator**: Is cross-cutting behavior (logging, retry, rate limiting) embedded
+  inside a struct rather than wrapping it via a decorator adapter?
+- **Template Method**: Is a multi-step algorithm duplicated with slight variations
+  instead of sharing a common template with overridable steps?
+- **Null Object**: Is an Option<VulnerabilityRepository> checked repeatedly with
+  if let Some(...) instead of a no-op trait implementation?
+
+### 6. Martin Fowler Refactoring Applicability
+
+Flag only if the refactoring clearly applies to the changed code.
+
+- **Extract Function**: Is a function longer than ~30 lines doing more than one thing?
+- **Extract Class / Module**: Does a struct handle responsibilities for a separate type?
+- **Replace Conditional with Polymorphism**: Is a match/if-else on a type replaceable
+  by trait method dispatch?
+- **Introduce Parameter Object**: Are 4+ related parameters always passed together?
+- **Replace Magic Number with Symbolic Constant**: Are numeric/string literals
+  hardcoded instead of named constants?
+- **Decompose Conditional**: Is a complex boolean condition unreadable inline?
+- **Move Function**: Is a function in the wrong module relative to the data it operates on?
+
+### 7. File Size and Complexity
+
+- **1000-line threshold (🟡 SHOULD FIX)**: If any modified file now exceeds 1000 lines
+  (excluding test blocks), propose a concrete refactoring — identify which
+  function/module to extract and the target location.
+- **Function length**: Flag any function exceeding 30 lines that mixes concerns.
+- **Nesting depth**: Flag any block nested more than 4 levels deep.
+
+Known large files (monitor for growth):
+- src/adapters/outbound/formatters/markdown_formatter/mod.rs (~882 lines)
+- src/application/use_cases/generate_sbom/tests.rs (1,032 lines) — test file, exempt
+
+### 8. Documentation Comments
+
+- Every public struct, enum, trait, and function added or modified must have a
+  `///` doc comment explaining its purpose. (🟡 SHOULD FIX if missing)
+- Non-obvious logic must have an inline `//` comment.
+- Port trait methods must document preconditions, postconditions, and error cases.
+- Functions that can panic must have `/// # Panics`.
+- Functions returning Result must have `/// # Errors`.
+
+### 9. Testability
+
+Dependency injection:
+- Are concrete types hardcoded where a trait object or generic bound would allow
+  test doubles? (🟡 SHOULD FIX)
+- Is any new struct non-testable because it constructs its own dependencies internally
+  instead of accepting them via constructor injection? (🟡 SHOULD FIX)
+
+Test surface:
+- Do new public functions or methods have corresponding unit tests?
+- Are domain service methods tested in isolation without adapter dependencies?
+- Are adapter implementations tested with TempDir (filesystem) or mock HTTP (network)?
+
+Test code quality:
+- Are test helper functions or fixtures duplicated across test modules?
+- Do test names follow the pattern: test_<function>_<scenario>_<expected>?
+
+### 10. Security
+
+File I/O safety (🔴 MUST FIX if violated):
+- Is symlink_metadata() used (not metadata()) before opening files?
+- Is is_symlink() checked and rejected before proceeding?
+- Is file size validated before allocating memory?
+- Is canonicalize() applied to prevent path traversal?
+- Is there a TOCTOU gap (check-then-use without fd-level re-verification)?
+
+External input validation:
+- Are CLI arguments and config file values validated through typed constructors
+  (PackageName::new(), Version::new()) rather than used as raw strings?
+
+Network safety:
+- Are new HTTP calls subject to timeout (30s), rate limiting (100ms interval),
+  and batch size limits (max 100 per request)?
+- Is response body size bounded before reading into memory?
+
+Sensitive data:
+- Are file paths, API responses, or config values included in error messages in a
+  way that could expose sensitive environment details?
+
+### 11. i18n Consistency
+
+- Does any new user-visible string bypass the i18n system (hardcoded English in output)?
+- Are new message keys added to both EN_MESSAGES and JA_MESSAGES?
+- If {} placeholder order differs between EN and JA templates, is this covered by tests?
+
+---
+
+## Output Format (respond ONLY in this exact format)
+
+### Result: PASS | FAIL
+
+### Findings
+[If PASS, write "No issues found."]
+[If FAIL, list each finding as:]
+- <severity> **[Criterion]** `path/to/file.rs:line`: Description of the violation and suggested fix.
+
+Severity levels:
+- 🔴 MUST FIX — blocks proceeding (architecture violation, security flaw, unwrap/panic)
+- 🟡 SHOULD FIX — strong recommendation (DRY, DDD, file size, missing docs, testability)
+- 🔵 CONSIDER — optional improvement (GoF pattern, Fowler refactoring)
+
+**FAIL condition**: any 🔴 finding exists, OR 3 or more 🟡 findings exist.
+**PASS condition**: only 🔵 findings (or no findings).
+
+### Summary
+[One-sentence overall assessment]
+```
+
+---
+
+### Step 3: Parse Result
+
+Extract `### Result: PASS | FAIL` from the Reviewer Agent's response.
+
+**If PASS**: report findings (🔵 items if any) to the user, return control to caller.
+
+**If FAIL** (iterations remaining):
+- Display all findings grouped by severity: 🔴 first, then 🟡, then 🔵
+- Apply fixes for every 🔴 and 🟡 finding
+- Increment iteration counter
+- Return to Step 1
+
+**If FAIL after 3 iterations**:
+- Report all remaining findings to the user
+- Do **NOT** proceed to commit
+- Ask: "Review failed after 3 iterations. Address the remaining issues manually, or cancel?"
+
+## Severity Reference
+
+| Severity | Condition | Action |
+|----------|-----------|--------|
+| 🔴 MUST FIX | Architecture violation, security flaw, `unwrap`/`panic` | Fix immediately; blocks commit |
+| 🟡 SHOULD FIX | DRY, DDD, file size ≥1000 lines, missing docs, testability | Fix before commit |
+| 🔵 CONSIDER | GoF pattern, Fowler refactoring | Advisory; does not block commit |
+
+## Example Output
+
+```
+### Result: FAIL
+
+### Findings
+- 🔴 MUST FIX **Hexagonal Architecture** `src/sbom_generation/domain/package.rs:42`:
+  Imports `reqwest` (HTTP client) directly in the domain layer.
+  Suggested fix: Move HTTP logic to `src/adapters/outbound/network/`.
+
+- 🟡 SHOULD FIX **DRY Principle** `src/adapters/outbound/formatters/cyclonedx.rs:88,112`:
+  Identical license normalization logic duplicated in two functions.
+  Suggested fix: Extract into `normalize_license()` in `src/shared/`.
+
+- 🟡 SHOULD FIX **File Size** `src/adapters/outbound/formatters/markdown_formatter/mod.rs`:
+  File is now 1,043 lines. Suggested refactoring: extract the vulnerability section
+  renderer (~lines 620–780) into a new `vulnerability_section.rs` submodule.
+
+- 🔵 CONSIDER **GoF: Strategy** `src/cli/config_resolver.rs:155-180`:
+  The format selection logic (match on OutputFormat) could be expressed as a Strategy
+  trait to simplify future format additions.
+
+### Summary
+One critical layer boundary violation and two strong-recommendation issues must be
+resolved before this change can proceed to commit.
+```

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -65,6 +65,16 @@ git checkout -b <branch-name> origin/develop
 - Add tests for new functionality
 - Update documentation as needed
 
+### Step 4.5: Code Review (MANDATORY)
+
+Invoke `/code-review` skill.
+
+- The skill runs a Reviewer Agent against the current `git diff HEAD`.
+- If the review **PASSES**, proceed to Step 5.
+- If the review **FAILS** after the maximum iteration limit (3), halt and report
+  remaining issues to the user. Do **NOT** invoke `/commit` until `/code-review`
+  returns PASS.
+
 ### Step 5: Commit Changes
 
 Invoke `/commit` skill with:


### PR DESCRIPTION
## Summary
- Add new `/code-review` Claude Code skill that spawns a Reviewer Agent via Agent Teams to evaluate code changes against 11 semantic quality criteria
- Integrate `/code-review` as mandatory Step 4.5 in the `/implement` skill workflow, gating commits behind a PASS result
- Update `CLAUDE.md` Skill Invocation Rules table to include `/code-review`

## Related Issue
Closes #420

## Changes Made
- **New**: `.claude/skills/code-review/SKILL.md` — full skill definition with Reviewer Agent prompt covering hexagonal architecture, separation of concerns, DRY, DDD, GoF patterns, Fowler refactoring, file size thresholds (≥1000 lines), documentation comments, testability, security, and i18n consistency
- **Updated**: `.claude/skills/implement/SKILL.md` — add Step 4.5 to invoke `/code-review` between implementation and commit; block `/commit` until review PASSES
- **Updated**: `.claude/CLAUDE.md` — add `/code-review` row to Skill Invocation Rules table

## Review Criteria Overview
Findings are classified into three severity levels:
- 🔴 MUST FIX — architecture violations, security flaws, `unwrap`/`panic` (triggers FAIL immediately)
- 🟡 SHOULD FIX — DRY, DDD, file size ≥1000 lines, missing docs, testability issues (3+ triggers FAIL)
- 🔵 CONSIDER — GoF pattern suggestions, Fowler refactoring opportunities (advisory only)

The skill retries fixes up to 3 iterations before halting and surfacing remaining issues to the user.

## Test Plan
- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `/code-review` is invocable as a standalone skill
- [ ] `/implement` Step 4.5 is present and references `/code-review`

---
Generated with [Claude Code](https://claude.com/claude-code)