### PR TITLE
refactor: remove all dead code reserved for Issue #486

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
@@ -162,11 +162,8 @@ mod tests {
                 source_url: Some("https://nvd.nist.gov/vuln/detail/CVE-2024-1234".to_string()),
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -264,11 +261,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -316,11 +310,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -434,11 +425,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -474,18 +462,14 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
             entries: vec![UpgradeEntryView::Upgradable {
                 direct_dep: "requests".to_string(),
-                current_version: "2.31.0".to_string(),
                 target_version: "2.32.3".to_string(),
                 transitive_dep: "urllib3".to_string(),
                 resolved_version: "2.2.1".to_string(),
@@ -522,17 +506,13 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
             entries: vec![UpgradeEntryView::Unresolvable {
-                direct_dep: "requests".to_string(),
                 reason: "no compatible version available".to_string(),
                 vulnerability_id: "CVE-2024-1234".to_string(),
             }],
@@ -564,11 +544,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });

--- a/src/adapters/outbound/formatters/markdown_formatter/links.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/links.rs
@@ -203,11 +203,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -282,11 +279,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -213,11 +213,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -256,11 +253,8 @@ mod tests {
                 description: None,
                 source_url: None,
             }],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 0,
-                informational_count: 1,
                 affected_package_count: 1,
             },
         });
@@ -376,11 +370,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -431,11 +422,8 @@ mod tests {
                 description: None,
                 source_url: None,
             }],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 2,
-                actionable_count: 1,
-                informational_count: 1,
                 affected_package_count: 2,
             },
         });
@@ -574,11 +562,8 @@ mod tests {
         model.vulnerabilities = Some(VulnerabilityReportView {
             actionable: vec![],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 0,
-                actionable_count: 0,
-                informational_count: 0,
                 affected_package_count: 0,
             },
         });
@@ -608,11 +593,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -630,11 +612,8 @@ mod tests {
         model.vulnerabilities = Some(VulnerabilityReportView {
             actionable: vec![],
             informational: vec![],
-            threshold_exceeded: false,
             summary: VulnerabilitySummary {
                 total_count: 0,
-                actionable_count: 0,
-                informational_count: 0,
                 affected_package_count: 0,
             },
         });
@@ -753,7 +732,6 @@ mod tests {
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
             entries: vec![UpgradeEntryView::Upgradable {
                 direct_dep: "requests".to_string(),
-                current_version: "2.31.0".to_string(),
                 target_version: "2.32.3".to_string(),
                 transitive_dep: "urllib3".to_string(),
                 resolved_version: "2.2.1".to_string(),
@@ -787,11 +765,8 @@ mod tests {
                 source_url: None,
             }],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 1,
-                actionable_count: 1,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });
@@ -838,11 +813,8 @@ mod tests {
                 },
             ],
             informational: vec![],
