### PR TITLE
docs: fix deprecated --check-cve in workspace examples (#462)

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -604,7 +604,7 @@ No security vulnerabilities were found in the scanned packages.
 
 [uv ワークスペース](https://docs.astral.sh/uv/concepts/projects/workspaces/)を使うと、共通の `uv.lock` ファイルを持つ複数の Python パッケージをひとつのリポジトリで管理できます。`uv-sbom --workspace` は各メンバーパッケージごとに個別の SBOM を生成し、そのメンバーから到達可能な依存関係のみを反映します。
 
-**こんなときに使う:**
+**ユースケース:**
 - リポジトリに複数の Python パッケージ（例: `api/`、`worker/`）が含まれている
 - セキュリティスキャンやコンプライアンス対応のためにメンバーごとの SBOM が必要
 
@@ -642,8 +642,8 @@ worker               /path/to/workspace/packages/worker/sbom.json
 # 全メンバーを Markdown 形式で出力
 uv-sbom --workspace --path examples/workspace --format markdown
 
-# CVE チェックを追加
-uv-sbom --workspace --path examples/workspace --check-cve
+# ライセンスコンプライアンスチェックを追加
+uv-sbom --workspace --path examples/workspace --check-license
 ```
 
 > **注意:** `--workspace` と `--output` は同時に使用できません。ワークスペースモードでは、各メンバーの SBOM は自動的にメンバー自身のディレクトリ内の `sbom.json`（Markdown の場合は `sbom.md`）に書き込まれます。

--- a/README.md
+++ b/README.md
@@ -648,8 +648,8 @@ Transitive dependencies are included, but packages belonging to other members ar
 # Markdown output for all members
 uv-sbom --workspace --path examples/workspace --format markdown
 
-# With CVE check
-uv-sbom --workspace --path examples/workspace --check-cve
+# With license compliance check
+uv-sbom --workspace --path examples/workspace --check-license
 ```
 
 > **Note:** `--workspace` and `--output` are mutually exclusive. In workspace mode, each member's SBOM is


### PR DESCRIPTION
## Summary
- Replace deprecated `--check-cve` flag with `--check-license` in workspace usage examples in both `README.md` and `README-JP.md`
- Replace colloquial Japanese heading `こんなときに使う:` with the more technical `ユースケース:` in `README-JP.md`

## Related Issue
Closes #462

## Changes Made
- `README.md` line 651–652: replaced `--check-cve` example with `--check-license`
- `README-JP.md` line 607: replaced `こんなときに使う:` with `ユースケース:`
- `README-JP.md` lines 645–646: replaced `--check-cve` example with `--check-license`

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Documentation-only changes verified; no broken links or formatting issues

---
Generated with [Claude Code](https://claude.com/claude-code)