### PR TITLE
docs(agents): add agent invocation rules table to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,6 +120,29 @@ invoke the `/ideate` skill or `/issue` skill directly.
 | Draft Issue from approved idea | /ideate | Feature passed triage |
 | Create Issue directly | /issue | Feature already approved by user |
 
+## Agent Invocation Rules
+
+Role-based agents in `.claude/agents/` provide specialized perspectives for open-ended analysis tasks. Invoke the appropriate agent when you need domain expertise beyond what skills and context files provide.
+
+| Situation | Agent to Invoke | File |
+|-----------|----------------|------|
+| Evaluating a feature proposal | PdM | `.claude/agents/pdm.md` |
+| Reviewing code structure or module placement | Architect | `.claude/agents/architect.md` |
+| Security review of new CVE/network code | Security Expert | `.claude/agents/security.md` |
+| Reviewing English README or documentation | DevRel | `.claude/agents/devrel.md` |
+| Reviewing `src/i18n/` or `README-JP.md` | i18n Specialist | `.claude/agents/i18n.md` |
+| Reviewing test coverage for a new feature | QA Engineer | `.claude/agents/qa.md` |
+| Checking release readiness before `/release` | Release Manager | `.claude/agents/release.md` |
+
+### Agents vs Skills
+
+- **Skills** = procedural workflows ("what steps to take") — e.g., `/commit`, `/release`
+- **Agents** = domain perspectives ("what lens to apply") — e.g., PdM, Architect
+
+Agents complement skills: the Release Manager agent judges readiness; the `/release` skill executes the mechanics.
+
+---
+
 ## README Update Checklist
 
 When updating README.md, check if the following files also need updates:


### PR DESCRIPTION
## Summary
- Add **Agent Invocation Rules** section to `.claude/CLAUDE.md` documenting when to use each of the seven role-based agents
- Include a 7-row table mapping situations to agents (PdM, Architect, Security Expert, DevRel, i18n Specialist, QA Engineer, Release Manager) with file references
- Add a brief explanation of the agents vs. skills distinction

## Related Issue
Closes #477
Part of #471

## Changes Made
- `.claude/CLAUDE.md`: Added `## Agent Invocation Rules` section with invocation table and Agents vs Skills explanation

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation-only change; no runtime behavior affected

---
Generated with [Claude Code](https://claude.com/claude-code)