### PR TITLE
refactor(adapters): scaffold builders/ and move metadata + dependency builders

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter/builders/dependency.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/builders/dependency.rs
@@ -1,0 +1,102 @@
+use crate::application::read_models::DependencyView;
+
+use super::super::schema::Dependency;
+
+/// Build a list of CycloneDX [`Dependency`] entries from a [`DependencyView`].
+///
+/// Direct dependencies are listed first, each with their transitive children as
+/// `depends_on`. Packages that appear only as transitives (not in
+/// `dep_view.direct`) are appended afterward with their own `depends_on` list.
+pub(in super::super) fn build(dep_view: &DependencyView) -> Vec<Dependency> {
+    let mut dependencies = Vec::new();
+
+    // Add direct dependencies
+    for direct_ref in &dep_view.direct {
+        let depends_on = dep_view
+            .transitive
+            .get(direct_ref)
+            .cloned()
+            .unwrap_or_default();
+        dependencies.push(Dependency {
+            bom_ref: direct_ref.clone(),
+            depends_on,
+        });
+    }
+
+    // Add transitive dependencies that are not direct
+    for (parent_ref, children) in &dep_view.transitive {
+        if !dep_view.direct.contains(parent_ref) {
+            dependencies.push(Dependency {
+                bom_ref: parent_ref.clone(),
+                depends_on: children.clone(),
+            });
+        }
+    }
+
+    dependencies
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_build_direct_dependency_with_transitive_children() {
+        let mut transitive = HashMap::new();
+        transitive.insert(
+            "pkg:pypi/requests@2.31.0".to_string(),
+            vec!["pkg:pypi/urllib3@1.26.0".to_string()],
+        );
+
+        let dep_view = DependencyView {
+            direct: vec!["pkg:pypi/requests@2.31.0".to_string()],
+            transitive,
+        };
+
+        let result = build(&dep_view);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].bom_ref, "pkg:pypi/requests@2.31.0");
+        assert_eq!(result[0].depends_on, vec!["pkg:pypi/urllib3@1.26.0"]);
+    }
+
+    #[test]
+    fn test_build_transitive_only_dependency_is_included() {
+        let mut transitive = HashMap::new();
+        transitive.insert(
+            "pkg:pypi/requests@2.31.0".to_string(),
+            vec!["pkg:pypi/urllib3@1.26.0".to_string()],
+        );
+        transitive.insert(
+            "pkg:pypi/urllib3@1.26.0".to_string(),
+            vec!["pkg:pypi/certifi@2023.0.0".to_string()],
+        );
+
+        let dep_view = DependencyView {
+            direct: vec!["pkg:pypi/requests@2.31.0".to_string()],
+            transitive,
+        };
+
+        let result = build(&dep_view);
+
+        assert_eq!(result.len(), 2);
+        let refs: Vec<&str> = result.iter().map(|d| d.bom_ref.as_str()).collect();
+        assert!(refs.contains(&"pkg:pypi/requests@2.31.0"));
+        assert!(refs.contains(&"pkg:pypi/urllib3@1.26.0"));
+    }
+
+    #[test]
+    fn test_build_direct_dependency_without_children() {
+        let dep_view = DependencyView {
+            direct: vec!["pkg:pypi/requests@2.31.0".to_string()],
+            transitive: HashMap::new(),
+        };
+
+        let result = build(&dep_view);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].bom_ref, "pkg:pypi/requests@2.31.0");
+        assert!(result[0].depends_on.is_empty());
+    }
+}

--- a/src/adapters/outbound/formatters/cyclonedx_formatter/builders/metadata.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/builders/metadata.rs
@@ -1,0 +1,22 @@
+use crate::application::read_models::SbomMetadataView;
+
+use super::super::schema::{Metadata, MetadataComponent, Tool};
+
+/// Build a CycloneDX `Metadata` from an [`SbomMetadataView`].
+pub(in super::super) fn build(metadata: &SbomMetadataView) -> Metadata {
+    let component = metadata.component.as_ref().map(|c| MetadataComponent {
+        component_type: "application".to_string(),
+        bom_ref: format!("{}-{}", c.name, c.version),
+        name: c.name.clone(),
+        version: c.version.clone(),
+    });
+
+    Metadata {
+        timestamp: metadata.timestamp.clone(),
+        tools: vec![Tool {
+            name: metadata.tool_name.clone(),
+            version: metadata.tool_version.clone(),
+        }],
+        component,
+    }
+}

--- a/src/adapters/outbound/formatters/cyclonedx_formatter/builders/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/builders/mod.rs
@@ -1,0 +1,2 @@
+pub(super) mod dependency;
+pub(super) mod metadata;

