### PR TITLE
feat(config): add workspace option to --init config template

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,9 @@ const CONFIG_TEMPLATE: &str = r#"# uv-sbom configuration file
 
 # Suggest upgrade paths to fix vulnerable transitive dependencies (requires check_cve: true)
 # suggest_fix: false
+
+# Enable workspace mode: generate per-member SBOMs for uv workspaces (equivalent to --workspace flag)
+# workspace: false
 "#;
 
 /// Generate a config template file in the specified directory.


### PR DESCRIPTION
## Summary
- Add a commented-out `workspace: false` entry to `CONFIG_TEMPLATE` in `src/config.rs`
- Improves discoverability of the `--workspace` flag (introduced in #454) for users who inspect the generated `.uv-sbom.yml`

## Related Issue
Closes #456

## Changes Made
- **`src/config.rs`**: Appended a commented-out `workspace: false` block at the end of `CONFIG_TEMPLATE` with a brief description referencing the `--workspace` CLI flag

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)