### PR TITLE
refactor(adapters): scaffold sections/ module and move header + components renderers (part 1 of 3, #424)

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -1,6 +1,7 @@
 mod helpers;
 mod links;
 mod section;
+mod sections;
 mod table;
 mod vuln_render;
 
@@ -56,8 +57,8 @@ impl SbomFormatter for MarkdownFormatter {
             model.vulnerabilities.as_ref(),
             model.license_compliance.as_ref(),
         );
-        section::render_header(self.messages, &mut output);
-        section::render_components(
+        sections::header::render(self.messages, &mut output);
+        sections::components::render(
             self.messages,
             self.verified_packages.as_ref(),
             &mut output,

--- a/src/adapters/outbound/formatters/markdown_formatter/section.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/section.rs
@@ -5,12 +5,6 @@ use crate::application::read_models::{
 use crate::i18n::Messages;
 use std::collections::{HashMap, HashSet};
 
-/// Renders the header section
-pub(super) fn render_header(messages: &'static Messages, output: &mut String) {
-    output.push_str(messages.section_sbom_title);
-    output.push_str("\n\n");
-}
-
 /// Renders the executive summary section
 pub(super) fn render_summary(
     messages: &'static Messages,
@@ -123,39 +117,6 @@ pub(super) fn render_summary(
     };
     output.push_str(overall);
     output.push_str("\n\n");
-}
-
-/// Renders the components section
-pub(super) fn render_components(
-    messages: &'static Messages,
-    verified_packages: Option<&HashSet<String>>,
-    output: &mut String,
-    components: &[ComponentView],
-) {
-    output.push_str(messages.section_component_inventory);
-    output.push_str("\n\n");
-    output.push_str(messages.desc_sbom_report);
-    output.push_str("\n\n");
-    output.push_str(&super::table::table_header(messages));
-    output.push_str(&super::table::table_separator(messages));
-
-    for component in components {
-        let license = component
-            .license
-            .as_ref()
-            .map(|l| l.spdx_id.as_deref().unwrap_or(l.name.as_str()))
-            .unwrap_or("N/A");
-        let description = component.description.as_deref().unwrap_or("");
-
-        output.push_str(&format!(
-            "| {} | {} | {} | {} |\n",
-            super::links::format_package_name(&component.name, verified_packages),
-            super::table::escape_markdown_table_cell(&component.version),
-            super::table::escape_markdown_table_cell(license),
-            super::table::escape_markdown_table_cell(description)
-        ));
-    }
-    output.push('\n');
 }
 
 /// Renders the dependencies section

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/components.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/components.rs
@@ -1,0 +1,40 @@
+use crate::application::read_models::ComponentView;
+use crate::i18n::Messages;
+use std::collections::HashSet;
+
+/// Renders the component inventory section into `output`.
+///
+/// Lists all components in a Markdown table with package name, version, license,
+/// and description columns. Package names are hyperlinked when `verified_packages`
+/// is provided and the package is present in the set.
+pub(in super::super) fn render(
+    messages: &'static Messages,
+    verified_packages: Option<&HashSet<String>>,
+    output: &mut String,
+    components: &[ComponentView],
+) {
+    output.push_str(messages.section_component_inventory);
+    output.push_str("\n\n");
+    output.push_str(messages.desc_sbom_report);
+    output.push_str("\n\n");
+    output.push_str(&super::super::table::table_header(messages));
+    output.push_str(&super::super::table::table_separator(messages));
+
+    for component in components {
+        let license = component
+            .license
+            .as_ref()
+            .map(|l| l.spdx_id.as_deref().unwrap_or(l.name.as_str()))
+            .unwrap_or("N/A");
+        let description = component.description.as_deref().unwrap_or("");
+
+        output.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            super::super::links::format_package_name(&component.name, verified_packages),
+            super::super::table::escape_markdown_table_cell(&component.version),
+            super::super::table::escape_markdown_table_cell(license),
+            super::super::table::escape_markdown_table_cell(description)
+        ));
+    }
+    output.push('\n');
+}

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/header.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/header.rs
@@ -1,0 +1,7 @@
+use crate::i18n::Messages;
+
+/// Renders the SBOM header section into `output`.
+pub(in super::super) fn render(messages: &'static Messages, output: &mut String) {
+    output.push_str(messages.section_sbom_title);
+    output.push_str("\n\n");
+}

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
@@ -1,0 +1,3 @@
+pub(super) mod components;
+pub(super) mod header;
+pub(super) mod section_renderer;

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/section_renderer.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/section_renderer.rs
@@ -1,0 +1,13 @@
+use crate::application::read_models::SbomReadModel;
+use crate::i18n::Messages;
+
+/// Common interface for section renderers in the `sections` module.
+///
+/// Each section renderer takes a read model and a message catalog and returns
+/// a rendered Markdown string. Concrete implementations will be introduced in
+/// subsequent subtasks (#428, #429) as the remaining functions are moved out of
+/// `section.rs`.
+#[allow(dead_code)] // Scaffold for subtasks #428 and #429; implementations pending.
+pub(super) trait SectionRenderer {
+    fn render(&self, model: &SbomReadModel, messages: &'static Messages) -> String;
+}


### PR DESCRIPTION
## Summary
- Create the `sections/` subdirectory under `markdown_formatter/` with `mod.rs`, `section_renderer.rs`, `header.rs`, and `components.rs`
- Move `render_header` and `render_components` out of `section.rs` into their respective `sections/` submodules
- Update `markdown_formatter/mod.rs` call sites to use `sections::header::render` and `sections::components::render`

## Related Issue
Closes #427
Part of #424

## Changes Made
- Add `sections/section_renderer.rs`: `SectionRenderer` trait scaffold (to be implemented in subtasks #428, #429)
- Add `sections/header.rs`: `render_header` logic moved here as `sections::header::render`
- Add `sections/components.rs`: `render_components` logic moved here as `sections::components::render`
- Add `sections/mod.rs`: declares the three submodules
- Update `markdown_formatter/mod.rs`: add `mod sections;` and update two call sites
- Remove `render_header` and `render_components` from `section.rs` (four remaining functions intact)

## Test Plan
- [x] `cargo test --all` passes (488 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)