### PR TITLE
test(adapters): add unit tests to sections/summary.rs in markdown_formatter

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
@@ -116,3 +116,248 @@ pub(in super::super) fn render(
     output.push_str(overall);
     output.push_str("\n\n");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::{
+        LicenseComplianceSummary, LicenseComplianceView, SeverityView, VulnerabilityReportView,
+        VulnerabilityView,
+    };
+    use crate::i18n::{Locale, Messages};
+
+    fn make_component(is_direct: bool) -> ComponentView {
+        ComponentView {
+            bom_ref: String::new(),
+            name: String::new(),
+            version: String::new(),
+            purl: String::new(),
+            license: None,
+            description: None,
+            sha256_hash: None,
+            is_direct_dependency: is_direct,
+        }
+    }
+
+    fn make_vuln(severity: SeverityView) -> VulnerabilityView {
+        VulnerabilityView {
+            bom_ref: String::new(),
+            id: String::new(),
+            affected_component: String::new(),
+            affected_component_name: String::new(),
+            affected_version: String::new(),
+            cvss_score: None,
+            cvss_vector: None,
+            severity,
+            fixed_version: None,
+            description: None,
+            source_url: None,
+        }
+    }
+
+    fn make_license_compliance(violation_count: usize) -> LicenseComplianceView {
+        LicenseComplianceView {
+            violations: vec![],
+            warnings: vec![],
+            has_violations: violation_count > 0,
+            summary: LicenseComplianceSummary {
+                violation_count,
+                warning_count: 0,
+            },
+        }
+    }
+
+    fn render_summary(
+        locale: Locale,
+        components: &[ComponentView],
+        vulnerabilities: Option<&VulnerabilityReportView>,
+        license_compliance: Option<&LicenseComplianceView>,
+    ) -> String {
+        let messages = Messages::for_locale(locale);
+        let mut output = String::new();
+        render(
+            messages,
+            &mut output,
+            components,
+            vulnerabilities,
+            license_compliance,
+        );
+        output
+    }
+
+    #[test]
+    fn test_summary_section_header_en() {
+        let output = render_summary(Locale::En, &[], None, None);
+        assert!(output.starts_with("## Summary\n\n"));
+    }
+
+    #[test]
+    fn test_summary_section_header_ja() {
+        let output = render_summary(Locale::Ja, &[], None, None);
+        assert!(output.starts_with("## サマリー\n\n"));
+    }
+
+    #[test]
+    fn test_summary_package_counts_en() {
+        let components = vec![
+            make_component(true),
+            make_component(true),
+            make_component(false),
+        ];
+        let output = render_summary(Locale::En, &components, None, None);
+        assert!(output.contains("| Direct dependencies | 2 | ✅ |"));
+        assert!(output.contains("| Transitive dependencies | 1 | ✅ |"));
+    }
+
+    #[test]
+    fn test_summary_package_counts_ja() {
+        let components = vec![
+            make_component(true),
+            make_component(false),
+            make_component(false),
+        ];
+        let output = render_summary(Locale::Ja, &components, None, None);
+        assert!(output.contains("| 直接依存パッケージ | 1 | ✅ |"));
+        assert!(output.contains("| 間接依存パッケージ | 2 | ✅ |"));
+    }
+
+    #[test]
+    fn test_vuln_check_skipped_en() {
+        let output = render_summary(Locale::En, &[], None, None);
+        assert!(output.contains("_Vulnerability check skipped._"));
+        assert!(!output.contains("Vulnerabilities (CRITICAL)"));
+    }
+
+    #[test]
+    fn test_vuln_check_skipped_ja() {
+        let output = render_summary(Locale::Ja, &[], None, None);
+        assert!(output.contains("_脆弱性チェックはスキップされました。_"));
+        assert!(!output.contains("脆弱性 (CRITICAL)"));
+    }
+
+    #[test]
+    fn test_vuln_rows_present_when_check_enabled() {
+        let report = VulnerabilityReportView::default();
+        let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("| Vulnerabilities (CRITICAL) | 0 | ✅ |"));
+        assert!(output.contains("| Vulnerabilities (HIGH) | 0 | ✅ |"));
+        assert!(output.contains("| Vulnerabilities (MEDIUM) | 0 | ✅ |"));
+        assert!(output.contains("| Vulnerabilities (LOW) | 0 | ✅ |"));
+        assert!(!output.contains("_Vulnerability check skipped._"));
+    }
+
+    #[test]
+    fn test_vuln_critical_status_is_error() {
+        let report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::Critical)],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("| Vulnerabilities (CRITICAL) | 1 | ❌ |"));
+        assert!(output.contains("**Overall: Action required**"));
+    }
+
+    #[test]
+    fn test_vuln_high_status_is_warning() {
+        let report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::High)],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("| Vulnerabilities (HIGH) | 1 | ⚠️ |"));
+        assert!(output.contains("**Overall: Attention recommended**"));
+    }
+
+    #[test]
+    fn test_vuln_medium_status_is_warning() {
+        let report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::Medium)],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("| Vulnerabilities (MEDIUM) | 1 | ⚠️ |"));
+        assert!(output.contains("**Overall: Attention recommended**"));
+    }
+
+    #[test]
+    fn test_vuln_low_status_is_warning() {
+        let report = VulnerabilityReportView {
+            informational: vec![make_vuln(SeverityView::Low)],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("| Vulnerabilities (LOW) | 1 | ⚠️ |"));
+        assert!(output.contains("**Overall: Attention recommended**"));
+    }
+
+    #[test]
+    fn test_license_violation_status_is_error() {
+        let license = make_license_compliance(2);
+        let output = render_summary(Locale::En, &[], None, Some(&license));
+        assert!(output.contains("| License violations | 2 | ❌ |"));
+        assert!(output.contains("**Overall: Action required**"));
+    }
+
+    #[test]
+    fn test_license_no_violation_status_is_ok() {
+        let license = make_license_compliance(0);
+        let output = render_summary(Locale::En, &[], None, Some(&license));
+        assert!(output.contains("| License violations | 0 | ✅ |"));
+    }
+
+    #[test]
+    fn test_overall_no_issues_en() {
+        let report = VulnerabilityReportView::default();
+        let license = make_license_compliance(0);
+        let output = render_summary(Locale::En, &[], Some(&report), Some(&license));
+        assert!(output.contains("**Overall: No issues found** ✅"));
+    }
+
+    #[test]
+    fn test_overall_no_issues_ja() {
+        let report = VulnerabilityReportView::default();
+        let license = make_license_compliance(0);
+        let output = render_summary(Locale::Ja, &[], Some(&report), Some(&license));
+        assert!(output.contains("**総合判定: 問題なし** ✅"));
+    }
+
+    #[test]
+    fn test_overall_action_required_ja() {
+        let report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::Critical)],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::Ja, &[], Some(&report), None);
+        assert!(output.contains("**総合判定: 対応が必要です**"));
+    }
+
+    #[test]
+    fn test_overall_attention_recommended_ja() {
+        let report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::High)],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::Ja, &[], Some(&report), None);
+        assert!(output.contains("**総合判定: 注意が必要です**"));
+    }
+
+    #[test]
+    fn test_license_compliance_none_shows_zero_violations() {
+        let output = render_summary(Locale::En, &[], None, None);
+        assert!(output.contains("| License violations | 0 | ✅ |"));
+    }
+
+    #[test]
+    fn test_critical_overrides_warning_in_overall() {
+        let report = VulnerabilityReportView {
+            actionable: vec![
+                make_vuln(SeverityView::Critical),
+                make_vuln(SeverityView::High),
+            ],
+            ..Default::default()
+        };
+        let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("**Overall: Action required**"));
+        assert!(!output.contains("**Overall: Attention recommended**"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `#[cfg(test)] mod tests { ... }` block to `sections/summary.rs` covering the `render()` function
- Tests cover all branches: vuln_check_skipped, severity status icons, license violations, and overall line
- Both English and Japanese locales are tested

## Related Issue
Closes #448

## Changes Made
- Added 19 unit tests to `src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs`
- Tests cover section header (En/Ja), package count rows, `vuln_check_skipped` branch, all four vulnerability severity rows with correct status icons (✅/⚠️/❌), license violation row, and all three overall line variants in both locales
- Test helper functions: `make_component`, `make_vuln`, `make_license_compliance`, `render_summary`

## Test Plan
- [x] `cargo test --all` passes (508 tests, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)