### PR TITLE
feat(cli): add --workspace flag and runner integration

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -86,6 +86,10 @@ pub struct Args {
     #[arg(long)]
     pub init: bool,
 
+    /// Analyze all workspace members (requires a uv workspace root with [manifest] in uv.lock)
+    #[arg(long, conflicts_with = "output")]
+    pub workspace: bool,
+
     /// Output language for human-readable formats: en (default) or ja
     #[arg(long, default_value = "en", value_parser = parse_lang)]
     pub lang: Locale,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod shared;
 use adapters::outbound::console::StderrProgressReporter;
 use adapters::outbound::filesystem::FileSystemReader;
 use adapters::outbound::network::{CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository};
+use adapters::outbound::uv::UvWorkspaceReader;
 use application::dto::{OutputFormat, SbomRequest};
 use application::factories::{FormatterFactory, PresenterFactory, PresenterType};
 use application::read_models::SbomReadModelBuilder;
@@ -18,12 +19,53 @@ use cli::config_resolver::{load_config, merge_config};
 use cli::runner::{display_banner, resolve_suggest_fix, validate_project_path};
 use cli::Args;
 use i18n::Messages;
-use ports::outbound::ProjectConfigReader;
+use ports::outbound::{LockfileParseResult, LockfileReader, ProjectConfigReader, WorkspaceReader};
 use shared::error::ExitCode;
 use shared::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use uv_sbom::config;
+
+/// A LockfileReader adapter that reads the workspace-root uv.lock but returns
+/// only packages reachable from the specified workspace member.
+///
+/// This adapter is used in workspace mode to scope the SBOM generation to a
+/// single workspace member, delegating to `read_and_parse_lockfile_for_member`.
+struct MemberScopedLockfileReader {
+    inner: FileSystemReader,
+    workspace_root: PathBuf,
+    member_name: String,
+}
+
+impl MemberScopedLockfileReader {
+    fn new(workspace_root: PathBuf, member_name: String) -> Self {
+        Self {
+            inner: FileSystemReader::new(),
+            workspace_root,
+            member_name,
+        }
+    }
+}
+
+impl LockfileReader for MemberScopedLockfileReader {
+    fn read_lockfile(&self, _project_path: &Path) -> Result<String> {
+        self.inner.read_lockfile(&self.workspace_root)
+    }
+
+    fn read_and_parse_lockfile(&self, _project_path: &Path) -> Result<LockfileParseResult> {
+        self.inner
+            .read_and_parse_lockfile_for_member(&self.workspace_root, &self.member_name)
+    }
+
+    fn read_and_parse_lockfile_for_member(
+        &self,
+        _project_path: &Path,
+        member_name: &str,
+    ) -> Result<LockfileParseResult> {
+        self.inner
+            .read_and_parse_lockfile_for_member(&self.workspace_root, member_name)
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -43,6 +85,25 @@ async fn main() {
             process::exit(exit_code.as_i32());
         }
     };
+
+    // Handle --workspace mode before normal flow
+    if args.workspace {
+        let workspace_root = PathBuf::from(args.path.as_deref().unwrap_or("."));
+        match run_workspace(args, workspace_root).await {
+            Ok(()) => process::exit(ExitCode::Success.as_i32()),
+            Err(e) => {
+                eprintln!("\n❌ An error occurred:\n");
+                eprintln!("{}", e);
+                let mut source = e.source();
+                while let Some(err) = source {
+                    eprintln!("\nCaused by: {}", err);
+                    source = err.source();
+                }
+                eprintln!();
+                process::exit(ExitCode::ApplicationError.as_i32());
+            }
+        }
+    }
 
     // Handle --init before normal flow
     if args.init {
@@ -263,4 +324,109 @@ async fn run(args: Args) -> Result<bool> {
         response.has_vulnerabilities_above_threshold || response.has_license_violations;
 
     Ok(has_issues)
+}
+
+/// Runs workspace mode: generates one SBOM per workspace member.
+///
+/// Reads `[manifest].members` from `workspace_root/uv.lock`, then for each
+/// member runs `GenerateSbomUseCase` scoped to that member and writes the
+/// output to `{member_path}/sbom.{ext}`. Prints a summary table when done.
+async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
+    display_banner();
+
+    validate_project_path(&workspace_root)?;
+
+    let workspace_reader = UvWorkspaceReader::new();
+    let members = workspace_reader.read_workspace_members(&workspace_root)?;
+
+    if members.is_empty() {
+        anyhow::bail!("No workspace members found. Is this a uv workspace?");
+    }
+
+    eprintln!("Workspace mode: {} members found\n", members.len());
+
+    let locale = args.lang;
+    let config = load_config(&args, &workspace_root)?;
+    let merged = merge_config(&args, &config);
+
+    let format_ext = match merged.format {
+        OutputFormat::Json => "json",
+        OutputFormat::Markdown => "md",
+    };
+
+    let mut summary: Vec<(String, PathBuf)> = Vec::new();
+
+    for member in &members {
+        eprintln!("  Processing: {}", member.name);
+
+        let lockfile_reader =
+            MemberScopedLockfileReader::new(workspace_root.clone(), member.name.clone());
+        let project_config_reader = FileSystemReader::new();
+        let pypi_repository = PyPiLicenseRepository::new()?;
+        let license_repository = CachingPyPiLicenseRepository::new(pypi_repository);
+        let progress_reporter = StderrProgressReporter::new(locale);
+
+        let vulnerability_repository = if merged.check_cve {
+            Some(OsvClient::new()?)
+        } else {
+            None
+        };
+
+        let use_case = GenerateSbomUseCase::new(
+            lockfile_reader,
+            project_config_reader,
+            license_repository,
+            progress_reporter,
+            vulnerability_repository,
+            locale,
+        );
+
+        let include_dependency_info = matches!(merged.format, OutputFormat::Markdown);
+        let request = SbomRequest::builder()
+            .project_path(member.absolute_path.clone())
+            .include_dependency_info(include_dependency_info)
+            .exclude_patterns(merged.exclude_patterns.clone())
+            .check_cve(merged.check_cve)
+            .severity_threshold_opt(merged.severity_threshold)
+            .cvss_threshold_opt(merged.cvss_threshold)
+            .ignore_cves(merged.ignore_cves.clone())
+            .check_license(merged.check_license)
+            .license_policy(merged.license_policy.clone())
+            .suggest_fix(false)
+            .locale(locale)
+            .build()?;
+
+        let response = use_case.execute(request).await?;
+
+        let read_model = SbomReadModelBuilder::build_with_project(
+            response.enriched_packages,
+            &response.metadata,
+            response.dependency_graph.as_ref(),
+            response.vulnerability_check_result.as_ref(),
+            response.license_compliance_result.as_ref(),
+            None,
+            response.upgrade_recommendations.as_deref(),
+        );
+
+        let formatter = FormatterFactory::create(merged.format, None, locale);
+        let formatted_output = formatter.format(&read_model)?;
+
+        let output_path = member.absolute_path.join(format!("sbom.{}", format_ext));
+        let presenter = PresenterFactory::create(PresenterType::File(output_path.clone()));
+        presenter.present(&formatted_output)?;
+
+        summary.push((member.name.clone(), output_path));
+    }
+
+    // Print summary table
+    eprintln!("\n📦 Workspace SBOM Summary");
+    eprintln!("{}", "─".repeat(60));
+    eprintln!("{:<20} Output File", "Member");
+    eprintln!("{}", "─".repeat(60));
+    for (name, path) in &summary {
+        eprintln!("{:<20} {}", name, path.display());
+    }
+    eprintln!("{}", "─".repeat(60));
+
+    Ok(())
 }

--- a/tests/e2e_workspace.rs
+++ b/tests/e2e_workspace.rs
@@ -1,0 +1,135 @@
+/// End-to-end tests for workspace mode (--workspace flag)
+mod workspace_tests {
+    use assert_cmd::cargo::cargo_bin_cmd;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Copies the workspace fixture into a temp directory and returns it.
+    /// This is needed because workspace mode writes sbom.* files inside
+    /// the fixture directories, which would pollute the source tree.
+    fn setup_workspace_temp() -> TempDir {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let src = std::path::Path::new("tests/fixtures/workspace");
+
+        // Copy uv.lock
+        fs::copy(src.join("uv.lock"), temp.path().join("uv.lock")).unwrap();
+
+        // Copy packages/api/
+        let api_dir = temp.path().join("packages/api");
+        fs::create_dir_all(&api_dir).unwrap();
+        fs::copy(
+            src.join("packages/api/pyproject.toml"),
+            api_dir.join("pyproject.toml"),
+        )
+        .unwrap();
+
+        // Copy packages/worker/
+        let worker_dir = temp.path().join("packages/worker");
+        fs::create_dir_all(&worker_dir).unwrap();
+        fs::copy(
+            src.join("packages/worker/pyproject.toml"),
+            worker_dir.join("pyproject.toml"),
+        )
+        .unwrap();
+
+        temp
+    }
+
+    /// --workspace generates sbom.json for each member
+    #[test]
+    fn test_workspace_generates_sbom_per_member() {
+        let temp = setup_workspace_temp();
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--workspace",
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+                "--format",
+                "json",
+            ])
+            .assert()
+            .code(0);
+
+        assert!(
+            temp.path().join("packages/api/sbom.json").exists(),
+            "sbom.json must exist for member api"
+        );
+        assert!(
+            temp.path().join("packages/worker/sbom.json").exists(),
+            "sbom.json must exist for member worker"
+        );
+    }
+
+    /// --workspace generates sbom.md for each member when --format markdown
+    #[test]
+    fn test_workspace_generates_markdown_sbom_per_member() {
+        let temp = setup_workspace_temp();
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--workspace",
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+                "--format",
+                "markdown",
+            ])
+            .assert()
+            .code(0);
+
+        assert!(
+            temp.path().join("packages/api/sbom.md").exists(),
+            "sbom.md must exist for member api"
+        );
+        assert!(
+            temp.path().join("packages/worker/sbom.md").exists(),
+            "sbom.md must exist for member worker"
+        );
+    }
+
+    /// --workspace on a non-workspace directory exits with error
+    #[test]
+    fn test_workspace_on_non_workspace_exits_with_error() {
+        let temp = TempDir::new().unwrap();
+        // Write a minimal non-workspace uv.lock (no [manifest] section)
+        fs::write(
+            temp.path().join("uv.lock"),
+            r#"version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "my-project"
+version = "1.0.0"
+source = { virtual = "." }
+"#,
+        )
+        .unwrap();
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--workspace",
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+            ])
+            .assert()
+            .code(3);
+    }
+
+    /// --workspace --output is mutually exclusive (clap should reject it)
+    #[test]
+    fn test_workspace_and_output_are_mutually_exclusive() {
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--workspace",
+                "--path",
+                "tests/fixtures/workspace",
+                "--output",
+                "/tmp/sbom.json",
+            ])
+            .assert()
+            .code(2);
+    }
+}

