### PR TITLE
fix(i18n): localize workspace output messages for --lang ja

### DIFF
--- a/src/adapters/outbound/filesystem/file_writer.rs
+++ b/src/adapters/outbound/filesystem/file_writer.rs
@@ -1,3 +1,4 @@
+use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::OutputPresenter;
 use crate::shared::error::SbomError;
 use crate::shared::security::validate_not_symlink;
@@ -11,11 +12,15 @@ use std::path::{Path, PathBuf};
 /// This adapter implements the OutputPresenter port for file output.
 pub struct FileSystemWriter {
     output_path: PathBuf,
+    locale: Locale,
 }
 
 impl FileSystemWriter {
-    pub fn new(output_path: PathBuf) -> Self {
-        Self { output_path }
+    pub fn new(output_path: PathBuf, locale: Locale) -> Self {
+        Self {
+            output_path,
+            locale,
+        }
     }
 
     /// Validates that the parent directory exists before writing
@@ -85,7 +90,14 @@ impl OutputPresenter for FileSystemWriter {
             details: e.to_string(),
         })?;
 
-        eprintln!("✅ Output complete: {}", self.output_path.display());
+        let msgs = Messages::for_locale(self.locale);
+        eprintln!(
+            "{}",
+            Messages::format(
+                msgs.output_complete,
+                &[&self.output_path.display().to_string()]
+            )
+        );
         Ok(())
     }
 }
@@ -119,6 +131,7 @@ impl OutputPresenter for StdoutPresenter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::i18n::Locale;
     use tempfile::TempDir;
 
     #[test]
@@ -126,7 +139,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let output_path = temp_dir.path().join("output.json");
 
-        let writer = FileSystemWriter::new(output_path.clone());
+        let writer = FileSystemWriter::new(output_path.clone(), Locale::En);
         let result = writer.present("test content");
 
         assert!(result.is_ok());