-            threshold_exceeded: true,
             summary: VulnerabilitySummary {
                 total_count: 2,
-                actionable_count: 2,
-                informational_count: 0,
                 affected_package_count: 1,
             },
         });

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -259,7 +259,6 @@ mod tests {
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
             entries: vec![UpgradeEntryView::Upgradable {
                 direct_dep: "requests".to_string(),
-                current_version: "2.31.0".to_string(),
                 target_version: "2.32.3".to_string(),
                 transitive_dep: "urllib3".to_string(),
                 resolved_version: "2.2.1".to_string(),
@@ -292,7 +291,6 @@ mod tests {
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
             entries: vec![UpgradeEntryView::Unresolvable {
-                direct_dep: "httpx".to_string(),
                 reason: "latest httpx still pins idna < 3.7".to_string(),
                 vulnerability_id: "GHSA-ZZZZZ".to_string(),
             }],

--- a/src/adapters/outbound/formatters/markdown_formatter/vuln_render.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/vuln_render.rs
@@ -200,8 +200,6 @@ mod tests {
     fn test_render_vulnerability_summary() {
         let summary = VulnerabilitySummary {
             total_count: 3,
-            actionable_count: 2,
-            informational_count: 1,
             affected_package_count: 2,
         };
 
@@ -215,8 +213,6 @@ mod tests {
     fn test_render_vulnerability_summary_singular() {
         let summary = VulnerabilitySummary {
             total_count: 1,
-            actionable_count: 1,
-            informational_count: 0,
             affected_package_count: 1,
         };
 

--- a/src/adapters/outbound/network/osv_client.rs
+++ b/src/adapters/outbound/network/osv_client.rs
@@ -292,18 +292,11 @@ struct OsvAffected {
 
 #[derive(Debug, Deserialize)]
 struct OsvRange {
-    #[serde(rename = "type")]
-    #[allow(dead_code)] // Reserved for Issue #486: future OSV range-type handling
-    range_type: String,
     events: Vec<OsvEvent>,
 }
 
 #[derive(Debug, Deserialize)]
 struct OsvEvent {
-    #[serde(default)]
-    #[allow(dead_code)]
-    // Reserved for Issue #486: paired with `fixed` for full OSV version-range evaluation
-    introduced: Option<String>,
     #[serde(default)]
     fixed: Option<String>,
 }

--- a/src/adapters/outbound/uv/uv_lock_adapter.rs
+++ b/src/adapters/outbound/uv/uv_lock_adapter.rs
@@ -127,7 +127,6 @@ impl UvLockSimulator for UvLockAdapter {
 
         // 7. Return result (temp_dir is dropped here, cleaning up automatically)
         Ok(SimulationResult {
-            upgraded_package: package_name.to_string(),
             upgraded_to_version,
             resolved_versions: new_versions,
         })
@@ -209,7 +208,6 @@ version = "0.1.0"
             .expect("requests must appear in after fixture");
 
         let sim_result = SimulationResult {
-            upgraded_package: package_name.to_string(),
             upgraded_to_version,
             resolved_versions,
         };

--- a/src/adapters/outbound/uv/workspace_reader.rs
+++ b/src/adapters/outbound/uv/workspace_reader.rs
@@ -88,7 +88,6 @@ impl UvWorkspaceReader {
                     let absolute_path = workspace_root.join(&member_id);
                     return WorkspaceMember {
                         name: pkg.name.clone(),
-                        relative_path: member_id,
                         absolute_path,
                     };
                 }
@@ -97,16 +96,15 @@ impl UvWorkspaceReader {
                 // such as "api". Look for a package whose name matches and derive the
                 // relative path from its source.editable / source.virtual field.
                 if let Some(pkg) = lock.package.iter().find(|p| p.name == member_id) {
-                    let relative_path = pkg
+                    let rel = pkg
                         .source
                         .as_ref()
                         .and_then(|s| s.local_path())
                         .map(|p| p.to_owned())
                         .unwrap_or_else(|| member_id.clone());
-                    let absolute_path = workspace_root.join(&relative_path);
+                    let absolute_path = workspace_root.join(&rel);
                     return WorkspaceMember {
                         name: pkg.name.clone(),
-                        relative_path,
                         absolute_path,
                     };
                 }
@@ -120,7 +118,6 @@ impl UvWorkspaceReader {
                 let absolute_path = workspace_root.join(&member_id);
                 WorkspaceMember {
                     name,
-                    relative_path: member_id,
                     absolute_path,
                 }
             })
@@ -142,12 +139,6 @@ impl WorkspaceReader for UvWorkspaceReader {
         let content = read_file_with_security(&lock_path, "uv.lock", MAX_FILE_SIZE)
             .with_context(|| format!("Failed to read uv.lock at: {}", lock_path.display()))?;
         Self::parse_members(&content, workspace_root)
-    }
-
-    fn is_workspace_root(&self, path: &Path) -> bool {
-        self.read_workspace_members(path)
-            .map(|members| !members.is_empty())
-            .unwrap_or(false)
     }
 }
 
@@ -220,17 +211,15 @@ source = { registry = "https://pypi.org/simple" }
 
         let alpha = members
             .iter()
-            .find(|m| m.relative_path == "packages/alpha")
+            .find(|m| m.absolute_path == root.join("packages/alpha"))
             .unwrap();
         assert_eq!(alpha.name, "alpha");
-        assert_eq!(alpha.absolute_path, root.join("packages/alpha"));
 
         let beta = members
             .iter()
-            .find(|m| m.relative_path == "packages/beta")
+            .find(|m| m.absolute_path == root.join("packages/beta"))
             .unwrap();
         assert_eq!(beta.name, "beta");
-        assert_eq!(beta.absolute_path, root.join("packages/beta"));
     }
 
     #[test]
@@ -267,7 +256,7 @@ source = { registry = "https://pypi.org/simple" }
 
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].name, "gamma");
-        assert_eq!(members[0].relative_path, "packages/gamma");
+        assert_eq!(members[0].absolute_path, root.join("packages/gamma"));
     }
 
     #[test]
@@ -279,32 +268,6 @@ source = { registry = "https://pypi.org/simple" }
             .unwrap_err()
             .to_string()
             .contains("Failed to parse uv.lock"));
-    }
-
-    #[test]
-    fn test_is_workspace_root_returns_true_for_workspace_lock_file() {
-        let temp_dir = TempDir::new().unwrap();
-        std::fs::write(temp_dir.path().join("uv.lock"), WORKSPACE_LOCK).unwrap();
-
-        let reader = UvWorkspaceReader::new();
-        assert!(reader.is_workspace_root(temp_dir.path()));
-    }
-
-    #[test]
-    fn test_is_workspace_root_returns_false_for_non_workspace_lock_file() {
-        let temp_dir = TempDir::new().unwrap();
-        std::fs::write(temp_dir.path().join("uv.lock"), NON_WORKSPACE_LOCK).unwrap();
-
-        let reader = UvWorkspaceReader::new();
-        assert!(!reader.is_workspace_root(temp_dir.path()));
-    }
-
-    #[test]
-    fn test_is_workspace_root_returns_false_when_no_lock_file() {
-        let reader = UvWorkspaceReader::new();
-        // Use a path that definitely does not have a uv.lock
-        let result = reader.is_workspace_root(Path::new("/nonexistent/path/that/does/not/exist"));
-        assert!(!result);
     }
 
     #[test]
@@ -359,11 +322,9 @@ source = { registry = "https://pypi.org/simple" }
         assert_eq!(members.len(), 2);
 
         let api = members.iter().find(|m| m.name == "api").unwrap();
-        assert_eq!(api.relative_path, "packages/api");
         assert_eq!(api.absolute_path, root.join("packages/api"));
 
         let worker = members.iter().find(|m| m.name == "worker").unwrap();
-        assert_eq!(worker.relative_path, "packages/worker");
         assert_eq!(worker.absolute_path, root.join("packages/worker"));
     }
 
@@ -376,9 +337,8 @@ source = { registry = "https://pypi.org/simple" }
 
         let alpha = members
             .iter()
-            .find(|m| m.relative_path == "packages/alpha")
+            .find(|m| m.absolute_path == root.join("packages/alpha"))
             .unwrap();
         assert_eq!(alpha.name, "alpha");
-        assert_eq!(alpha.absolute_path, root.join("packages/alpha"));
     }
 }

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -80,7 +80,7 @@ impl SbomRequest {
 ///     .project_path("/path/to/project")
 ///     .include_dependency_info(true)
 ///     .check_cve(true)
-///     .add_exclude_pattern("test-*")
+///     .exclude_patterns(vec!["test-*".to_string()])
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -148,13 +148,6 @@ impl SbomRequestBuilder {
         self
     }
 
-    /// Adds a single exclusion pattern.
-    #[allow(dead_code)] // Reserved for Issue #486: public library builder API, used by integration tests and library consumers
-    pub fn add_exclude_pattern(mut self, pattern: impl Into<String>) -> Self {
-        self.exclude_patterns.push(pattern.into());
-        self
-    }
-
     /// Sets whether to perform dry-run validation only.
     pub fn dry_run(mut self, dry_run: bool) -> Self {
         self.dry_run = dry_run;
@@ -167,26 +160,12 @@ impl SbomRequestBuilder {
         self
     }
 
-    /// Sets the severity threshold for vulnerability filtering.
-    #[allow(dead_code)] // Reserved for Issue #486: public library builder API, used by integration tests and library consumers
-    pub fn severity_threshold(mut self, severity: Severity) -> Self {
-        self.severity_threshold = Some(severity);
-        self
-    }
-
     /// Sets the severity threshold from an Option value.
     ///
     /// This is useful when the threshold comes from CLI arguments
     /// which may or may not be specified.
     pub fn severity_threshold_opt(mut self, severity: Option<Severity>) -> Self {
         self.severity_threshold = severity;
-        self
-    }
-
-    /// Sets the CVSS threshold for vulnerability filtering.
-    #[allow(dead_code)] // Reserved for Issue #486: public library builder API, used by integration tests and library consumers
-    pub fn cvss_threshold(mut self, cvss: f32) -> Self {
-        self.cvss_threshold = Some(cvss);
         self
     }
 
@@ -301,8 +280,8 @@ mod tests {
             .exclude_patterns(vec!["test-*".to_string()])
             .dry_run(true)
             .check_cve(true)
-            .severity_threshold(Severity::High)
-            .cvss_threshold(7.5)
+            .severity_threshold_opt(Some(Severity::High))
+            .cvss_threshold_opt(Some(7.5))
             .ignore_cves(vec![IgnoreCve {
                 id: "CVE-2024-1234".to_string(),
                 reason: Some("test".to_string()),
@@ -322,12 +301,14 @@ mod tests {
     }
 
     #[test]
-    fn test_add_exclude_pattern_accumulates() {
+    fn test_exclude_patterns_accumulates() {
         let request = SbomRequest::builder()
             .project_path("/test/project")
-            .add_exclude_pattern("pattern1")
-            .add_exclude_pattern("pattern2")
-            .add_exclude_pattern("pattern3")
+            .exclude_patterns(vec![
+                "pattern1".to_string(),
+                "pattern2".to_string(),
+                "pattern3".to_string(),
+            ])
             .build()
             .unwrap();
 
@@ -342,7 +323,7 @@ mod tests {
     fn test_exclude_patterns_replaces_previous() {
         let request = SbomRequest::builder()
             .project_path("/test/project")
-            .add_exclude_pattern("old-pattern")
+            .exclude_patterns(vec!["old-pattern".to_string()])
             .exclude_patterns(vec!["new-pattern".to_string()])
             .build()
             .unwrap();

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -1,7 +1,6 @@
 use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
-use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
 use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata, UpgradeRecommendation};
 use crate::shared::error::SbomError;
 
@@ -17,10 +16,6 @@ pub struct SbomResponse {
     pub dependency_graph: Option<DependencyGraph>,
     /// SBOM metadata (timestamp, tool info, serial number)
     pub metadata: SbomMetadata,
-    /// Optional vulnerability report (only present when CVE check is enabled)
-    /// None = not checked, Some(vec) = checked (empty vec means no vulnerabilities found)
-    #[allow(dead_code)] // Reserved for Issue #486: public DTO field for library consumers
-    pub vulnerability_report: Option<Vec<PackageVulnerabilities>>,
     /// Whether vulnerabilities above threshold were detected
     /// Used to determine exit code for CI integration
     pub has_vulnerabilities_above_threshold: bool,
@@ -46,7 +41,6 @@ pub struct SbomResponseBuilder {
     enriched_packages: Vec<EnrichedPackage>,
     dependency_graph: Option<DependencyGraph>,
     metadata: Option<SbomMetadata>,
-    vulnerability_report: Option<Vec<PackageVulnerabilities>>,
     has_vulnerabilities_above_threshold: bool,
     vulnerability_check_result: Option<VulnerabilityCheckResult>,
     license_compliance_result: Option<LicenseComplianceResult>,
@@ -60,7 +54,6 @@ impl SbomResponseBuilder {
             enriched_packages: Vec::new(),
             dependency_graph: None,
             metadata: None,
-            vulnerability_report: None,
             has_vulnerabilities_above_threshold: false,
             vulnerability_check_result: None,
             license_compliance_result: None,
@@ -87,11 +80,6 @@ impl SbomResponseBuilder {
 
     pub fn metadata(mut self, metadata: SbomMetadata) -> Self {
         self.metadata = Some(metadata);
-        self
-    }
-
-    pub fn vulnerability_report(mut self, report: Vec<PackageVulnerabilities>) -> Self {
-        self.vulnerability_report = Some(report);
         self
     }
 
@@ -129,7 +117,6 @@ impl SbomResponseBuilder {
             enriched_packages: self.enriched_packages,
             dependency_graph: self.dependency_graph,
             metadata,
-            vulnerability_report: self.vulnerability_report,
             has_vulnerabilities_above_threshold: self.has_vulnerabilities_above_threshold,
             vulnerability_check_result: self.vulnerability_check_result,
             license_compliance_result: self.license_compliance_result,
@@ -166,7 +153,6 @@ mod tests {
 
         assert!(response.enriched_packages.is_empty());
         assert!(response.dependency_graph.is_none());
-        assert!(response.vulnerability_report.is_none());
         assert!(!response.has_vulnerabilities_above_threshold);
         assert!(response.vulnerability_check_result.is_none());
         assert!(response.license_compliance_result.is_none());

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -26,36 +26,6 @@ use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata, UpgradeRecom
 pub struct SbomReadModelBuilder;
 
 impl SbomReadModelBuilder {
-    /// Builds a SbomReadModel from domain objects
-    ///
-    /// # Arguments
-    /// * `packages` - List of enriched packages with license information
-    /// * `metadata` - SBOM metadata (timestamp, tool info, serial number)
-    /// * `dependency_graph` - Optional dependency graph for determining direct dependencies
-    /// * `_vulnerability_result` - Optional vulnerability check result (reserved for future use)
-    ///
-    /// # Returns
-    /// A fully constructed SbomReadModel
-    /// Builds a SbomReadModel without project metadata component (backwards compatible)
-    #[allow(dead_code)] // Reserved for Issue #486: backwards-compatible wrapper used by integration tests and library consumers
-    pub fn build(
-        packages: Vec<EnrichedPackage>,
-        metadata: &SbomMetadata,
-        dependency_graph: Option<&DependencyGraph>,
-        vulnerability_result: Option<&VulnerabilityCheckResult>,
-        license_compliance_result: Option<&LicenseComplianceResult>,
-    ) -> SbomReadModel {
-        Self::build_with_project(
-            packages,
-            metadata,
-            dependency_graph,
-            vulnerability_result,
-            license_compliance_result,
-            None,
-            None,
-        )
-    }
-
     /// Builds a SbomReadModel from domain objects with optional project metadata component
     pub fn build_with_project(
         packages: Vec<EnrichedPackage>,
@@ -232,7 +202,7 @@ mod tests {
         let metadata = create_test_metadata();
         let graph = create_test_graph();
 
-        let read_model = SbomReadModelBuilder::build(packages, &metadata, Some(&graph), None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(packages, &metadata, Some(&graph), None, None, None, None);
 
         // Check metadata
         assert_eq!(read_model.metadata.tool_name, "uv-sbom");
@@ -255,7 +225,7 @@ mod tests {
         let packages: Vec<EnrichedPackage> = vec![];
         let metadata = create_test_metadata();
 
-        let read_model = SbomReadModelBuilder::build(packages, &metadata, None, None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(packages, &metadata, None, None, None, None, None);
 
         assert!(read_model.components.is_empty());
     }
@@ -504,7 +474,7 @@ mod tests {
         assert_eq!(report.actionable[0].id, "CVE-2024-001");
         assert_eq!(report.informational.len(), 1);
         assert_eq!(report.informational[0].id, "CVE-2024-002");
-        assert!(report.threshold_exceeded);
+        assert!(!report.actionable.is_empty());
     }
 
     #[test]
@@ -526,8 +496,8 @@ mod tests {
         let report = vulnerability_builder::build_vulnerabilities(&result, &components);
 
         assert_eq!(report.summary.total_count, 3);
-        assert_eq!(report.summary.actionable_count, 2);
-        assert_eq!(report.summary.informational_count, 1);
+        assert_eq!(report.actionable.len(), 2);
+        assert_eq!(report.informational.len(), 1);
         assert_eq!(report.summary.affected_package_count, 2);
     }
 
@@ -544,7 +514,7 @@ mod tests {
 
         assert!(report.actionable.is_empty());
         assert!(report.informational.is_empty());
-        assert!(!report.threshold_exceeded);
+        assert!(report.actionable.is_empty());
         assert_eq!(report.summary.total_count, 0);
         assert_eq!(report.summary.affected_package_count, 0);
     }
@@ -590,13 +560,13 @@ mod tests {
         };
 
         let read_model =
-            SbomReadModelBuilder::build(packages, &metadata, None, Some(&vuln_result), None);
+            SbomReadModelBuilder::build_with_project(packages, &metadata, None, Some(&vuln_result), None, None, None);
 
         assert!(read_model.vulnerabilities.is_some());
         let vulns = read_model.vulnerabilities.unwrap();
         assert_eq!(vulns.actionable.len(), 1);
         assert_eq!(vulns.actionable[0].id, "CVE-2024-1234");
-        assert!(vulns.threshold_exceeded);
+        assert!(!vulns.actionable.is_empty());
     }
 
     // Tests for resolution guide builder
@@ -706,11 +676,13 @@ mod tests {
             threshold_exceeded: true,
         };
 
-        let read_model = SbomReadModelBuilder::build(
+        let read_model = SbomReadModelBuilder::build_with_project(
             packages,
             &metadata,
             Some(&graph),
             Some(&vuln_result),
+            None,
+            None,
             None,
         );
 
@@ -735,7 +707,7 @@ mod tests {
         };
 
         let read_model =
-            SbomReadModelBuilder::build(packages, &metadata, None, Some(&vuln_result), None);
+            SbomReadModelBuilder::build_with_project(packages, &metadata, None, Some(&vuln_result), None, None, None);
 
         assert!(read_model.resolution_guide.is_none());
     }
@@ -746,7 +718,7 @@ mod tests {
         let metadata = create_test_metadata();
         let graph = create_test_graph();
 
-        let read_model = SbomReadModelBuilder::build(packages, &metadata, Some(&graph), None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(packages, &metadata, Some(&graph), None, None, None, None);
 
         assert!(read_model.resolution_guide.is_none());
     }
@@ -766,11 +738,13 @@ mod tests {
             threshold_exceeded: true,
         };
 
-        let read_model = SbomReadModelBuilder::build(
+        let read_model = SbomReadModelBuilder::build_with_project(
             packages,
             &metadata,
             Some(&graph),
             Some(&vuln_result),
+            None,
+            None,
             None,
         );
 

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -202,7 +202,15 @@ mod tests {
         let metadata = create_test_metadata();
         let graph = create_test_graph();
 
-        let read_model = SbomReadModelBuilder::build_with_project(packages, &metadata, Some(&graph), None, None, None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(
+            packages,
+            &metadata,
+            Some(&graph),
+            None,
+            None,
+            None,
+            None,
+        );
 
         // Check metadata
         assert_eq!(read_model.metadata.tool_name, "uv-sbom");
@@ -225,7 +233,9 @@ mod tests {
         let packages: Vec<EnrichedPackage> = vec![];
         let metadata = create_test_metadata();
 
-        let read_model = SbomReadModelBuilder::build_with_project(packages, &metadata, None, None, None, None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(
+            packages, &metadata, None, None, None, None, None,
+        );
 
         assert!(read_model.components.is_empty());
     }
@@ -559,8 +569,15 @@ mod tests {
             threshold_exceeded: true,
         };
 
-        let read_model =
-            SbomReadModelBuilder::build_with_project(packages, &metadata, None, Some(&vuln_result), None, None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(
+            packages,
+            &metadata,
+            None,
+            Some(&vuln_result),
+            None,
+            None,
+            None,
+        );
 
         assert!(read_model.vulnerabilities.is_some());
         let vulns = read_model.vulnerabilities.unwrap();
@@ -706,8 +723,15 @@ mod tests {
             threshold_exceeded: true,
         };
 
-        let read_model =
-            SbomReadModelBuilder::build_with_project(packages, &metadata, None, Some(&vuln_result), None, None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(
+            packages,
+            &metadata,
+            None,
+            Some(&vuln_result),
+            None,
+            None,
+            None,
+        );
 
         assert!(read_model.resolution_guide.is_none());
     }
@@ -718,7 +742,15 @@ mod tests {
         let metadata = create_test_metadata();
         let graph = create_test_graph();
 
-        let read_model = SbomReadModelBuilder::build_with_project(packages, &metadata, Some(&graph), None, None, None, None);
+        let read_model = SbomReadModelBuilder::build_with_project(
+            packages,
+            &metadata,
+            Some(&graph),
+            None,
+            None,
+            None,
+            None,
+        );
 
         assert!(read_model.resolution_guide.is_none());
     }

--- a/src/application/read_models/sbom_read_model_builder/upgrade_recommendation_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/upgrade_recommendation_builder.rs
@@ -10,25 +10,23 @@ pub(super) fn build_upgrade_recommendations(
         .map(|rec| match rec {
             UpgradeRecommendation::Upgradable {
                 direct_dep_name,
-                direct_dep_current_version,
                 direct_dep_target_version,
                 transitive_dep_name,
                 transitive_resolved_version,
                 vulnerability_id,
+                ..
             } => UpgradeEntryView::Upgradable {
                 direct_dep: direct_dep_name.clone(),
-                current_version: direct_dep_current_version.clone(),
                 target_version: direct_dep_target_version.clone(),
                 transitive_dep: transitive_dep_name.clone(),
                 resolved_version: transitive_resolved_version.clone(),
                 vulnerability_id: vulnerability_id.clone(),
             },
             UpgradeRecommendation::Unresolvable {
-                direct_dep_name,
                 reason,
                 vulnerability_id,
+                ..
             } => UpgradeEntryView::Unresolvable {
-                direct_dep: direct_dep_name.clone(),
                 reason: reason.clone(),
                 vulnerability_id: vulnerability_id.clone(),
             },

--- a/src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs
@@ -40,15 +40,12 @@ pub(super) fn build_vulnerabilities(
 
     let summary = VulnerabilitySummary {
         total_count: result.actionable_count() + result.informational_count(),
-        actionable_count: result.actionable_count(),
-        informational_count: result.informational_count(),
         affected_package_count: affected_packages.len(),
     };
 
     VulnerabilityReportView {
         actionable,
         informational,
-        threshold_exceeded: result.threshold_exceeded,
         summary,
     }
 }

--- a/src/application/read_models/upgrade_recommendation_view.rs
+++ b/src/application/read_models/upgrade_recommendation_view.rs
@@ -11,12 +11,10 @@ pub struct UpgradeRecommendationView {
 
 /// Individual upgrade recommendation entry view
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Reserved for Issue #486: enum variant fields unused in binary but read by library consumers/formatters
 pub enum UpgradeEntryView {
     /// Upgrading the direct dependency resolves the vulnerability
     Upgradable {
         direct_dep: String,
-        current_version: String,
         target_version: String,
         transitive_dep: String,
         resolved_version: String,
@@ -24,7 +22,6 @@ pub enum UpgradeEntryView {
     },
     /// Upgrading the direct dependency does NOT resolve the vulnerability
     Unresolvable {
-        direct_dep: String,
         reason: String,
         vulnerability_id: String,
     },

--- a/src/application/read_models/vulnerability_view.rs
+++ b/src/application/read_models/vulnerability_view.rs
@@ -13,10 +13,6 @@ pub struct VulnerabilityReportView {
     pub actionable: Vec<VulnerabilityView>,
     /// Vulnerabilities for information only (LOW, NONE)
     pub informational: Vec<VulnerabilityView>,
-    /// Whether the severity threshold was exceeded
-    #[allow(dead_code)]
-    // Reserved for Issue #486: public read model field for library consumers
-    pub threshold_exceeded: bool,
     /// Summary statistics
     pub summary: VulnerabilitySummary,
 }
@@ -115,14 +111,6 @@ impl SeverityView {
 pub struct VulnerabilitySummary {
     /// Total number of vulnerabilities
     pub total_count: usize,
-    /// Number of actionable vulnerabilities
-    #[allow(dead_code)]
-    // Reserved for Issue #486: public read model field for library consumers
-    pub actionable_count: usize,
-    /// Number of informational vulnerabilities
-    #[allow(dead_code)]
-    // Reserved for Issue #486: public read model field for library consumers
-    pub informational_count: usize,
     /// Number of unique affected packages
     pub affected_package_count: usize,
 }

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -134,7 +134,6 @@ where
         Ok(self.build_response(
             enriched_packages,
             dependency_graph,
-            vulnerability_report,
             vulnerability_check_result,
             license_compliance_result,
             upgrade_recommendations,
@@ -492,7 +491,6 @@ where
         &self,
         enriched_packages: Vec<EnrichedPackage>,
         dependency_graph: Option<crate::sbom_generation::domain::DependencyGraph>,
-        vulnerability_report: Option<Vec<crate::sbom_generation::domain::PackageVulnerabilities>>,
         vulnerability_check_result: Option<VulnerabilityCheckResult>,
         license_compliance_result: Option<LicenseComplianceResult>,
         upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
@@ -518,9 +516,6 @@ where
 
         if let Some(graph) = dependency_graph {
             builder = builder.dependency_graph(graph);
-        }
-        if let Some(report) = vulnerability_report {
-            builder = builder.vulnerability_report(report);
         }
         if let Some(result) = vulnerability_check_result {
             builder = builder.vulnerability_check_result(result);

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -253,7 +253,7 @@ version = "3.4.0"
     let response = use_case.execute(request).await.unwrap();
 
     assert_eq!(response.enriched_packages.len(), 2);
-    assert!(response.vulnerability_report.is_some());
+    assert!(response.vulnerability_check_result.is_some());
 }
 
 #[tokio::test]
@@ -287,7 +287,7 @@ version = "2024.8.30"
     let response = use_case.execute(request).await.unwrap();
 
     assert_eq!(response.enriched_packages.len(), 1);
-    assert!(response.vulnerability_report.is_none());
+    assert!(response.vulnerability_check_result.is_none());
 }
 
 #[tokio::test]
@@ -319,7 +319,7 @@ version = "2024.8.30"
     let response = use_case.execute(request).await.unwrap();
 
     assert_eq!(response.enriched_packages.len(), 1);
-    assert!(response.vulnerability_report.is_none());
+    assert!(response.vulnerability_check_result.is_none());
 }
 
 #[tokio::test]
@@ -353,7 +353,7 @@ version = "2024.8.30"
     let response = use_case.execute(request).await.unwrap();
 
     assert_eq!(response.enriched_packages.len(), 0); // dry-run returns empty
-    assert!(response.vulnerability_report.is_none()); // CVE check skipped
+    assert!(response.vulnerability_check_result.is_none()); // CVE check skipped
 }
 
 // ===== Tests for extracted methods =====
@@ -413,7 +413,7 @@ fn test_apply_exclusion_filters_with_patterns() {
     ];
     let request = SbomRequest::builder()
         .project_path("/test/project")
-        .add_exclude_pattern("requests")
+        .exclude_patterns(vec!["requests".to_string()])
         .build()
         .unwrap();
 
@@ -444,7 +444,7 @@ fn test_apply_exclusion_filters_all_excluded_error() {
     let packages = vec![Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap()];
     let request = SbomRequest::builder()
         .project_path("/test/project")
-        .add_exclude_pattern("pkg1")
+        .exclude_patterns(vec!["pkg1".to_string()])
         .build()
         .unwrap();
 
@@ -541,11 +541,11 @@ fn test_build_response() {
         Some("Test description".to_string()),
     )];
 
-    let response = use_case.build_response(enriched_packages.clone(), None, None, None, None, None);
+    let response = use_case.build_response(enriched_packages.clone(), None, None, None, None);
 
     assert_eq!(response.enriched_packages.len(), 1);
     assert!(response.dependency_graph.is_none());
-    assert!(response.vulnerability_report.is_none());
+    assert!(response.vulnerability_check_result.is_none());
     assert!(response.vulnerability_check_result.is_none());
     assert!(!response.metadata.serial_number().is_empty());
     assert!(!response.metadata.timestamp().is_empty());
@@ -667,7 +667,7 @@ fn test_build_threshold_config_severity() {
     let request = SbomRequest::builder()
         .project_path("/test/project")
         .check_cve(true)
-        .severity_threshold(Severity::High)
+        .severity_threshold_opt(Some(Severity::High))
         .build()
         .unwrap();
 
@@ -687,7 +687,7 @@ fn test_build_threshold_config_cvss() {
     let request = SbomRequest::builder()
         .project_path("/test/project")
         .check_cve(true)
-        .cvss_threshold(7.0)
+        .cvss_threshold_opt(Some(7.0))
         .build()
         .unwrap();
 
@@ -749,7 +749,6 @@ fn test_build_response_with_threshold_exceeded() {
 
     let response = use_case.build_response(
         enriched_packages,
-        None,
         None,
         Some(check_result),
         None,
@@ -813,7 +812,6 @@ fn test_build_response_with_threshold_not_exceeded() {
 
     let response = use_case.build_response(
         enriched_packages,
-        None,
         None,
         Some(check_result),
         None,
@@ -885,7 +883,7 @@ version = "1.26.0"
     let request = SbomRequest::builder()
         .project_path("/test/project")
         .include_dependency_info(true)
-        .add_exclude_pattern("myproject")
+        .exclude_patterns(vec!["myproject".to_string()])
         .build()
         .unwrap();
 
@@ -1017,7 +1015,7 @@ version = "7.0.0"
     let request = SbomRequest::builder()
         .project_path("/test/project")
         .include_dependency_info(true)
-        .add_exclude_pattern("pytest")
+        .exclude_patterns(vec!["pytest".to_string()])
         .build()
         .unwrap();
 

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -747,13 +747,7 @@ fn test_build_response_with_threshold_exceeded() {
         threshold_exceeded: true,
     };
 
-    let response = use_case.build_response(
-        enriched_packages,
-        None,
-        Some(check_result),
-        None,
-        None,
-    );
+    let response = use_case.build_response(enriched_packages, None, Some(check_result), None, None);
 
     assert!(response.has_vulnerabilities_above_threshold);
     assert!(response.vulnerability_check_result.is_some());
@@ -810,13 +804,7 @@ fn test_build_response_with_threshold_not_exceeded() {
         threshold_exceeded: false,
     };
 
-    let response = use_case.build_response(
-        enriched_packages,
-        None,
-        Some(check_result),
-        None,
-        None,
-    );
+    let response = use_case.build_response(enriched_packages, None, Some(check_result), None, None);
 
     assert!(!response.has_vulnerabilities_above_threshold);
     assert!(response.vulnerability_check_result.is_some());

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -30,7 +30,6 @@ impl Locale {
 }
 
 /// All translatable strings used in formatted output.
-#[allow(dead_code)] // Reserved for Issue #486: some message keys are unused pending future formatter sections
 pub struct Messages {
     // Section headers
     pub section_sbom_title: &'static str,
@@ -51,13 +50,6 @@ pub struct Messages {
     pub col_severity: &'static str,
     pub col_vuln_id: &'static str,
     pub col_cvss: &'static str,
-
-    // Status labels
-    pub status_compliant: &'static str,
-    pub status_violation: &'static str,
-    pub status_no_vulns: &'static str,
-    pub status_direct_dep: &'static str,
-    pub status_introduced_by: &'static str,
 
     // Progress messages (formatter/main layer)
     pub progress_generating_json: &'static str,
@@ -217,13 +209,6 @@ static EN_MESSAGES: Messages = Messages {
     col_vuln_id: "Vulnerability ID",
     col_cvss: "CVSS",
 
-    // Status labels
-    status_compliant: "Compliant",
-    status_violation: "Violation",
-    status_no_vulns: "No vulnerabilities found",
-    status_direct_dep: "Direct dependency",
-    status_introduced_by: "Introduced by",
-
     // Progress messages
     progress_generating_json: "📝 Generating CycloneDX JSON format output...",
     progress_generating_markdown: "📝 Generating Markdown format output...",
@@ -350,13 +335,6 @@ static JA_MESSAGES: Messages = Messages {
     col_severity: "深刻度",
     col_vuln_id: "脆弱性ID",
     col_cvss: "CVSS",
-
-    // Status labels
-    status_compliant: "準拠",
-    status_violation: "違反",
-    status_no_vulns: "脆弱性は検出されませんでした",
-    status_direct_dep: "直接依存",
-    status_introduced_by: "導入元",
 
     // Progress messages
     progress_generating_json: "📝 CycloneDX JSON形式で出力を生成中...",
@@ -500,7 +478,6 @@ mod tests {
         );
         assert_eq!(msgs.section_direct_deps, "## Direct Dependencies");
         assert_eq!(msgs.col_package, "Package");
-        assert_eq!(msgs.status_compliant, "Compliant");
         assert_eq!(
             msgs.progress_generating_json,
             "📝 Generating CycloneDX JSON format output..."
@@ -513,7 +490,6 @@ mod tests {
         assert_eq!(msgs.section_sbom_title, "# ソフトウェア部品表 (SBOM)");
         assert_eq!(msgs.section_direct_deps, "## 直接依存パッケージ");
         assert_eq!(msgs.col_package, "パッケージ");
-        assert_eq!(msgs.status_compliant, "準拠");
         assert_eq!(
             msgs.progress_generating_json,
             "📝 CycloneDX JSON形式で出力を生成中..."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,11 @@
 //! let response = use_case.execute(request).await?;
 //!
 //! // Build read model and format output
-//! let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
+//! let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build_with_project(
 //!     response.enriched_packages,
 //!     &response.metadata,
+//!     None,
+//!     None,
 //!     None,
 //!     None,
 //!     None,

--- a/src/ports/outbound/uv_lock_simulator.rs
+++ b/src/ports/outbound/uv_lock_simulator.rs
@@ -4,10 +4,6 @@ use std::collections::HashMap;
 /// Represents the result of a `uv lock --upgrade-package` simulation
 #[derive(Debug, Clone)]
 pub struct SimulationResult {
-    /// The direct package that was upgraded
-    #[allow(dead_code)]
-    // Reserved for Issue #486: field retained for completeness of SimulationResult API
-    pub upgraded_package: String,
     /// The version it was upgraded to
     pub upgraded_to_version: String,
     /// Map of transitive package name → resolved version after upgrade

--- a/src/ports/outbound/workspace_reader.rs
+++ b/src/ports/outbound/workspace_reader.rs
@@ -6,9 +6,6 @@ use std::path::{Path, PathBuf};
 pub struct WorkspaceMember {
     /// The package name as declared in the `[[package]]` entry.
     pub name: String,
-    /// The relative path to the workspace member (as listed in `[manifest].members`).
-    #[allow(dead_code)] // Reserved for Issue #486: public field for library consumers
-    pub relative_path: String,
     /// The absolute path to the workspace member, resolved from the workspace root.
     pub absolute_path: PathBuf,
 }
@@ -31,16 +28,4 @@ pub trait WorkspaceReader {
     /// # Errors
     /// Returns an error if the `uv.lock` file cannot be read or parsed.
     fn read_workspace_members(&self, workspace_root: &Path) -> Result<Vec<WorkspaceMember>>;
-
-    /// Returns `true` if the given path is a uv workspace root.
-    ///
-    /// A path is considered a workspace root if its `uv.lock` file contains a
-    /// non-empty `[manifest].members` array.
-    ///
-    /// # Postconditions
-    /// Returns `false` if `uv.lock` does not exist, cannot be read, or has no
-    /// `[manifest].members` section. Errors reading the lock file are silently
-    /// treated as non-workspace (returns `false`).
-    #[allow(dead_code)] // Reserved for Issue #486: public trait method for library consumers
-    fn is_workspace_root(&self, path: &Path) -> bool;
 }

--- a/src/sbom_generation/domain/services/upgrade_advisor.rs
+++ b/src/sbom_generation/domain/services/upgrade_advisor.rs
@@ -59,7 +59,6 @@ impl UpgradeAdvisor {
 
             for introduced in entry.introduced_by() {
                 let direct_dep_name = introduced.package_name().to_string();
-                let direct_dep_current_version = introduced.version().to_string();
 
                 match simulation_outcomes.get(&direct_dep_name) {
                     Some(Ok(sim_result)) => {
@@ -69,7 +68,6 @@ impl UpgradeAdvisor {
                             if version_satisfies_min(resolved_version, &fixed_version_normalized) {
                                 recommendations.push(UpgradeRecommendation::Upgradable {
                                     direct_dep_name,
-                                    direct_dep_current_version,
                                     direct_dep_target_version: sim_result
                                         .upgraded_to_version
                                         .clone(),
@@ -94,7 +92,6 @@ impl UpgradeAdvisor {
                             // Vulnerable package removed after upgrade — treat as resolved
                             recommendations.push(UpgradeRecommendation::Upgradable {
                                 direct_dep_name,
-                                direct_dep_current_version,
                                 direct_dep_target_version: sim_result.upgraded_to_version.clone(),
                                 transitive_dep_name: entry.vulnerable_package().to_string(),
                                 transitive_resolved_version: String::new(),
@@ -311,7 +308,7 @@ mod tests {
     }
 
     fn make_sim_result(
-        upgraded_package: &str,
+        _upgraded_package: &str,
         upgraded_to: &str,
         resolved: Vec<(&str, &str)>,
     ) -> SimulationResult {
@@ -320,7 +317,6 @@ mod tests {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
         SimulationResult {
-            upgraded_package: upgraded_package.to_string(),
             upgraded_to_version: upgraded_to.to_string(),
             resolved_versions,
         }

--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -42,18 +42,6 @@ pub struct VulnerabilityCheckResult {
 }
 
 impl VulnerabilityCheckResult {
-    /// Returns true if there are actionable vulnerabilities (above threshold)
-    #[allow(dead_code)] // Reserved for Issue #486: future presenter/summary use
-    pub fn has_actionable_vulnerabilities(&self) -> bool {
-        !self.above_threshold.is_empty()
-    }
-
-    /// Returns true if there are informational vulnerabilities (below threshold)
-    #[allow(dead_code)] // Reserved for Issue #486: future presenter/summary use
-    pub fn has_informational_vulnerabilities(&self) -> bool {
-        !self.below_threshold.is_empty()
-    }
-
     /// Returns total count of actionable vulnerabilities
     pub fn actionable_count(&self) -> usize {
         self.above_threshold
@@ -70,17 +58,6 @@ impl VulnerabilityCheckResult {
             .sum()
     }
 
-    /// Returns affected package count for actionable vulnerabilities
-    #[allow(dead_code)] // Reserved for Issue #486: future presenter/summary use
-    pub fn actionable_package_count(&self) -> usize {
-        self.above_threshold.len()
-    }
-
-    /// Returns affected package count for informational vulnerabilities
-    #[allow(dead_code)] // Reserved for Issue #486: future presenter/summary use
-    pub fn informational_package_count(&self) -> usize {
-        self.below_threshold.len()
-    }
 }
 
 /// Domain service for evaluating vulnerabilities against thresholds
@@ -310,58 +287,6 @@ mod tests {
         assert_eq!(result.below_threshold[0].vulnerabilities().len(), 1); // 6.9 is < 7.0
     }
 
-    // Tests for VulnerabilityCheckResult semantic methods
-
-    #[test]
-    fn test_has_actionable_vulnerabilities_true() {
-        let vuln = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
-        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln]);
-
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![pkg],
-            below_threshold: vec![],
-            threshold_exceeded: true,
-        };
-
-        assert!(result.has_actionable_vulnerabilities());
-    }
-
-    #[test]
-    fn test_has_actionable_vulnerabilities_false() {
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![],
-            below_threshold: vec![],
-            threshold_exceeded: false,
-        };
-
-        assert!(!result.has_actionable_vulnerabilities());
-    }
-
-    #[test]
-    fn test_has_informational_vulnerabilities_true() {
-        let vuln = create_vulnerability("CVE-2024-001", Some(3.0), Severity::Low);
-        let pkg = create_package_vulnerabilities("test-pkg", vec![vuln]);
-
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![],
-            below_threshold: vec![pkg],
-            threshold_exceeded: false,
-        };
-
-        assert!(result.has_informational_vulnerabilities());
-    }
-
-    #[test]
-    fn test_has_informational_vulnerabilities_false() {
-        let result = VulnerabilityCheckResult {
-            above_threshold: vec![],
-            below_threshold: vec![],
-            threshold_exceeded: false,
-        };
-
-        assert!(!result.has_informational_vulnerabilities());
-    }
-
     #[test]
     fn test_actionable_count_single_package() {
         let vuln1 = create_vulnerability("CVE-2024-001", Some(9.0), Severity::Critical);
@@ -450,7 +375,7 @@ mod tests {
             threshold_exceeded: true,
         };
 
-        assert_eq!(result.actionable_package_count(), 2);
+        assert_eq!(result.above_threshold.len(), 2);
     }
 
     #[test]
@@ -461,7 +386,7 @@ mod tests {
             threshold_exceeded: false,
         };
 
-        assert_eq!(result.actionable_package_count(), 0);
+        assert_eq!(result.above_threshold.len(), 0);
     }
 
     #[test]
@@ -479,7 +404,7 @@ mod tests {
             threshold_exceeded: false,
         };
 
-        assert_eq!(result.informational_package_count(), 3);
+        assert_eq!(result.below_threshold.len(), 3);
     }
 
     #[test]
@@ -500,12 +425,12 @@ mod tests {
             threshold_exceeded: true,
         };
 
-        assert!(result.has_actionable_vulnerabilities());
-        assert!(result.has_informational_vulnerabilities());
+        assert!(!result.above_threshold.is_empty());
+        assert!(!result.below_threshold.is_empty());
         assert_eq!(result.actionable_count(), 2);
         assert_eq!(result.informational_count(), 2);
-        assert_eq!(result.actionable_package_count(), 1);
-        assert_eq!(result.informational_package_count(), 2);
+        assert_eq!(result.above_threshold.len(), 1);
+        assert_eq!(result.below_threshold.len(), 2);
     }
 
     // Tests for CVE ignore filtering

--- a/src/sbom_generation/domain/services/vulnerability_checker.rs
+++ b/src/sbom_generation/domain/services/vulnerability_checker.rs
@@ -57,7 +57,6 @@ impl VulnerabilityCheckResult {
             .map(|pv| pv.vulnerabilities().len())
             .sum()
     }
-
 }
 
 /// Domain service for evaluating vulnerabilities against thresholds

--- a/src/sbom_generation/domain/upgrade_recommendation.rs
+++ b/src/sbom_generation/domain/upgrade_recommendation.rs
@@ -5,8 +5,6 @@ pub enum UpgradeRecommendation {
     Upgradable {
         /// Direct dependency to upgrade (e.g., "requests")
         direct_dep_name: String,
-        /// Current version of the direct dependency (e.g., "2.31.0")
-        direct_dep_current_version: String,
         /// Recommended version to upgrade to (e.g., "2.32.3")
         direct_dep_target_version: String,
         /// Vulnerable transitive dep name (e.g., "urllib3")

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -95,12 +95,14 @@ async fn test_e2e_json_format() {
     let response = result.unwrap();
 
     // Build read model and format as JSON
-    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build_with_project(
         response.enriched_packages,
         &response.metadata,
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
+        None,
     );
     let formatter = CycloneDxFormatter::new();
     let json_output = formatter.format(&read_model);
@@ -144,12 +146,14 @@ async fn test_e2e_markdown_format() {
     let response = result.unwrap();
 
     // Build read model and format as Markdown
-    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build_with_project(
         response.enriched_packages,
         &response.metadata,
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
+        None,
     );
     let formatter = MarkdownFormatter::new(uv_sbom::i18n::Locale::En);
     let markdown_output = formatter.format(&read_model);
@@ -252,7 +256,7 @@ async fn test_e2e_exclude_single_package() {
     // Exclude urllib3
     let request = SbomRequest::builder()
         .project_path(project_path)
-        .add_exclude_pattern("urllib3")
+        .exclude_patterns(vec!["urllib3".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -334,7 +338,7 @@ async fn test_e2e_exclude_with_wildcard() {
     // Exclude packages starting with "char"
     let request = SbomRequest::builder()
         .project_path(project_path)
-        .add_exclude_pattern("char*")
+        .exclude_patterns(vec!["char*".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -419,7 +423,7 @@ async fn test_e2e_exclude_root_project_preserves_dependency_classification() {
     let request = SbomRequest::builder()
         .project_path(project_path)
         .include_dependency_info(true)
-        .add_exclude_pattern("sample-project")
+        .exclude_patterns(vec!["sample-project".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -472,7 +476,7 @@ async fn test_e2e_exclude_root_project_markdown_output() {
     let request = SbomRequest::builder()
         .project_path(project_path)
         .include_dependency_info(true)
-        .add_exclude_pattern("sample-project")
+        .exclude_patterns(vec!["sample-project".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -481,12 +485,14 @@ async fn test_e2e_exclude_root_project_markdown_output() {
     let response = result.unwrap();
 
     // Build read model and format as Markdown
-    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build(
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build_with_project(
         response.enriched_packages,
         &response.metadata,
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
+        None,
     );
     let formatter = MarkdownFormatter::new(uv_sbom::i18n::Locale::En);
     let markdown_output = formatter.format(&read_model);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -322,7 +322,7 @@ source = { registry = "https://pypi.org/simple" }
     // Exclude urllib3
     let request = SbomRequest::builder()
         .project_path(".")
-        .add_exclude_pattern("urllib3")
+        .exclude_patterns(vec!["urllib3".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -451,7 +451,7 @@ source = { registry = "https://pypi.org/simple" }
     // Exclude all pytest-related packages
     let request = SbomRequest::builder()
         .project_path(".")
-        .add_exclude_pattern("pytest*")
+        .exclude_patterns(vec!["pytest*".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -493,7 +493,7 @@ source = { registry = "https://pypi.org/simple" }
     // Exclude all packages with a pattern that matches everything
     let request = SbomRequest::builder()
         .project_path(".")
-        .add_exclude_pattern("*requests*")
+        .exclude_patterns(vec!["*requests*".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;
@@ -556,7 +556,7 @@ source = { registry = "https://pypi.org/simple" }
     let request = SbomRequest::builder()
         .project_path(".")
         .include_dependency_info(true)
-        .add_exclude_pattern("urllib3")
+        .exclude_patterns(vec!["urllib3".to_string()])
         .build()
         .unwrap();
     let result = use_case.execute(request).await;


### PR DESCRIPTION
## Summary

- Removes all `#[allow(dead_code)]` annotations that were marked "Reserved for Issue #486" in the previous audit PR (#487)
- Each deleted item was either genuinely unused in production paths or superseded by an equivalent active API
- All callers updated; `cargo clippy --all-targets --all-features -- -D warnings` passes clean

## Related Issue

Closes #486

## Changes Made

**Deleted fields/methods/keys:**
- `SimulationResult::upgraded_package` (port + adapter)
- `WorkspaceMember::relative_path` and `WorkspaceReader::is_workspace_root` (port trait + adapter impl)
- `SbomResponse::vulnerability_report` field and builder method (DTO layer)
- `UpgradeEntryView::Upgradable::current_version` and `Unresolvable::direct_dep` (view model)
- `UpgradeRecommendation::Upgradable::direct_dep_current_version` (domain enum)
- `VulnerabilityReportView::threshold_exceeded` and `VulnerabilitySummary::actionable_count/informational_count` (view model)
- `VulnerabilityCheckResult` helpers: `has_actionable_vulnerabilities`, `has_informational_vulnerabilities`, `actionable_package_count`, `informational_package_count`
- `Messages` status keys: `status_compliant`, `status_violation`, `status_no_vulns`, `status_direct_dep`, `status_introduced_by`
- `SbomRequestBuilder::add_exclude_pattern` (replaced by `exclude_patterns(vec![...])`)
- `OsvRange::range_type` and `OsvEvent::introduced` (serde deserialization structs)

**Test updates:**
- `threshold_exceeded` field assertions replaced with `!actionable.is_empty()`
- `actionable_count` / `informational_count` assertions replaced with `actionable.len()` / `informational.len()`
- All `add_exclude_pattern(...)` call sites updated to `exclude_patterns(vec![...])`
- `build_response()` call sites updated after removing `vulnerability_report` parameter

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)