### PR TITLE
feat(skills): add Opus-powered planning phase to /implement (Step 3.5)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -14,7 +14,8 @@ Orchestrates the complete workflow for implementing a GitHub issue, from branch 
 ## Workflow Overview
 
 ```
-Issue Analysis → Branch Creation → Implementation → Commit → PR Creation
+Issue Analysis → Branch Creation → [Planning] → Implementation → Commit → PR Creation
+                                        ↑ Opus        ↑ Sonnet
 ```
 
 ## Steps
@@ -58,9 +59,47 @@ git checkout -b <branch-name> origin/develop
 
 **CRITICAL**: This step cannot be skipped. If already on the correct feature branch, verify and continue.
 
+### Step 3.5: Implementation Planning (MANDATORY)
+
+Spawn the Architect agent using the Opus model with the issue description and
+relevant existing code as context:
+
+```
+Agent({
+  subagent_type: "architect",
+  model: "opus",
+  prompt: <issue description> + <relevant existing code context>
+})
+```
+
+Gather relevant existing code context by:
+- Reading files listed in the issue's "Files to Update / Modify" section
+- Reading adjacent modules or traits that the new code must implement or extend
+- Running `git grep` for key symbols mentioned in the issue
+
+The Architect agent produces an implementation plan covering:
+
+| Plan Section | Content |
+|-------------|---------|
+| Files to modify | Path + reason for each file |
+| Files to create | Path + module role + which layer (domain / application / adapter / port) |
+| Interface design | New traits, structs, enums with their signatures |
+| Implementation order | Step-by-step sequence with rationale |
+| Risk flags | Potential layer boundary violations, DDD concerns, edge cases |
+
+**Present the plan to the user and wait for explicit confirmation before
+proceeding to Step 4. Do not modify any files until the user confirms.**
+
+Accepted responses:
+- "Looks good, proceed" → continue to Step 4
+- "Adjust X" → revise plan, re-present
+- "Cancel" → halt
+
 ### Step 4: Implement Changes
 
-- Follow the issue's technical specifications
+- **Follow the confirmed plan from Step 3.5 exactly**
+- If an unexpected situation arises that requires deviating from the plan,
+  **pause and report to the user before proceeding**
 - Adhere to project architecture (see `.claude/CLAUDE.md`)
 - Add tests for new functionality
 - Update documentation as needed
@@ -120,7 +159,7 @@ Output:
 
 If already on a feature branch:
 1. Verify it matches the issue being implemented
-2. If yes, continue from Step 4
+2. If yes, continue from Step 3.5
 3. If no, ask user for clarification
 
 ### Issue Not Found
@@ -143,7 +182,8 @@ Claude executes /implement skill:
 1. Reads issue #96 details
 2. Determines label is "enhancement" → prefix "feature/"
 3. Creates branch `feature/96-check-vulnerabilities-usecase`
-4. Implements the changes per issue specification
-5. Runs `/commit` skill
-6. Runs `/pr` skill
-7. Reports: "Created PR #XX for issue #96"
+4. Spawns Architect agent (Opus), presents implementation plan, awaits user confirmation
+5. Implements the changes following the confirmed plan
+6. Runs `/commit` skill
+7. Runs `/pr` skill
+8. Reports: "Created PR #XX for issue #96"


### PR DESCRIPTION
## Summary
- Add Step 3.5 to `/implement` skill: an Opus-powered Architect agent consultation that produces a structured implementation plan before any code is written
- Insert a mandatory human confirmation gate between plan generation and coding
- Update Step 4 to follow the confirmed plan and pause on unexpected deviations

## Related Issue
Closes #473

## Changes Made
- Add Step 3.5 with `Agent({ subagent_type: "architect", model: "opus", ... })` invocation
- Add guidance on gathering relevant existing code context (issue files, adjacent modules, `git grep`)
- Define required plan output sections: files to modify/create, interface design, implementation order, risk flags
- Update workflow overview diagram with Opus/Sonnet model labels
- Update Step 4 to reference the confirmed plan from Step 3.5
- Fix Error Handling section: "Already on Feature Branch" now continues from Step 3.5
- Update Example Usage to include the planning step (8 steps total)

## Test Plan
- [ ] Manual review: Step 3.5 instructions are unambiguous and complete
- [ ] Consistency check: all cross-references point to the correct step numbers
- [ ] Code review passed (Reviewer Agent: PASS)

---
Generated with [Claude Code](https://claude.com/claude-code)