### PR TITLE
fix(deps): update rustls-webpki to 0.103.12 to fix GHSA-965h-392x-2mh5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,9 +1434,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Updates `rustls-webpki` from `0.103.10` to `0.103.12`
- Fixes URI name constraint validation bypass (GHSA-965h-392x-2mh5)

## Security Fix

- **Advisory**: GHSA-965h-392x-2mh5
- **CVE**: N/A (not yet assigned)
- **Package**: rustls-webpki
- **Severity**: low
- **Fixed Version**: 0.103.12
- **Summary**: URI name constraints for X.509 certificates were incorrectly accepted instead of being validated. The fix rejects URI name constraints unconditionally.

## Changes Made

- Updated `Cargo.lock`: `rustls-webpki` `0.103.10` → `0.103.12`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes

---
Generated with [Claude Code](https://claude.com/claude-code)