### PR TITLE
fix(i18n): localize license compliance progress messages for --lang ja

### DIFF
--- a/src/adapters/outbound/formatters/markdown_formatter/vuln_render.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/vuln_render.rs
@@ -106,7 +106,7 @@ pub(super) fn render_actionable_vulnerabilities(
 
     // Sort by severity (Critical first)
     let mut sorted_vulns: Vec<&VulnerabilityView> = vulns.iter().collect();
-    sorted_vulns.sort_by(|a, b| a.severity.cmp(&b.severity));
+    sorted_vulns.sort_by_key(|v| &v.severity);
 
     for vuln in sorted_vulns {
         render_vulnerability_row(verified_packages, output, vuln);
@@ -149,7 +149,7 @@ pub(super) fn render_informational_vulnerabilities(
     output.push_str(&super::table::vuln_table_separator(messages));
 
     let mut sorted_vulns: Vec<&VulnerabilityView> = vulns.iter().collect();
-    sorted_vulns.sort_by(|a, b| a.severity.cmp(&b.severity));
+    sorted_vulns.sort_by_key(|v| &v.severity);
 
     for vuln in sorted_vulns {
         render_vulnerability_row(verified_packages, output, vuln);

--- a/src/adapters/outbound/network/osv_client.rs
+++ b/src/adapters/outbound/network/osv_client.rs
@@ -174,7 +174,7 @@ impl VulnerabilityRepository for OsvClient {
 
             let osv_results = self.fetch_batch(chunk).await?;
 
-            for (package, osv_result) in chunk.iter().zip(osv_results.into_iter()) {
+            for (package, osv_result) in chunk.iter().zip(osv_results) {
                 total_vulns += osv_result.vulns.len();
                 batch_results.push((package.clone(), osv_result));
             }

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -466,20 +466,21 @@ where
         let result = LicenseComplianceChecker::check(&packages, policy);
 
         // Report results
+        let msgs = Messages::for_locale(self.locale);
         if result.has_violations() {
-            self.progress_reporter.report(&format!(
-                "⚠️  License compliance: {} violation(s) found",
-                result.violations.len()
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_license_violations_found,
+                &[&result.violations.len().to_string()],
             ));
         } else {
             self.progress_reporter
-                .report("✅ License compliance: No violations found");
+                .report(msgs.progress_license_no_violations);
         }
 
         if !result.warnings.is_empty() {
-            self.progress_reporter.report(&format!(
-                "⚠️  License compliance: {} package(s) with unknown license",
-                result.warnings.len()
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_license_unknown_packages,
+                &[&result.warnings.len().to_string()],
             ));
         }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -77,6 +77,11 @@ pub struct Messages {
     pub progress_vuln_found: &'static str,
     pub progress_vuln_none: &'static str,
 
+    // License compliance progress messages (use case layer)
+    pub progress_license_violations_found: &'static str,
+    pub progress_license_no_violations: &'static str,
+    pub progress_license_unknown_packages: &'static str,
+
     // Warning messages
     pub warn_check_cve_no_effect: &'static str,
     pub warn_check_license_no_effect: &'static str,
@@ -238,6 +243,11 @@ static EN_MESSAGES: Messages = Messages {
     progress_vuln_found: "✅ Vulnerability check complete: {} vulnerabilities found in {} packages",
     progress_vuln_none: "✅ Vulnerability check complete: No known vulnerabilities found",
 
+    // License compliance progress messages (use case layer)
+    progress_license_violations_found: "⚠️  License compliance: {} violation(s) found",
+    progress_license_no_violations: "✅ License compliance: No violations found",
+    progress_license_unknown_packages: "⚠️  License compliance: {} package(s) with unknown license",
+
     // Warning messages
     warn_check_cve_no_effect: "⚠️  Warning: --check-cve has no effect with JSON format.",
     warn_check_license_no_effect: "⚠️  Warning: --check-license has no effect with JSON format.",
@@ -365,6 +375,11 @@ static JA_MESSAGES: Messages = Messages {
     progress_license_complete: "✅ ライセンス情報取得完了: {}件成功 / {}件中、{}件失敗",
     progress_vuln_found: "✅ 脆弱性チェック完了: {}個のパッケージで{}件の脆弱性を検出",
     progress_vuln_none: "✅ 脆弱性チェック完了: 既知の脆弱性は検出されませんでした",
+
+    // License compliance progress messages (use case layer)
+    progress_license_violations_found: "⚠️  ライセンスコンプライアンス: {}件の違反が見つかりました",
+    progress_license_no_violations: "✅ ライセンスコンプライアンス: 違反なし",
+    progress_license_unknown_packages: "⚠️  ライセンスコンプライアンス: ライセンス不明のパッケージが{}件あります",
 
     // Warning messages
     warn_check_cve_no_effect: "⚠️  警告: JSON形式では --check-cve は効果がありません。",
@@ -526,6 +541,18 @@ mod tests {
             msgs.progress_vuln_none,
             "✅ Vulnerability check complete: No known vulnerabilities found"
         );
+        assert_eq!(
+            msgs.progress_license_violations_found,
+            "⚠️  License compliance: {} violation(s) found"
+        );
+        assert_eq!(
+            msgs.progress_license_no_violations,
+            "✅ License compliance: No violations found"
+        );
+        assert_eq!(
+            msgs.progress_license_unknown_packages,
+            "⚠️  License compliance: {} package(s) with unknown license"
+        );
     }
 
     #[test]
@@ -554,6 +581,18 @@ mod tests {
         assert_eq!(
             msgs.progress_vuln_none,
             "✅ 脆弱性チェック完了: 既知の脆弱性は検出されませんでした"
+        );
+        assert_eq!(
+            msgs.progress_license_violations_found,
+            "⚠️  ライセンスコンプライアンス: {}件の違反が見つかりました"
+        );
+        assert_eq!(
+            msgs.progress_license_no_violations,
+            "✅ ライセンスコンプライアンス: 違反なし"
+        );
+        assert_eq!(
+            msgs.progress_license_unknown_packages,
+            "⚠️  ライセンスコンプライアンス: ライセンス不明のパッケージが{}件あります"
         );
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -378,7 +378,7 @@ static JA_MESSAGES: Messages = Messages {
 
     // License compliance progress messages (use case layer)
     progress_license_violations_found: "⚠️  ライセンスコンプライアンス: {}件の違反が見つかりました",
-    progress_license_no_violations: "✅ ライセンスコンプライアンス: 違反なし",
+    progress_license_no_violations: "✅ ライセンスコンプライアンス: 違反は見つかりませんでした",
     progress_license_unknown_packages: "⚠️  ライセンスコンプライアンス: ライセンス不明のパッケージが{}件あります",
 
     // Warning messages
@@ -588,7 +588,7 @@ mod tests {
         );
         assert_eq!(
             msgs.progress_license_no_violations,
-            "✅ ライセンスコンプライアンス: 違反なし"
+            "✅ ライセンスコンプライアンス: 違反は見つかりませんでした"
         );
         assert_eq!(
             msgs.progress_license_unknown_packages,


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in `check_license_compliance_if_requested` with `Messages::for_locale` calls
- Add three new i18n keys to `MessageCatalog` with EN and JA translations
- Add unit test assertions for the new keys in both EN and JA catalogs

## Related Issue
Closes #470

## Changes Made
- `src/i18n/mod.rs`: Added `progress_license_violations_found`, `progress_license_no_violations`, and `progress_license_unknown_packages` to `MessageCatalog` struct, EN catalog, and JA catalog; added test assertions in `test_messages_use_case_progress_en` and `test_messages_use_case_progress_ja`
- `src/application/use_cases/generate_sbom/mod.rs`: Replaced three hardcoded English progress message strings with `Messages::for_locale(self.locale)` calls following the existing pattern

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)