### PR TITLE
docs(skills): add CHANGELOG enforcement gates to /pr and /release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,7 @@ Skills contain mandatory pre-flight checks and language requirements that preven
 
 - **PR #121**: Created in Japanese, `cargo fmt --all -- --check` failed in CI
 - **Issue #59**: `cargo clippy` was run without `-D warnings`, causing CI failure after push
+- **2026-04-18**: v2.2.0 release promoted an empty `[Unreleased]` section. Features added in PRs #441–#483 were never recorded in CHANGELOG. Fixed by Issue #491 (added gate in `/release` Step 3.6 and `/pr` Step 4.5).
 
 ### Enforcement
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -103,6 +103,76 @@ git log origin/develop..HEAD --oneline
 git diff origin/develop...HEAD
 ```
 
+### Step 4.5: CHANGELOG Gate (MANDATORY)
+
+**Skip this step entirely** when the current branch prefix is one of:
+`refactor/`, `ci/`, `test/`, `chore/`, `docs/`
+
+Detect via:
+```bash
+git branch --show-current
+```
+
+If the prefix is unrecognized or not in the skip list, **do not skip** (fail-closed).
+
+**For all other branch types** (`feature/`, `bugfix/`, `hotfix/`, `security/`):
+
+#### 1. Check if CHANGELOG.md was updated on this branch
+
+```bash
+# For feature/bugfix/refactor branches (base: develop)
+git diff origin/develop...HEAD -- CHANGELOG.md
+
+# For hotfix/* branches (base: main)
+git diff origin/main...HEAD -- CHANGELOG.md
+```
+
+If this diff is **non-empty**, CHANGELOG.md was updated — gate passes. Proceed to Step 5.
+
+#### 2. If CHANGELOG.md was NOT updated, detect user-facing changes
+
+Check for user-facing changes in the diff:
+
+```bash
+# New CLI flags (additions of #[arg( or #[clap( lines)
+git diff origin/develop...HEAD -G'#\[arg\(|#\[clap\(' -- 'src/cli/'
+
+# Changes to core behavior (application, formatters, config)
+git diff origin/develop...HEAD --stat -- src/sbom_generation/ src/application/ src/adapters/outbound/formatters/ src/cli/config_resolver.rs src/config.rs
+```
+
+Also consider:
+- Branch prefix `bugfix/` or `hotfix/` → always treat as user-facing (bug fix)
+- Branch prefix `security/` or label `security` → always treat as user-facing (security fix)
+
+#### 3. Decision
+
+| User-facing changes? | CHANGELOG updated? | Action |
+|---|---|---|
+| No | No | ✅ Gate passes — internal-only PR |
+| No | Yes | ✅ Gate passes |
+| Yes | Yes | ✅ Gate passes |
+| Yes | No | ❌ **STOP** — prompt user |
+
+If user-facing changes are detected and CHANGELOG.md was **not** updated, output:
+
+> ⚠️ User-facing changes detected but `CHANGELOG.md [Unreleased]` was not updated on this branch.
+>
+> Please add an entry under the appropriate section before pushing:
+> - `### Added` — new features or CLI flags
+> - `### Fixed` — bug fixes
+> - `### Security` — security fixes
+> - `### Changed` — behavior changes
+>
+> Update `CHANGELOG.md`, commit the change, then re-run `/pr`.
+> Type **yes** to proceed anyway (only if this PR is truly internal), or **no** to abort.
+
+- **yes**: proceed but add a note in the PR body: `⚠️ CHANGELOG not updated — author confirmed internal-only.`
+- **no** (or no response): **STOP**. Do not push or create the PR.
+
+> **Note**: This gate complements `/release` Step 3.6 — catching missing entries at PR
+> time prevents the empty `[Unreleased]` scenario that caused the v2.2.0 incident (Issue #491).
+
 ### Step 5: Push to Remote
 
 ```bash

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -158,14 +158,34 @@ versioned entry in Step 4.
 
 #### Edge case: [Unreleased] becomes empty after cleaning
 
-If all entries are removed, leave only the empty `## [Unreleased]` placeholder
-and proceed with an empty versioned section:
+⚠️ **WARNING: STOP — DO NOT PROCEED SILENTLY.**
 
-```markdown
-## [Unreleased]
+If after removing internal entries the `[Unreleased]` section is empty, this
+typically means one of two things:
+- (a) Every entry in `[Unreleased]` was legitimately internal (refactor, CI, tests) — safe to release with no user-facing changelog.
+- (b) Feature PRs landed without anyone updating `CHANGELOG.md` — this is the v2.2.0 incident (Issue #491).
 
-## [X.Y.Z] - YYYY-MM-DD
-```
+**You must ask the user explicitly before continuing:**
+
+> ⚠️ The `[Unreleased]` section is empty after removing internal entries.
+> Promoting this will produce a release with no user-facing changelog.
+>
+> Did you intentionally make no user-facing changes in this release?
+> Run `git log <last-tag>..HEAD --oneline` to audit merged PRs if unsure.
+>
+> Type **yes** to proceed with an empty release entry, or **no** to pause and add missing entries first.
+
+- If the user answers **yes**: continue to Step 4. The resulting file will look like:
+
+  ```markdown
+  ## [Unreleased]
+
+  ## [X.Y.Z] - YYYY-MM-DD
+  ```
+
+- If the user answers **no**: **STOP HERE.** Do not proceed to Step 4.
+  Instruct the user to add missing entries under the appropriate sections
+  (`### Added`, `### Fixed`, `### Security`, `### Changed`) and then re-run `/release`.
 
 ### Step 4: Update CHANGELOG.md
 


### PR DESCRIPTION
## Summary
- Add blocking confirmation gate to `/release` Step 3.6 — agent can no longer silently proceed when `[Unreleased]` is empty after cleaning
- Add mandatory Step 4.5 (CHANGELOG Gate) to `/pr` skill — detects user-facing changes and blocks PR push if `CHANGELOG.md` was not updated
- Add v2.2.0 incident note to `CLAUDE.md` Recent Incidents to prevent recurrence

## Related Issue
Closes #491

## Changes Made
- `.claude/skills/release/SKILL.md`: Replace silent empty-`[Unreleased]` edge case (lines 159–168) with ⚠️ WARNING block and explicit yes/no user prompt
- `.claude/skills/pr/SKILL.md`: Insert Step 4.5 between Step 4 and Step 5 with CHANGELOG detection logic, decision table, and fail-closed behavior for unrecognized branch prefixes
- `.claude/CLAUDE.md`: Add 2026-04-18 incident entry to `### Recent Incidents` under Skill Invocation Rules

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] Code review (Reviewer Agent) passed with no findings

---
Generated with [Claude Code](https://claude.com/claude-code)