--- a/tests/fixtures/workspace/packages/api/pyproject.toml
+++ b/tests/fixtures/workspace/packages/api/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "api"
+version = "0.1.0"
+requires-python = ">=3.11"

--- a/tests/fixtures/workspace/packages/worker/pyproject.toml
+++ b/tests/fixtures/workspace/packages/worker/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "worker"
+version = "0.1.0"
+requires-python = ">=3.11"

--- a/tests/fixtures/workspace/uv.lock
+++ b/tests/fixtures/workspace/uv.lock
@@ -1,0 +1,18 @@
+version = 1
+requires-python = ">=3.11"
+
+[manifest]
+members = [
+    "packages/api",
+    "packages/worker",
+]
+
+[[package]]
+name = "api"
+version = "0.1.0"
+source = { editable = "packages/api" }
+
+[[package]]
+name = "worker"
+version = "0.1.0"
+source = { editable = "packages/worker" }


### PR DESCRIPTION
## Summary
- Add `--workspace` boolean flag to CLI with `conflicts_with = "output"` constraint
- Implement per-member SBOM generation orchestration via `MemberScopedLockfileReader` adapter and `run_workspace()` runner
- Add minimal workspace test fixture and comprehensive e2e test suite

## Related Issue
Closes #443

## Changes Made
- **`src/cli/mod.rs`**: Added `--workspace` flag (`conflicts_with = "output"`)
- **`src/main.rs`**:
  - Added `MemberScopedLockfileReader` adapter that reads workspace-root `uv.lock` but scopes package resolution to a specific member via `read_and_parse_lockfile_for_member`
  - Added `run_workspace()` async function that reads workspace members with `UvWorkspaceReader`, runs `GenerateSbomUseCase` per member, writes `sbom.{json,md}` to each member directory, and prints a summary table
  - Added workspace mode branch in `main()` before the normal flow
- **`tests/fixtures/workspace/`**: Minimal workspace fixture with two members (`api`, `worker`) and no external dependencies (ensures no network calls in tests)
- **`tests/e2e_workspace.rs`**: Four e2e tests covering:
  - JSON SBOM generation per member
  - Markdown SBOM generation per member
  - Error on non-workspace directory ("No workspace members found")
  - `--workspace` + `--output` mutual exclusion (exit code 2)

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)