### PR TITLE
test(formatters): add unit tests to sections/license_compliance.rs (#450)

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/sections/license_compliance.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/license_compliance.rs
@@ -94,3 +94,242 @@ pub(in super::super) fn render(
         output.push('\n');
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::{
+        LicenseComplianceSummary, LicenseComplianceView, LicenseViolationView, LicenseWarningView,
+    };
+    use crate::i18n::{Locale, Messages};
+
+    fn make_compliance(
+        violations: Vec<LicenseViolationView>,
+        warnings: Vec<LicenseWarningView>,
+    ) -> LicenseComplianceView {
+        let violation_count = violations.len();
+        let warning_count = warnings.len();
+        LicenseComplianceView {
+            has_violations: violation_count > 0,
+            summary: LicenseComplianceSummary {
+                violation_count,
+                warning_count,
+            },
+            violations,
+            warnings,
+        }
+    }
+
+    fn make_violation(
+        package: &str,
+        version: &str,
+        license: &str,
+        reason: &str,
+        pattern: Option<&str>,
+    ) -> LicenseViolationView {
+        LicenseViolationView {
+            package_name: package.to_string(),
+            package_version: version.to_string(),
+            license: license.to_string(),
+            reason: reason.to_string(),
+            matched_pattern: pattern.map(|s| s.to_string()),
+        }
+    }
+
+    fn make_warning(package: &str, version: &str) -> LicenseWarningView {
+        LicenseWarningView {
+            package_name: package.to_string(),
+            package_version: version.to_string(),
+        }
+    }
+
+    fn call_render(locale: Locale, compliance: &LicenseComplianceView) -> String {
+        let messages = Messages::for_locale(locale);
+        let mut output = String::new();
+        render(messages, &mut output, compliance);
+        output
+    }
+
+    // --- section header ---
+
+    #[test]
+    fn test_section_header_en() {
+        let compliance = make_compliance(vec![], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("## License Compliance Report"));
+    }
+
+    #[test]
+    fn test_section_header_ja() {
+        let compliance = make_compliance(vec![], vec![]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("## ライセンスコンプライアンスレポート"));
+    }
+
+    // --- zero-violation edge case ---
+
+    #[test]
+    fn test_zero_violations_shows_no_violations_label_en() {
+        let compliance = make_compliance(vec![], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("**No license violations found.**"));
+    }
+
+    #[test]
+    fn test_zero_violations_shows_no_violations_label_ja() {
+        let compliance = make_compliance(vec![], vec![]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("**ライセンス違反は見つかりませんでした。**"));
+    }
+
+    #[test]
+    fn test_zero_violations_no_violations_table() {
+        let compliance = make_compliance(vec![], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(!output.contains("### Violations"));
+    }
+
+    // --- violation count summary (singular/plural) ---
+
+    #[test]
+    fn test_single_violation_count_singular_en() {
+        let v = make_violation("pkg-a", "1.0.0", "GPL-3.0", "Copyleft", Some("GPL*"));
+        let compliance = make_compliance(vec![v], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("**1 license violation found.**"));
+    }
+
+    #[test]
+    fn test_multiple_violations_count_plural_en() {
+        let v1 = make_violation("pkg-a", "1.0.0", "GPL-3.0", "Copyleft", Some("GPL*"));
+        let v2 = make_violation("pkg-b", "2.0.0", "AGPL-3.0", "Copyleft", None);
+        let compliance = make_compliance(vec![v1, v2], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("**2 license violations found.**"));
+    }
+
+    #[test]
+    fn test_single_violation_count_ja() {
+        let v = make_violation("pkg-a", "1.0.0", "GPL-3.0", "Copyleft", Some("GPL*"));
+        let compliance = make_compliance(vec![v], vec![]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("**1 件のライセンス違反が見つかりました。**"));
+    }
+
+    #[test]
+    fn test_multiple_violations_count_ja() {
+        let v1 = make_violation("pkg-a", "1.0.0", "GPL-3.0", "Copyleft", Some("GPL*"));
+        let v2 = make_violation("pkg-b", "2.0.0", "AGPL-3.0", "Copyleft", None);
+        let compliance = make_compliance(vec![v1, v2], vec![]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("**2 件のライセンス違反が見つかりました。**"));
+    }
+
+    // --- violations table rows ---
+
+    #[test]
+    fn test_violations_table_contains_package_info() {
+        let v = make_violation(
+            "requests",
+            "2.31.0",
+            "GPL-3.0",
+            "Copyleft license",
+            Some("GPL*"),
+        );
+        let compliance = make_compliance(vec![v], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("requests"));
+        assert!(output.contains("2.31.0"));
+        assert!(output.contains("GPL-3.0"));
+        assert!(output.contains("Copyleft license"));
+        assert!(output.contains("GPL*"));
+    }
+
+    #[test]
+    fn test_violations_table_no_matched_pattern_shows_dash() {
+        let v = make_violation("pkg-a", "1.0.0", "GPL-3.0", "Copyleft", None);
+        let compliance = make_compliance(vec![v], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("| - |"));
+    }
+
+    #[test]
+    fn test_violations_table_header_en() {
+        let v = make_violation("pkg-a", "1.0.0", "GPL-3.0", "Copyleft", None);
+        let compliance = make_compliance(vec![v], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("### Violations"));
+        assert!(output.contains("| Package | Version | License | Reason | Matched Pattern |"));
+    }
+
+    #[test]
+    fn test_violations_table_header_ja() {
+        let v = make_violation("pkg-a", "1.0.0", "GPL-3.0", "コピーレフト", None);
+        let compliance = make_compliance(vec![v], vec![]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("### 違反"));
+        assert!(
+            output.contains("| パッケージ | バージョン | ライセンス | 理由 | マッチしたパターン |")
+        );
+    }
+
+    // --- warnings table ---
+
+    #[test]
+    fn test_warnings_section_not_rendered_when_empty() {
+        let compliance = make_compliance(vec![], vec![]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(!output.contains("### Warnings"));
+    }
+
+    #[test]
+    fn test_warnings_single_package_singular_en() {
+        let w = make_warning("unknown-pkg", "0.1.0");
+        let compliance = make_compliance(vec![], vec![w]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("**1 package with unknown license.**"));
+    }
+
+    #[test]
+    fn test_warnings_multiple_packages_plural_en() {
+        let w1 = make_warning("pkg-a", "1.0.0");
+        let w2 = make_warning("pkg-b", "2.0.0");
+        let compliance = make_compliance(vec![], vec![w1, w2]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("**2 packages with unknown license.**"));
+    }
+
+    #[test]
+    fn test_warnings_count_ja() {
+        let w1 = make_warning("pkg-a", "1.0.0");
+        let w2 = make_warning("pkg-b", "2.0.0");
+        let compliance = make_compliance(vec![], vec![w1, w2]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("**2個のライセンス不明パッケージがあります。**"));
+    }
+
+    #[test]
+    fn test_warnings_table_contains_package_info() {
+        let w = make_warning("unknown-pkg", "0.1.0");
+        let compliance = make_compliance(vec![], vec![w]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("unknown-pkg"));
+        assert!(output.contains("0.1.0"));
+    }
+
+    #[test]
+    fn test_warnings_header_en() {
+        let w = make_warning("unknown-pkg", "0.1.0");
+        let compliance = make_compliance(vec![], vec![w]);
+        let output = call_render(Locale::En, &compliance);
+        assert!(output.contains("### Warnings"));
+    }
+
+    #[test]
+    fn test_warnings_header_ja() {
+        let w = make_warning("unknown-pkg", "0.1.0");
+        let compliance = make_compliance(vec![], vec![w]);
+        let output = call_render(Locale::Ja, &compliance);
+        assert!(output.contains("### 警告"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `#[cfg(test)] mod tests { ... }` block to `sections/license_compliance.rs`
- 20 unit tests covering zero-violation edge case, violation count summary (singular/plural), violations table, warnings table, and i18n (En + Ja)

## Related Issue
Closes #450

## Changes Made
- Added `#[cfg(test)] mod tests` block directly in `license_compliance.rs`
- Tests cover section header rendering in both locales
- Tests cover zero-violation label (no violations table rendered)
- Tests cover singular/plural violation count summary in English
- Tests cover Japanese violation count (no plural distinction)
- Tests cover violations table rows including `matched_pattern = None` showing "-"
- Tests cover warnings section with singular/plural package count (En/Ja)
- Tests cover warnings table row content

## Test Plan
- [x] `cargo test --all` passes (553 tests, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)