--- a/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
@@ -1,10 +1,10 @@
+mod builders;
 mod schema;
 use schema::*;
 
 use crate::application::read_models::{
-    ComponentView, DependencyView, LicenseComplianceView, LicenseView, ResolutionGuideView,
-    SbomMetadataView, SbomReadModel, UpgradeEntryView, UpgradeRecommendationView,
-    VulnerabilityReportView, VulnerabilityView,
+    ComponentView, LicenseComplianceView, LicenseView, ResolutionGuideView, SbomReadModel,
+    UpgradeEntryView, UpgradeRecommendationView, VulnerabilityReportView, VulnerabilityView,
 };
 use crate::ports::outbound::SbomFormatter;
 use crate::shared::Result;
@@ -38,12 +38,9 @@ impl SbomFormatter for CycloneDxFormatter {
             spec_version: "1.6".to_string(),
             version: 1,
             serial_number: model.metadata.serial_number.clone(),
-            metadata: self.build_metadata(&model.metadata),
+            metadata: builders::metadata::build(&model.metadata),
             components: self.build_components(&model.components),
-            dependencies: model
-                .dependencies
-                .as_ref()
-                .map(|d| self.build_dependencies(d)),
+            dependencies: model.dependencies.as_ref().map(builders::dependency::build),
             vulnerabilities: model.vulnerabilities.as_ref().map(|v| {
                 self.build_vulnerabilities(
                     v,
@@ -59,25 +56,6 @@ impl SbomFormatter for CycloneDxFormatter {
 }
 
 impl CycloneDxFormatter {
-    /// Build metadata from SbomMetadataView
-    fn build_metadata(&self, metadata: &SbomMetadataView) -> Metadata {
-        let component = metadata.component.as_ref().map(|c| MetadataComponent {
-            component_type: "application".to_string(),
-            bom_ref: format!("{}-{}", c.name, c.version),
-            name: c.name.clone(),
-            version: c.version.clone(),
-        });
-
-        Metadata {
-            timestamp: metadata.timestamp.clone(),
-            tools: vec![Tool {
-                name: metadata.tool_name.clone(),
-                version: metadata.tool_version.clone(),
-            }],
-            component,
-        }
-    }
-
     /// Build components from ComponentView slice
     fn build_components(&self, components: &[ComponentView]) -> Vec<Component> {
         components
@@ -123,36 +101,6 @@ impl CycloneDxFormatter {
                 }
             },
         }]
-    }
-
-    /// Build dependencies from DependencyView
-    fn build_dependencies(&self, dep_view: &DependencyView) -> Vec<Dependency> {
-        let mut dependencies = Vec::new();
-
-        // Add direct dependencies
-        for direct_ref in &dep_view.direct {
-            let depends_on = dep_view
-                .transitive
-                .get(direct_ref)
-                .cloned()
-                .unwrap_or_default();
-            dependencies.push(Dependency {
-                bom_ref: direct_ref.clone(),
-                depends_on,
-            });
-        }
-
-        // Add transitive dependencies that are not direct
-        for (parent_ref, children) in &dep_view.transitive {
-            if !dep_view.direct.contains(parent_ref) {
-                dependencies.push(Dependency {
-                    bom_ref: parent_ref.clone(),
-                    depends_on: children.clone(),
-                });
-            }
-        }
-
-        dependencies
     }
 
     /// Build vulnerabilities from VulnerabilityReportView
@@ -335,7 +283,9 @@ impl CycloneDxFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::application::read_models::{SeverityView, VulnerabilitySummary};
+    use crate::application::read_models::{
+        DependencyView, SbomMetadataView, SeverityView, VulnerabilitySummary,
+    };
     use std::collections::HashMap;
 
     fn create_test_read_model() -> SbomReadModel {


### PR DESCRIPTION
## Summary
- Create `builders/` subdirectory under `cyclonedx_formatter/` with `metadata.rs` and `dependency.rs` submodules
- Migrate `build_metadata` and `build_dependencies` from `CycloneDxFormatter` impl into dedicated free-function modules
- Add doc comments and unit tests for the new builder functions

## Related Issue
Closes #434

## Changes Made
- Add `src/adapters/outbound/formatters/cyclonedx_formatter/builders/mod.rs` — declares submodules
- Add `src/adapters/outbound/formatters/cyclonedx_formatter/builders/metadata.rs` — `build_metadata` as `pub(in super::super) fn build`
- Add `src/adapters/outbound/formatters/cyclonedx_formatter/builders/dependency.rs` — `build_dependencies` as `pub(in super::super) fn build`, with unit tests
- Update `mod.rs` to delegate to `builders::metadata::build` and `builders::dependency::build`
- Remove migrated methods from `mod.rs`; no behavior change

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)