### PR TITLE
docs(skills): strengthen i18n enforcement in code-review and implement skills

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -39,6 +39,19 @@ git diff HEAD               # full diff for the reviewer
 For each file listed by `--name-only`, also read its **full current content**.
 This is required for file-size checks and documentation coverage checks.
 
+In addition, run the following scan and include its output as supplemental
+context for criterion 11:
+
+```bash
+grep -rn 'eprintln!\|println!' src/ \
+  | grep -v 'msgs\.\|Messages::' \
+  | grep -v '#\[cfg(test)\]' \
+  | grep -v '\.rs:.*//.*i18n-ok'
+```
+
+- Lines in **changed files**: flag as 🔴 MUST FIX under criterion 11.
+- Lines in **unchanged files**: flag as 🟡 SHOULD FIX (pre-existing violation).
+
 If `git diff HEAD` is empty, report "Nothing to review — no uncommitted changes."
 and exit.
 
@@ -243,9 +256,15 @@ Sensitive data:
 
 ### 11. i18n Consistency
 
-- Does any new user-visible string bypass the i18n system (hardcoded English in output)?
-- Are new message keys added to both EN_MESSAGES and JA_MESSAGES?
-- If {} placeholder order differs between EN and JA templates, is this covered by tests?
+User-visible string bypass (🔴 MUST FIX if any):
+- Does any new user-visible string bypass the i18n system (hardcoded English
+  in `eprintln!`/`println!` output)?
+- Is a new message key missing from either `EN_MESSAGES` or `JA_MESSAGES`
+  in `src/i18n/mod.rs`?
+
+Test coverage (🟡 SHOULD FIX):
+- If `{}` placeholder order differs between EN and JA templates, is this
+  covered by a dedicated unit test in `src/i18n/mod.rs`?
 
 ---
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -61,9 +61,12 @@ git checkout -b <branch-name> origin/develop
 ### Step 4: Implement Changes
 
 - Follow the issue's technical specifications
-- Adhere to project architecture (see `.claude/instructions.md`)
+- Adhere to project architecture (see `.claude/CLAUDE.md`)
 - Add tests for new functionality
 - Update documentation as needed
+- **i18n**: Every new user-visible string output via `eprintln!` or `println!`
+  MUST be added as a named key in both `EN_MESSAGES` and `JA_MESSAGES` in
+  `src/i18n/mod.rs`. Never hardcode English text in output paths.
 
 ### Step 4.5: Code Review (MANDATORY)
 


### PR DESCRIPTION
## Summary
- Promote hardcoded user-visible strings to 🔴 MUST FIX in `/code-review` Section 11
- Add supplemental `grep` scan to `/code-review` Step 1 to surface pre-existing i18n violations
- Add explicit i18n bullet to `/implement` Step 4 to enforce i18n at implementation time

## Related Issue
Closes #464

## Changes Made
- `.claude/skills/code-review/SKILL.md`: Section 11 now labels hardcoded user-visible strings as 🔴 MUST FIX and missing placeholder-order tests as 🟡 SHOULD FIX
- `.claude/skills/code-review/SKILL.md`: Step 1 appends a `grep` scan for `eprintln!`/`println!` calls bypassing `Messages::`; changed-file matches → 🔴, unchanged-file matches → 🟡
- `.claude/skills/implement/SKILL.md`: Step 4 adds an explicit i18n bullet requiring all new user-visible strings to be keyed in both `EN_MESSAGES` and `JA_MESSAGES`
- `.claude/skills/implement/SKILL.md`: Fix incorrect path reference `.claude/instructions.md` → `.claude/CLAUDE.md`

## Test Plan
- [ ] No Rust source changes — `cargo fmt`/`cargo clippy`/`cargo test` not applicable
- [ ] Acceptance criteria verified:
  - Section 11 labels hardcoded strings as 🔴 MUST FIX ✅
  - Section 11 labels missing placeholder-order tests as 🟡 SHOULD FIX ✅
  - Step 1 includes supplemental grep scan with changed/unchanged file handling ✅
  - Step 4 of implement skill includes explicit i18n bullet ✅

---
Generated with [Claude Code](https://claude.com/claude-code)