### PR TITLE
feat(ports,adapters): add WorkspaceReader port and UvWorkspaceReader adapter

### DIFF
--- a/src/adapters/outbound/uv/mod.rs
+++ b/src/adapters/outbound/uv/mod.rs
@@ -1,6 +1,10 @@
 /// uv CLI adapters for lock file simulation
 mod uv_lock_adapter;
+mod workspace_reader;
 
 // Note: Will be used in a subsequent subtask for uv lock simulation
 #[allow(unused_imports)]
 pub use uv_lock_adapter::UvLockAdapter;
+// Note: Will be used in a subsequent subtask for workspace detection
+#[allow(unused_imports)]
+pub use workspace_reader::UvWorkspaceReader;

--- a/src/adapters/outbound/uv/workspace_reader.rs
+++ b/src/adapters/outbound/uv/workspace_reader.rs
@@ -1,0 +1,293 @@
+use crate::ports::outbound::workspace_reader::{WorkspaceMember, WorkspaceReader};
+use crate::shared::security::{read_file_with_security, MAX_FILE_SIZE};
+use crate::shared::Result;
+use anyhow::Context;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+/// Adapter that reads uv workspace members by parsing `uv.lock`.
+#[allow(dead_code)]
+pub struct UvWorkspaceReader;
+
+#[allow(dead_code)]
+impl UvWorkspaceReader {
+    /// Creates a new `UvWorkspaceReader` instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Parse the raw TOML content of a `uv.lock` file and extract workspace members.
+    ///
+    /// Looks for a `[manifest].members` array in the lock file. For each member path,
+    /// finds the matching `[[package]]` entry where `source.editable` equals the member
+    /// path to resolve the package name. Falls back to the last path component if no
+    /// matching package is found.
+    ///
+    /// # Arguments
+    /// * `content` - The raw TOML content of the `uv.lock` file.
+    /// * `workspace_root` - The workspace root path used to compute absolute paths.
+    ///
+    /// # Returns
+    /// A vector of [`WorkspaceMember`] entries. Returns an empty `Vec` if the lock file
+    /// has no `[manifest]` section or the `members` array is empty.
+    ///
+    /// # Errors
+    /// Returns an error if the content cannot be parsed as valid TOML.
+    fn parse_members(content: &str, workspace_root: &Path) -> Result<Vec<WorkspaceMember>> {
+        #[derive(Deserialize, Default)]
+        struct Manifest {
+            members: Option<Vec<String>>,
+        }
+
+        #[derive(Deserialize)]
+        struct PackageSource {
+            editable: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        struct UvPackage {
+            name: String,
+            source: Option<PackageSource>,
+        }
+
+        #[derive(Deserialize)]
+        struct UvLock {
+            manifest: Option<Manifest>,
+            #[serde(default)]
+            package: Vec<UvPackage>,
+        }
+
+        let lock: UvLock = toml::from_str(content).context("Failed to parse uv.lock")?;
+
+        let member_paths = match lock.manifest.and_then(|m| m.members) {
+            Some(paths) if !paths.is_empty() => paths,
+            _ => return Ok(vec![]),
+        };
+
+        let members = member_paths
+            .into_iter()
+            .map(|relative_path| {
+                // Find the matching [[package]] entry where source.editable == relative_path
+                let name = lock
+                    .package
+                    .iter()
+                    .find(|p| {
+                        p.source
+                            .as_ref()
+                            .and_then(|s| s.editable.as_deref())
+                            .map(|e| e == relative_path)
+                            .unwrap_or(false)
+                    })
+                    .map(|p| p.name.clone())
+                    .unwrap_or_else(|| {
+                        // Fallback: derive name from the last path component
+                        PathBuf::from(&relative_path)
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| relative_path.clone())
+                    });
+
+                let absolute_path = workspace_root.join(&relative_path);
+
+                WorkspaceMember {
+                    name,
+                    relative_path,
+                    absolute_path,
+                }
+            })
+            .collect();
+
+        Ok(members)
+    }
+}
+
+impl Default for UvWorkspaceReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkspaceReader for UvWorkspaceReader {
+    fn read_workspace_members(&self, workspace_root: &Path) -> Result<Vec<WorkspaceMember>> {
+        let lock_path = workspace_root.join("uv.lock");
+        let content = read_file_with_security(&lock_path, "uv.lock", MAX_FILE_SIZE)
+            .with_context(|| format!("Failed to read uv.lock at: {}", lock_path.display()))?;
+        Self::parse_members(&content, workspace_root)
+    }
+
+    fn is_workspace_root(&self, path: &Path) -> bool {
+        self.read_workspace_members(path)
+            .map(|members| !members.is_empty())
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    const WORKSPACE_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[manifest]
+members = [
+    "packages/alpha",
+    "packages/beta",
+]
+
+[[package]]
+name = "alpha"
+version = "0.1.0"
+source = { editable = "packages/alpha" }
+
+[[package]]
+name = "beta"
+version = "0.2.0"
+source = { editable = "packages/beta" }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    const NON_WORKSPACE_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.8"
+
+[[package]]
+name = "sample-project"
+version = "1.0.0"
+source = { virtual = "." }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    const EMPTY_MEMBERS_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[manifest]
+members = []
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    #[test]
+    fn test_parse_members_returns_correct_members_for_workspace_lock() {
+        let root = Path::new("/workspace");
+        let members = UvWorkspaceReader::parse_members(WORKSPACE_LOCK, root).unwrap();
+
+        assert_eq!(members.len(), 2);
+
+        let alpha = members
+            .iter()
+            .find(|m| m.relative_path == "packages/alpha")
+            .unwrap();
+        assert_eq!(alpha.name, "alpha");
+        assert_eq!(alpha.absolute_path, root.join("packages/alpha"));
+
+        let beta = members
+            .iter()
+            .find(|m| m.relative_path == "packages/beta")
+            .unwrap();
+        assert_eq!(beta.name, "beta");
+        assert_eq!(beta.absolute_path, root.join("packages/beta"));
+    }
+
+    #[test]
+    fn test_parse_members_returns_empty_for_non_workspace_lock() {
+        let root = Path::new("/project");
+        let members = UvWorkspaceReader::parse_members(NON_WORKSPACE_LOCK, root).unwrap();
+        assert!(members.is_empty());
+    }
+
+    #[test]
+    fn test_parse_members_returns_empty_for_empty_members_array() {
+        let root = Path::new("/project");
+        let members = UvWorkspaceReader::parse_members(EMPTY_MEMBERS_LOCK, root).unwrap();
+        assert!(members.is_empty());
+    }
+
+    #[test]
+    fn test_parse_members_falls_back_to_path_component_when_no_matching_package() {
+        let content = r#"
+version = 1
+
+[manifest]
+members = [
+    "packages/gamma",
+]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+"#;
+        let root = Path::new("/workspace");
+        let members = UvWorkspaceReader::parse_members(content, root).unwrap();
+
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].name, "gamma");
+        assert_eq!(members[0].relative_path, "packages/gamma");
+    }
+
+    #[test]
+    fn test_parse_members_invalid_toml_returns_error() {
+        let root = Path::new("/workspace");
+        let result = UvWorkspaceReader::parse_members("invalid [[[ toml", root);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse uv.lock"));
+    }
+
+    #[test]
+    fn test_is_workspace_root_returns_true_for_workspace_lock_file() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(temp_dir.path().join("uv.lock"), WORKSPACE_LOCK).unwrap();
+
+        let reader = UvWorkspaceReader::new();
+        assert!(reader.is_workspace_root(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_is_workspace_root_returns_false_for_non_workspace_lock_file() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(temp_dir.path().join("uv.lock"), NON_WORKSPACE_LOCK).unwrap();
+
+        let reader = UvWorkspaceReader::new();
+        assert!(!reader.is_workspace_root(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_is_workspace_root_returns_false_when_no_lock_file() {
+        let reader = UvWorkspaceReader::new();
+        // Use a path that definitely does not have a uv.lock
+        let result = reader.is_workspace_root(Path::new("/nonexistent/path/that/does/not/exist"));
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_read_workspace_members_returns_members_from_real_file() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(temp_dir.path().join("uv.lock"), WORKSPACE_LOCK).unwrap();
+
+        let reader = UvWorkspaceReader::new();
+        let members = reader.read_workspace_members(temp_dir.path()).unwrap();
+
+        assert_eq!(members.len(), 2);
+        assert!(members.iter().any(|m| m.name == "alpha"));
+        assert!(members.iter().any(|m| m.name == "beta"));
+    }
+}

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -11,6 +11,7 @@ pub mod progress_reporter;
 pub mod project_config_reader;
 pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
+pub mod workspace_reader;
 
 pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
@@ -25,3 +26,6 @@ pub use uv_lock_simulator::{SimulationResult, UvLockSimulator};
 // Note: This will be used in subsequent subtasks (Subtask 3-8)
 #[allow(unused_imports)]
 pub use vulnerability_repository::VulnerabilityRepository;
+// Note: Will be used in a subsequent subtask for workspace detection
+#[allow(unused_imports)]
+pub use workspace_reader::{WorkspaceMember, WorkspaceReader};

--- a/src/ports/outbound/workspace_reader.rs
+++ b/src/ports/outbound/workspace_reader.rs
@@ -1,0 +1,46 @@
+use crate::shared::Result;
+use std::path::{Path, PathBuf};
+
+/// Represents a member of a uv workspace.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct WorkspaceMember {
+    /// The package name as declared in the `[[package]]` entry.
+    pub name: String,
+    /// The relative path to the workspace member (as listed in `[manifest].members`).
+    pub relative_path: String,
+    /// The absolute path to the workspace member, resolved from the workspace root.
+    pub absolute_path: PathBuf,
+}
+
+/// Port for reading uv workspace members from a `uv.lock` file.
+#[allow(dead_code)]
+pub trait WorkspaceReader {
+    /// Reads workspace members from `uv.lock` in the given workspace root directory.
+    ///
+    /// # Arguments
+    /// * `workspace_root` - Path to the workspace root directory containing `uv.lock`.
+    ///
+    /// # Returns
+    /// A vector of [`WorkspaceMember`] objects. Returns an empty `Vec` if the lock file
+    /// has no `[manifest]` section (i.e., not a workspace project).
+    ///
+    /// # Postconditions
+    /// Each returned [`WorkspaceMember`]'s `absolute_path` is always formed by joining
+    /// `workspace_root` with the member's `relative_path`.
+    ///
+    /// # Errors
+    /// Returns an error if the `uv.lock` file cannot be read or parsed.
+    fn read_workspace_members(&self, workspace_root: &Path) -> Result<Vec<WorkspaceMember>>;
+
+    /// Returns `true` if the given path is a uv workspace root.
+    ///
+    /// A path is considered a workspace root if its `uv.lock` file contains a
+    /// non-empty `[manifest].members` array.
+    ///
+    /// # Postconditions
+    /// Returns `false` if `uv.lock` does not exist, cannot be read, or has no
+    /// `[manifest].members` section. Errors reading the lock file are silently
+    /// treated as non-workspace (returns `false`).
+    fn is_workspace_root(&self, path: &Path) -> bool;
+}


### PR DESCRIPTION
## Summary

- Add `WorkspaceReader` outbound port trait and `WorkspaceMember` struct to `src/ports/outbound/workspace_reader.rs`
- Implement `UvWorkspaceReader` adapter in `src/adapters/outbound/uv/workspace_reader.rs` that parses `[manifest].members` from `uv.lock`
- Delegate file I/O to `read_file_with_security` for symlink rejection, size validation, and TOCTOU mitigation

## Related Issue

Closes #441

## Changes Made

- `src/ports/outbound/workspace_reader.rs` (new): `WorkspaceMember` struct and `WorkspaceReader` trait
- `src/ports/outbound/mod.rs`: export `workspace_reader` module
- `src/adapters/outbound/uv/workspace_reader.rs` (new): `UvWorkspaceReader` implementing `WorkspaceReader` with 9 unit tests
- `src/adapters/outbound/uv/mod.rs`: export `UvWorkspaceReader`

## Test Plan

- [x] `cargo test --all` passes (9 new unit tests added)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)