### PR TITLE
test(formatters): add unit tests to sections/dependencies.rs

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/sections/dependencies.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/dependencies.rs
@@ -93,3 +93,180 @@ pub(in super::super) fn render(
         output.push_str("\n\n");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::{ComponentView, DependencyView, LicenseView};
+    use crate::i18n::Locale;
+
+    fn make_component(bom_ref: &str, name: &str, version: &str) -> ComponentView {
+        ComponentView {
+            bom_ref: bom_ref.to_string(),
+            name: name.to_string(),
+            version: version.to_string(),
+            purl: format!("pkg:pypi/{name}@{version}"),
+            license: Some(LicenseView {
+                spdx_id: Some("MIT".to_string()),
+                name: "MIT License".to_string(),
+                url: None,
+            }),
+            description: Some(format!("{name} description")),
+            sha256_hash: None,
+            is_direct_dependency: true,
+        }
+    }
+
+    fn call_render(locale: Locale, deps: &DependencyView, components: &[ComponentView]) -> String {
+        let messages = crate::i18n::Messages::for_locale(locale);
+        let mut output = String::new();
+        render(messages, None, &mut output, deps, components);
+        output
+    }
+
+    // --- i18n header tests ---
+
+    #[test]
+    fn test_section_headers_en() {
+        let deps = DependencyView::default();
+        let output = call_render(Locale::En, &deps, &[]);
+
+        assert!(output.contains("## Direct Dependencies"));
+        assert!(output.contains("## Transitive Dependencies"));
+    }
+
+    #[test]
+    fn test_section_headers_ja() {
+        let deps = DependencyView::default();
+        let output = call_render(Locale::Ja, &deps, &[]);
+
+        assert!(output.contains("## 直接依存パッケージ"));
+        assert!(output.contains("## 間接依存パッケージ"));
+    }
+
+    // --- empty-dependency edge cases ---
+
+    #[test]
+    fn test_empty_direct_deps_shows_label() {
+        let deps = DependencyView::default();
+        let output = call_render(Locale::En, &deps, &[]);
+
+        assert!(output.contains("*No direct dependencies*"));
+    }
+
+    #[test]
+    fn test_empty_transitive_deps_shows_label() {
+        let deps = DependencyView::default();
+        let output = call_render(Locale::En, &deps, &[]);
+
+        assert!(output.contains("*No transitive dependencies*"));
+    }
+
+    #[test]
+    fn test_empty_labels_ja() {
+        let deps = DependencyView::default();
+        let output = call_render(Locale::Ja, &deps, &[]);
+
+        assert!(output.contains("*直接依存パッケージなし*"));
+        assert!(output.contains("*間接依存パッケージなし*"));
+    }
+
+    // --- direct dependency row rendering ---
+
+    #[test]
+    fn test_direct_dep_row_appears() {
+        let component = make_component("pkg-a", "requests", "2.31.0");
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+
+        let output = call_render(Locale::En, &deps, &[component]);
+
+        assert!(output.contains("requests"));
+        assert!(output.contains("2.31.0"));
+        assert!(output.contains("MIT"));
+    }
+
+    #[test]
+    fn test_multiple_direct_deps_appear() {
+        let comp_a = make_component("pkg-a", "requests", "2.31.0");
+        let comp_b = make_component("pkg-b", "httpx", "0.25.0");
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+        deps.direct.push("pkg-b".to_string());
+
+        let output = call_render(Locale::En, &deps, &[comp_a, comp_b]);
+
+        assert!(output.contains("requests"));
+        assert!(output.contains("httpx"));
+    }
+
+    #[test]
+    fn test_direct_dep_no_license_shows_na() {
+        let mut component = make_component("pkg-a", "no-license-pkg", "1.0.0");
+        component.license = None;
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+
+        let output = call_render(Locale::En, &deps, &[component]);
+
+        assert!(output.contains("N/A"));
+    }
+
+    // --- transitive dependency row rendering ---
+
+    #[test]
+    fn test_transitive_dep_row_appears() {
+        let direct = make_component("pkg-a", "requests", "2.31.0");
+        let transitive = make_component("pkg-b", "urllib3", "2.0.7");
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+        deps.transitive
+            .insert("pkg-a".to_string(), vec!["pkg-b".to_string()]);
+
+        let output = call_render(Locale::En, &deps, &[direct, transitive]);
+
+        assert!(output.contains("urllib3"));
+        assert!(output.contains("2.0.7"));
+    }
+
+    #[test]
+    fn test_transitive_section_header_shows_parent_name() {
+        let direct = make_component("pkg-a", "requests", "2.31.0");
+        let transitive = make_component("pkg-b", "urllib3", "2.0.7");
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+        deps.transitive
+            .insert("pkg-a".to_string(), vec!["pkg-b".to_string()]);
+
+        let output = call_render(Locale::En, &deps, &[direct, transitive]);
+
+        assert!(output.contains("### Dependencies for requests"));
+    }
+
+    #[test]
+    fn test_transitive_section_header_shows_parent_name_ja() {
+        let direct = make_component("pkg-a", "requests", "2.31.0");
+        let transitive = make_component("pkg-b", "urllib3", "2.0.7");
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+        deps.transitive
+            .insert("pkg-a".to_string(), vec!["pkg-b".to_string()]);
+
+        let output = call_render(Locale::Ja, &deps, &[direct, transitive]);
+
+        assert!(output.contains("### requestsの依存パッケージ"));
+    }
+
+    #[test]
+    fn test_direct_with_no_transitive_shows_no_transitive_label() {
+        let component = make_component("pkg-a", "requests", "2.31.0");
+        let mut deps = DependencyView::default();
+        deps.direct.push("pkg-a".to_string());
+        // transitive is empty
+
+        let output = call_render(Locale::En, &deps, &[component]);
+
+        assert!(output.contains("requests"));
+        assert!(output.contains("*No transitive dependencies*"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `#[cfg(test)] mod tests { ... }` block to `sections/dependencies.rs`
- Cover all four test scope areas specified in issue #449

## Related Issue
Closes #449

## Changes Made
- Added 12 unit tests to `src/adapters/outbound/formatters/markdown_formatter/sections/dependencies.rs`
  - `test_section_headers_en` / `test_section_headers_ja` — i18n section headers
  - `test_empty_direct_deps_shows_label` / `test_empty_transitive_deps_shows_label` / `test_empty_labels_ja` — empty-dependency edge cases
  - `test_direct_dep_row_appears` / `test_multiple_direct_deps_appear` / `test_direct_dep_no_license_shows_na` — direct dependency rows
  - `test_transitive_dep_row_appears` / `test_transitive_section_header_shows_parent_name` / `test_transitive_section_header_shows_parent_name_ja` — transitive rows and sub-headers
  - `test_direct_with_no_transitive_shows_no_transitive_label` — mixed state (direct deps present, transitive empty)

## Test Plan
- [x] `cargo test --all` passes (12 new tests, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)