@@ -138,7 +151,7 @@ mod tests {
     fn test_file_writer_parent_directory_not_found() {
         let output_path = PathBuf::from("/nonexistent/directory/output.json");
 
-        let writer = FileSystemWriter::new(output_path);
+        let writer = FileSystemWriter::new(output_path, Locale::En);
         let result = writer.present("test content");
 
         assert!(result.is_err());

--- a/src/application/factories/presenter_factory.rs
+++ b/src/application/factories/presenter_factory.rs
@@ -1,4 +1,5 @@
 use crate::adapters::outbound::filesystem::{FileSystemWriter, StdoutPresenter};
+use crate::i18n::Locale;
 use crate::ports::outbound::OutputPresenter;
 use std::path::PathBuf;
 
@@ -21,6 +22,7 @@ impl PresenterFactory {
     ///
     /// # Arguments
     /// * `presenter_type` - The type of presenter to create
+    /// * `locale` - The locale used for status messages (only applies to `File` variant)
     ///
     /// # Returns
     /// A boxed OutputPresenter trait object appropriate for the specified type
@@ -28,13 +30,14 @@ impl PresenterFactory {
     /// # Examples
     /// ```
     /// use uv_sbom::application::factories::{PresenterFactory, PresenterType};
+    /// use uv_sbom::i18n::Locale;
     ///
-    /// let presenter = PresenterFactory::create(PresenterType::Stdout);
+    /// let presenter = PresenterFactory::create(PresenterType::Stdout, Locale::En);
     /// ```
-    pub fn create(presenter_type: PresenterType) -> Box<dyn OutputPresenter> {
+    pub fn create(presenter_type: PresenterType, locale: Locale) -> Box<dyn OutputPresenter> {
         match presenter_type {
             PresenterType::Stdout => Box::new(StdoutPresenter::new()),
-            PresenterType::File(path) => Box::new(FileSystemWriter::new(path)),
+            PresenterType::File(path) => Box::new(FileSystemWriter::new(path, locale)),
         }
     }
 }
@@ -42,10 +45,11 @@ impl PresenterFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::i18n::Locale;
 
     #[test]
     fn test_create_stdout_presenter() {
-        let presenter = PresenterFactory::create(PresenterType::Stdout);
+        let presenter = PresenterFactory::create(PresenterType::Stdout, Locale::En);
         // Verify it doesn't panic when created
         assert!(std::mem::size_of_val(&presenter) > 0);
     }
@@ -53,7 +57,7 @@ mod tests {
     #[test]
     fn test_create_file_presenter() {
         let path = PathBuf::from("/tmp/test_output.json");
-        let presenter = PresenterFactory::create(PresenterType::File(path));
+        let presenter = PresenterFactory::create(PresenterType::File(path), Locale::En);
         assert!(std::mem::size_of_val(&presenter) > 0);
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -134,6 +134,12 @@ pub struct Messages {
     // Vulnerability summary line (4 placeholders: count, unit, count, unit)
     pub summary_vuln_found: &'static str,
 
+    // Workspace output messages
+    pub output_complete: &'static str,
+    pub workspace_summary_header: &'static str,
+    pub workspace_col_member: &'static str,
+    pub workspace_col_output_file: &'static str,
+
     // Executive summary section
     pub section_summary: &'static str,
     pub col_item: &'static str,
@@ -286,6 +292,12 @@ static EN_MESSAGES: Messages = Messages {
     // Vulnerability summary line
     summary_vuln_found: "**Found {} {} in {} {}.**",
 
+    // Workspace output messages
+    output_complete: "✅ Output complete: {}",
+    workspace_summary_header: "📦 Workspace SBOM Summary",
+    workspace_col_member: "Member",
+    workspace_col_output_file: "Output File",
+
     // Executive summary section
     section_summary: "## Summary",
     col_item: "Item",
@@ -407,6 +419,12 @@ static JA_MESSAGES: Messages = Messages {
 
     // Vulnerability summary line
     summary_vuln_found: "**{}{}が{}{}で見つかりました。**",
+
+    // Workspace output messages
+    output_complete: "✅ 出力完了: {}",
+    workspace_summary_header: "📦 ワークスペース SBOM サマリー",
+    workspace_col_member: "メンバー",
+    workspace_col_output_file: "出力ファイル",
 
     // Executive summary section
     section_summary: "## サマリー",
@@ -643,6 +661,27 @@ mod tests {
         assert_eq!(msgs.col_recommended_action, "推奨アクション");
         assert_eq!(msgs.action_cannot_resolve, "⚠️ 解決不可: {}");
         assert_eq!(msgs.action_could_not_analyze, "❓ 分析不可: {}");
+    }
+
+    #[test]
+    fn test_workspace_messages_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(msgs.output_complete, "✅ Output complete: {}");
+        assert_eq!(msgs.workspace_summary_header, "📦 Workspace SBOM Summary");
+        assert_eq!(msgs.workspace_col_member, "Member");
+        assert_eq!(msgs.workspace_col_output_file, "Output File");
+    }
+
+    #[test]
+    fn test_workspace_messages_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(msgs.output_complete, "✅ 出力完了: {}");
+        assert_eq!(
+            msgs.workspace_summary_header,
+            "📦 ワークスペース SBOM サマリー"
+        );
+        assert_eq!(msgs.workspace_col_member, "メンバー");
+        assert_eq!(msgs.workspace_col_output_file, "出力ファイル");
     }
 
     #[test]

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -136,6 +136,8 @@ pub struct Messages {
 
     // Workspace output messages
     pub output_complete: &'static str,
+    pub workspace_mode_members_found: &'static str,
+    pub workspace_processing_member: &'static str,
     pub workspace_summary_header: &'static str,
     pub workspace_col_member: &'static str,
     pub workspace_col_output_file: &'static str,
@@ -294,6 +296,8 @@ static EN_MESSAGES: Messages = Messages {
 
     // Workspace output messages
     output_complete: "✅ Output complete: {}",
+    workspace_mode_members_found: "Workspace mode: {} members found",
+    workspace_processing_member: "  Processing: {}",
     workspace_summary_header: "📦 Workspace SBOM Summary",
     workspace_col_member: "Member",
     workspace_col_output_file: "Output File",
@@ -422,6 +426,8 @@ static JA_MESSAGES: Messages = Messages {
 
     // Workspace output messages
     output_complete: "✅ 出力完了: {}",
+    workspace_mode_members_found: "ワークスペースモード: {} メンバーを検出",
+    workspace_processing_member: "  処理中: {}",
     workspace_summary_header: "📦 ワークスペース SBOM サマリー",
     workspace_col_member: "メンバー",
     workspace_col_output_file: "出力ファイル",
@@ -667,6 +673,11 @@ mod tests {
     fn test_workspace_messages_en() {
         let msgs = Messages::for_locale(Locale::En);
         assert_eq!(msgs.output_complete, "✅ Output complete: {}");
+        assert_eq!(
+            msgs.workspace_mode_members_found,
+            "Workspace mode: {} members found"
+        );
+        assert_eq!(msgs.workspace_processing_member, "  Processing: {}");
         assert_eq!(msgs.workspace_summary_header, "📦 Workspace SBOM Summary");
         assert_eq!(msgs.workspace_col_member, "Member");
         assert_eq!(msgs.workspace_col_output_file, "Output File");
@@ -676,6 +687,11 @@ mod tests {
     fn test_workspace_messages_ja() {
         let msgs = Messages::for_locale(Locale::Ja);
         assert_eq!(msgs.output_complete, "✅ 出力完了: {}");
+        assert_eq!(
+            msgs.workspace_mode_members_found,
+            "ワークスペースモード: {} メンバーを検出"
+        );
+        assert_eq!(msgs.workspace_processing_member, "  処理中: {}");
         assert_eq!(
             msgs.workspace_summary_header,
             "📦 ワークスペース SBOM サマリー"

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,9 +343,16 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
         anyhow::bail!("No workspace members found. Is this a uv workspace?");
     }
 
-    eprintln!("Workspace mode: {} members found\n", members.len());
-
     let locale = args.lang;
+    let msgs = Messages::for_locale(locale);
+    eprintln!(
+        "{}\n",
+        Messages::format(
+            msgs.workspace_mode_members_found,
+            &[&members.len().to_string()]
+        )
+    );
+
     let config = load_config(&args, &workspace_root)?;
     let merged = merge_config(&args, &config);
 
@@ -357,7 +364,10 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
     let mut summary: Vec<(String, PathBuf)> = Vec::new();
 
     for member in &members {
-        eprintln!("  Processing: {}", member.name);
+        eprintln!(
+            "{}",
+            Messages::format(msgs.workspace_processing_member, &[&member.name])
+        );
 
         let lockfile_reader =
             MemberScopedLockfileReader::new(workspace_root.clone(), member.name.clone());
@@ -419,7 +429,6 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
     }
 
     // Print summary table
-    let msgs = Messages::for_locale(locale);
     eprintln!("\n{}", msgs.workspace_summary_header);
     eprintln!("{}", "─".repeat(60));
     eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,7 +316,7 @@ async fn run(args: Args) -> Result<bool> {
         PresenterType::Stdout
     };
 
-    let presenter = PresenterFactory::create(presenter_type);
+    let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted_output)?;
 
     // Determine if vulnerabilities or license violations were detected
@@ -412,16 +412,17 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
         let formatted_output = formatter.format(&read_model)?;
 
         let output_path = member.absolute_path.join(format!("sbom.{}", format_ext));
-        let presenter = PresenterFactory::create(PresenterType::File(output_path.clone()));
+        let presenter = PresenterFactory::create(PresenterType::File(output_path.clone()), locale);
         presenter.present(&formatted_output)?;
 
         summary.push((member.name.clone(), output_path));
     }
 
     // Print summary table
-    eprintln!("\n📦 Workspace SBOM Summary");
+    let msgs = Messages::for_locale(locale);
+    eprintln!("\n{}", msgs.workspace_summary_header);
     eprintln!("{}", "─".repeat(60));
-    eprintln!("{:<20} Output File", "Member");
+    eprintln!("{:<20} {}", msgs.workspace_col_member, msgs.workspace_col_output_file);
     eprintln!("{}", "─".repeat(60));
     for (name, path) in &summary {
         eprintln!("{:<20} {}", name, path.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,7 +422,10 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
     let msgs = Messages::for_locale(locale);
     eprintln!("\n{}", msgs.workspace_summary_header);
     eprintln!("{}", "─".repeat(60));
-    eprintln!("{:<20} {}", msgs.workspace_col_member, msgs.workspace_col_output_file);
+    eprintln!(
+        "{:<20} {}",
+        msgs.workspace_col_member, msgs.workspace_col_output_file
+    );
     eprintln!("{}", "─".repeat(60));
     for (name, path) in &summary {
         eprintln!("{:<20} {}", name, path.display());


### PR DESCRIPTION
## Summary

- Hardcoded English strings in workspace mode now use the \`Messages\` i18n catalog so \`--lang ja\` produces Japanese output throughout
- \`FileSystemWriter\` accepts a \`Locale\` field; \`PresenterFactory::create\` receives a \`locale\` parameter and threads it through
- Six new message keys added to both \`EN_MESSAGES\` and \`JA_MESSAGES\`, with unit tests for each

## Related Issues
Closes #463
Closes #469

## Changes Made
- \`src/i18n/mod.rs\`: add \`output_complete\`, \`workspace_mode_members_found\`, \`workspace_processing_member\`, \`workspace_summary_header\`, \`workspace_col_member\`, \`workspace_col_output_file\` to \`Messages\` struct, \`EN_MESSAGES\`, \`JA_MESSAGES\`, and unit tests
- \`src/adapters/outbound/filesystem/file_writer.rs\`: add \`locale: Locale\` field to \`FileSystemWriter\`; replace hardcoded \`eprintln!\` with \`Messages::format\`
- \`src/application/factories/presenter_factory.rs\`: add \`locale: Locale\` parameter to \`PresenterFactory::create\`
- \`src/main.rs\`: move \`locale\` resolution before workspace progress messages; pass \`locale\` to \`PresenterFactory::create\` in both workspace and non-workspace paths; replace all hardcoded workspace \`eprintln!\` calls with \`Messages\` catalog lookups

## Test Plan
- [x] \`cargo test --all\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [x] \`cargo fmt --all -- --check\` passes

---
Generated with [Claude Code](https://claude.com/claude-code)