### PR TITLE
docs: add --workspace section to README and README-JP

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -600,6 +600,56 @@ No security vulnerabilities were found in the scanned packages.
 *Vulnerability data provided by [OSV](https://osv.dev) under CC-BY 4.0*
 ```
 
+### uv ワークスペースサポート
+
+[uv ワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)を使うと、共通の `uv.lock` ファイルを持つ複数の Python パッケージをひとつのリポジトリで管理できます。`uv-sbom --workspace` は各メンバーパッケージごとに個別の SBOM を生成し、そのメンバーから到達可能な依存関係のみを反映します。
+
+**こんなときに使う:**
+- リポジトリに複数の Python パッケージ（例: `api/`、`worker/`）が含まれている
+- セキュリティスキャンやコンプライアンス対応のためにメンバーごとの SBOM が必要
+
+**使用例:**
+
+```bash
+# ワークスペースの各メンバーに対して SBOM を生成（デフォルト: CycloneDX JSON）
+uv-sbom --workspace --path /path/to/workspace
+```
+
+**実行結果の例:**
+
+```
+Workspace mode: 2 members found
+
+  Processing: api
+  ...
+  Processing: worker
+  ...
+
+📦 Workspace SBOM Summary
+────────────────────────────────────────────────────────────
+Member               Output File
+────────────────────────────────────────────────────────────
+api                  /path/to/workspace/packages/api/sbom.json
+worker               /path/to/workspace/packages/worker/sbom.json
+────────────────────────────────────────────────────────────
+```
+
+各メンバーは、そのメンバーから到達可能なパッケージのみを含む独自の `sbom.json` を取得します。推移的依存関係は含まれますが、他のメンバーに属するパッケージは除外されます。
+
+**他のオプションとの組み合わせ:**
+
+```bash
+# 全メンバーを Markdown 形式で出力
+uv-sbom --workspace --path examples/workspace --format markdown
+
+# CVE チェックを追加
+uv-sbom --workspace --path examples/workspace --check-cve
+```
+
+> **注意:** `--workspace` と `--output` は同時に使用できません。ワークスペースモードでは、各メンバーの SBOM は自動的にメンバー自身のディレクトリ内の `sbom.json`（Markdown の場合は `sbom.md`）に書き込まれます。
+
+2 つのメンバーパッケージ（`api` と `worker`）を含む実行可能なデモは [`examples/workspace/`](examples/workspace/) を参照してください。
+
 ### dry-runモードで設定を検証する
 
 `--dry-run`オプションを使用して、ツールが外部レジストリと通信する前に設定を検証できます：
@@ -698,6 +748,8 @@ Options:
                                      --no-check-cveとの同時使用は不可
       --suggest-fix                  推移的脆弱性を解決するための直接依存関係アップグレードバージョンを提案
                                      --no-check-cveとの同時使用は不可、uvのインストール、プロジェクトディレクトリのpyproject.tomlが必要
+      --workspace                    ワークスペースの各メンバーに対して SBOM を生成
+                                     --outputとの同時使用は不可
       --check-license                ライセンスコンプライアンスをポリシーに対してチェック
       --license-allow <LIST>         許可するライセンスパターンのカンマ区切りリスト（設定ファイルを上書き）
       --license-deny <LIST>          拒否するライセンスパターンのカンマ区切りリスト（設定ファイルを上書き）

--- a/README.md
+++ b/README.md
@@ -603,6 +603,60 @@ No security vulnerabilities were found in the scanned packages.
 *Vulnerability data provided by [OSV](https://osv.dev) under CC-BY 4.0*
 ```
 
+### uv Workspace Support
+
+[uv workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) let you manage multiple Python
+packages in a single repository with a shared `uv.lock` file. `uv-sbom --workspace` generates a separate
+SBOM for each member package, reflecting only the dependencies reachable from that member.
+
+**When to use:**
+- Your repository contains multiple Python packages (e.g., `api/`, `worker/`)
+- You need per-member SBOMs for independent security scanning or compliance reporting
+
+**Usage:**
+
+```bash
+# Generate one SBOM per workspace member (CycloneDX JSON, default)
+uv-sbom --workspace --path /path/to/workspace
+```
+
+**Expected output:**
+
+```
+Workspace mode: 2 members found
+
+  Processing: api
+  ...
+  Processing: worker
+  ...
+
+📦 Workspace SBOM Summary
+────────────────────────────────────────────────────────────
+Member               Output File
+────────────────────────────────────────────────────────────
+api                  /path/to/workspace/packages/api/sbom.json
+worker               /path/to/workspace/packages/worker/sbom.json
+────────────────────────────────────────────────────────────
+```
+
+Each member gets its own `sbom.json` containing only the packages reachable from that member.
+Transitive dependencies are included, but packages belonging to other members are excluded.
+
+**With other options:**
+
+```bash
+# Markdown output for all members
+uv-sbom --workspace --path examples/workspace --format markdown
+
+# With CVE check
+uv-sbom --workspace --path examples/workspace --check-cve
+```
+
+> **Note:** `--workspace` and `--output` are mutually exclusive. In workspace mode, each member's SBOM is
+> automatically written to `sbom.json` (or `sbom.md` for Markdown) inside the member's own directory.
+
+See [`examples/workspace/`](examples/workspace/) for a runnable demo with two member packages (`api` and `worker`).
+
 ### Validating configuration with dry-run
 
 Use the `--dry-run` option to validate your configuration before the tool communicates with external registries:
@@ -700,6 +754,8 @@ Options:
                                      Cannot be used with --no-check-cve
       --suggest-fix                  Suggest direct dependency upgrade versions to resolve transitive vulnerabilities
                                      Requires uv CLI installed and pyproject.toml in project directory
+      --workspace                    Generate one SBOM per workspace member
+                                     Cannot be used with --output
       --check-license                Check license compliance against policy
       --license-allow <LIST>         Comma-separated list of allowed license patterns (overrides config)
       --license-deny <LIST>          Comma-separated list of denied license patterns (overrides config)


### PR DESCRIPTION
## Summary
- Add a dedicated **uv Workspace Support** section to both `README.md` and `README-JP.md`
- Document `--workspace` in the Command-line options reference table of both files

## Related Issue
Closes #445

## Changes Made
- `README.md`: New "uv Workspace Support" section with usage example, expected stdout output, mutual-exclusion note (`--workspace` / `--output`), and link to `examples/workspace/`
- `README-JP.md`: Full Japanese translation of the above section
- Both files: `--workspace` added to the Command-line options table

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] Documentation content verified against `examples/workspace/README.md`

---
Generated with [Claude Code](https://claude.com/claude-code)