### PR TITLE
feat(domain): add dependency_chains to ResolutionEntry and ResolutionEntryView

### DIFF
--- a/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
@@ -278,6 +278,7 @@ mod tests {
                     package_name: "my-app".to_string(),
                     version: "1.0.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
 
@@ -333,6 +334,7 @@ mod tests {
                         version: "2.0.0".to_string(),
                     },
                 ],
+                dependency_chains: vec![],
             }],
         });
 

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -727,6 +727,7 @@ mod tests {
                     package_name: "requests".to_string(),
                     version: "2.31.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -149,6 +149,7 @@ mod tests {
                     package_name: "requests".to_string(),
                     version: "2.31.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
 
@@ -186,6 +187,7 @@ mod tests {
                         version: "0.25.0".to_string(),
                     },
                 ],
+                dependency_chains: vec![],
             }],
         });
 
@@ -229,6 +231,7 @@ mod tests {
                     package_name: "requests".to_string(),
                     version: "2.31.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
 
@@ -254,6 +257,7 @@ mod tests {
                     package_name: "requests".to_string(),
                     version: "2.31.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
@@ -287,6 +291,7 @@ mod tests {
                     package_name: "httpx".to_string(),
                     version: "0.25.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
@@ -317,6 +322,7 @@ mod tests {
                     package_name: "requests".to_string(),
                     version: "2.31.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
         model.upgrade_recommendations = Some(UpgradeRecommendationView {
@@ -347,6 +353,7 @@ mod tests {
                     package_name: "requests".to_string(),
                     version: "2.31.0".to_string(),
                 }],
+                dependency_chains: vec![],
             }],
         });
         // upgrade_recommendations is None (default in test model)

--- a/src/application/read_models/resolution_guide_view.rs
+++ b/src/application/read_models/resolution_guide_view.rs
@@ -33,6 +33,12 @@ pub struct ResolutionEntryView {
     pub vulnerability_id: String,
     /// Direct dependencies that introduce this vulnerable package
     pub introduced_by: Vec<IntroducedByView>,
+    /// Full dependency chains from direct deps to the vulnerable package.
+    /// Each inner Vec is [direct_dep, ..., vulnerable_package].
+    /// Populated by the builder (Issue #498) but not yet rendered by formatters;
+    /// rendering will be added in Issue #499.
+    #[allow(dead_code)]
+    pub dependency_chains: Vec<Vec<String>>,
 }
 
 /// View representation of a direct dependency that introduces a vulnerable package
@@ -66,6 +72,7 @@ mod tests {
                 package_name: "requests".to_string(),
                 version: "2.28.0".to_string(),
             }],
+            dependency_chains: vec![vec!["requests".to_string(), "urllib3".to_string()]],
         };
 
         assert_eq!(entry.vulnerable_package, "urllib3");
@@ -76,6 +83,8 @@ mod tests {
         assert_eq!(entry.introduced_by.len(), 1);
         assert_eq!(entry.introduced_by[0].package_name, "requests");
         assert_eq!(entry.introduced_by[0].version, "2.28.0");
+        assert_eq!(entry.dependency_chains.len(), 1);
+        assert_eq!(entry.dependency_chains[0], ["requests", "urllib3"]);
     }
 
     #[test]
@@ -87,11 +96,13 @@ mod tests {
             severity: SeverityView::Critical,
             vulnerability_id: "CVE-2024-0001".to_string(),
             introduced_by: vec![],
+            dependency_chains: vec![],
         };
 
         assert_eq!(entry.fixed_version, None);
         assert_eq!(entry.severity, SeverityView::Critical);
         assert!(entry.introduced_by.is_empty());
+        assert!(entry.dependency_chains.is_empty());
     }
 
     #[test]

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -602,6 +602,7 @@ mod tests {
                     "2.28.0".to_string(),
                 ),
             ],
+            vec![],
         )];
 
         let guide = resolution_guide_builder::build_resolution_guide(&entries);
@@ -631,6 +632,7 @@ mod tests {
                     "1.0.0".to_string(),
                 ),
             ],
+            vec![],
         )];
 
         let guide = resolution_guide_builder::build_resolution_guide(&entries);
@@ -658,6 +660,7 @@ mod tests {
                     "2.28.0".to_string(),
                 ),
             ],
+            vec![],
         )];
 
         let guide = resolution_guide_builder::build_resolution_guide(&entries);

--- a/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
@@ -27,6 +27,8 @@ fn build_resolution_entry_view(entry: &ResolutionEntry) -> ResolutionEntryView {
         })
         .collect();
 
+    let dependency_chains = entry.dependency_chains().to_vec();
+
     ResolutionEntryView {
         vulnerable_package: entry.vulnerable_package().to_string(),
         current_version: entry.current_version().to_string(),
@@ -34,5 +36,69 @@ fn build_resolution_entry_view(entry: &ResolutionEntry) -> ResolutionEntryView {
         severity: super::vulnerability_builder::map_severity(&entry.severity()),
         vulnerability_id: entry.vulnerability_id().to_string(),
         introduced_by,
+        dependency_chains,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::resolution_guide::{IntroducedBy, ResolutionEntry};
+    use crate::sbom_generation::domain::vulnerability::Severity;
+
+    fn make_entry(
+        pkg: &str,
+        version: &str,
+        chains: Vec<Vec<String>>,
+    ) -> ResolutionEntry {
+        ResolutionEntry::new(
+            pkg.to_string(),
+            version.to_string(),
+            None,
+            Severity::High,
+            "CVE-2024-0001".to_string(),
+            vec![IntroducedBy::new("parent".to_string(), "1.0.0".to_string())],
+            chains,
+        )
+    }
+
+    #[test]
+    fn test_build_resolution_entry_view_maps_dependency_chains() {
+        let chains = vec![
+            vec!["requests".to_string(), "urllib3".to_string()],
+            vec!["httpx".to_string(), "urllib3".to_string()],
+        ];
+        let entry = make_entry("urllib3", "1.26.5", chains.clone());
+
+        let view = build_resolution_entry_view(&entry);
+
+        assert_eq!(view.dependency_chains, chains);
+    }
+
+    #[test]
+    fn test_build_resolution_entry_view_empty_dependency_chains() {
+        let entry = make_entry("urllib3", "1.26.5", vec![]);
+
+        let view = build_resolution_entry_view(&entry);
+
+        assert!(view.dependency_chains.is_empty());
+    }
+
+    #[test]
+    fn test_build_resolution_guide_propagates_chains() {
+        let entries = vec![
+            make_entry(
+                "urllib3",
+                "1.26.5",
+                vec![vec!["requests".to_string(), "urllib3".to_string()]],
+            ),
+            make_entry("certifi", "2023.7.22", vec![]),
+        ];
+
+        let guide = build_resolution_guide(&entries);
+
+        assert_eq!(guide.entries.len(), 2);
+        assert_eq!(guide.entries[0].dependency_chains.len(), 1);
+        assert!(guide.entries[1].dependency_chains.is_empty());
     }
 }

--- a/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
@@ -46,11 +46,7 @@ mod tests {
     use crate::sbom_generation::domain::resolution_guide::{IntroducedBy, ResolutionEntry};
     use crate::sbom_generation::domain::vulnerability::Severity;
 
-    fn make_entry(
-        pkg: &str,
-        version: &str,
-        chains: Vec<Vec<String>>,
-    ) -> ResolutionEntry {
+    fn make_entry(pkg: &str, version: &str, chains: Vec<Vec<String>>) -> ResolutionEntry {
         ResolutionEntry::new(
             pkg.to_string(),
             version.to_string(),

--- a/src/sbom_generation/domain/dependency_graph.rs
+++ b/src/sbom_generation/domain/dependency_graph.rs
@@ -39,8 +39,6 @@ impl DependencyGraph {
     /// Each path is ordered `[direct_dep, ..., target]`.
     /// Returns an empty Vec if `target` is itself a direct dependency (one-hop not shown).
     /// Uses BFS with per-path visited tracking to handle cyclic graphs safely.
-    // Called by the use case in #498; remove this annotation when that issue is implemented.
-    #[allow(dead_code)]
     pub fn find_paths_to(&self, target: &PackageName) -> Vec<Vec<PackageName>> {
         let mut results: Vec<Vec<PackageName>> = Vec::new();
         let mut queue: VecDeque<(PackageName, Vec<PackageName>, HashSet<PackageName>)> =

--- a/src/sbom_generation/domain/resolution_guide.rs
+++ b/src/sbom_generation/domain/resolution_guide.rs
@@ -15,6 +15,10 @@ pub struct ResolutionEntry {
     vulnerability_id: String,
     /// List of direct dependencies that introduce this vulnerable package
     introduced_by: Vec<IntroducedBy>,
+    /// Full dependency chains from direct deps to the vulnerable package.
+    /// Each inner Vec is [direct_dep, ..., vulnerable_package].
+    /// Empty if introduced directly (one-hop) or if the target is a direct dependency.
+    dependency_chains: Vec<Vec<String>>,
 }
 
 impl ResolutionEntry {
@@ -25,6 +29,7 @@ impl ResolutionEntry {
         severity: Severity,
         vulnerability_id: String,
         introduced_by: Vec<IntroducedBy>,
+        dependency_chains: Vec<Vec<String>>,
     ) -> Self {
         Self {
             vulnerable_package,
@@ -33,6 +38,7 @@ impl ResolutionEntry {
             severity,
             vulnerability_id,
             introduced_by,
+            dependency_chains,
         }
     }
 
@@ -58,6 +64,10 @@ impl ResolutionEntry {
 
     pub fn introduced_by(&self) -> &[IntroducedBy] {
         &self.introduced_by
+    }
+
+    pub fn dependency_chains(&self) -> &[Vec<String>] {
+        &self.dependency_chains
     }
 }
 
@@ -105,6 +115,10 @@ mod tests {
             IntroducedBy::new("requests".to_string(), "2.28.0".to_string()),
             IntroducedBy::new("httpx".to_string(), "0.23.0".to_string()),
         ];
+        let chains = vec![
+            vec!["requests".to_string(), "urllib3".to_string()],
+            vec!["httpx".to_string(), "urllib3".to_string()],
+        ];
 
         let entry = ResolutionEntry::new(
             "urllib3".to_string(),
@@ -113,6 +127,7 @@ mod tests {
             Severity::High,
             "CVE-2023-43804".to_string(),
             introduced,
+            chains,
         );
 
         assert_eq!(entry.vulnerable_package(), "urllib3");
@@ -123,6 +138,9 @@ mod tests {
         assert_eq!(entry.introduced_by().len(), 2);
         assert_eq!(entry.introduced_by()[0].package_name(), "requests");
         assert_eq!(entry.introduced_by()[1].package_name(), "httpx");
+        assert_eq!(entry.dependency_chains().len(), 2);
+        assert_eq!(entry.dependency_chains()[0], ["requests", "urllib3"]);
+        assert_eq!(entry.dependency_chains()[1], ["httpx", "urllib3"]);
     }
 
     #[test]
@@ -137,6 +155,7 @@ mod tests {
                 "parent-pkg".to_string(),
                 "1.0.0".to_string(),
             )],
+            vec![],
         );
 
         assert_eq!(entry.fixed_version(), None);
@@ -152,8 +171,29 @@ mod tests {
             Severity::Medium,
             "GHSA-xxxx-yyyy-zzzz".to_string(),
             vec![],
+            vec![],
         );
 
         assert!(entry.introduced_by().is_empty());
+        assert!(entry.dependency_chains().is_empty());
+    }
+
+    #[test]
+    fn test_resolution_entry_dependency_chains_accessor() {
+        let chains = vec![
+            vec!["a".to_string(), "b".to_string(), "vuln".to_string()],
+            vec!["c".to_string(), "vuln".to_string()],
+        ];
+        let entry = ResolutionEntry::new(
+            "vuln".to_string(),
+            "1.0.0".to_string(),
+            None,
+            Severity::Low,
+            "CVE-2024-0002".to_string(),
+            vec![],
+            chains.clone(),
+        );
+
+        assert_eq!(entry.dependency_chains(), chains.as_slice());
     }
 }

--- a/src/sbom_generation/domain/services/resolution_analyzer.rs
+++ b/src/sbom_generation/domain/services/resolution_analyzer.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crate::ports::outbound::enriched_package::EnrichedPackage;
 use crate::sbom_generation::domain::dependency_graph::DependencyGraph;
+use crate::sbom_generation::domain::package::PackageName;
 use crate::sbom_generation::domain::resolution_guide::{IntroducedBy, ResolutionEntry};
 use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
 
@@ -58,6 +59,18 @@ impl ResolutionAnalyzer {
             // Sort introduced_by for deterministic output
             introduced_by.sort_by(|a, b| a.package_name().cmp(b.package_name()));
 
+            // Compute full dependency chains. If PackageName construction fails for a
+            // malformed name, default to empty chains to preserve the entry.
+            let dependency_chains: Vec<Vec<String>> = PackageName::new(pkg_vuln.package_name().to_string())
+                .map(|pkg_name| {
+                    dependency_graph
+                        .find_paths_to(&pkg_name)
+                        .into_iter()
+                        .map(|path| path.iter().map(|p| p.as_str().to_string()).collect())
+                        .collect()
+                })
+                .unwrap_or_default();
+
             for vuln in pkg_vuln.vulnerabilities() {
                 entries.push(ResolutionEntry::new(
                     pkg_vuln.package_name().to_string(),
@@ -66,6 +79,7 @@ impl ResolutionAnalyzer {
                     vuln.severity(),
                     vuln.id().to_string(),
                     introduced_by.clone(),
+                    dependency_chains.clone(),
                 ));
             }
         }
@@ -169,6 +183,11 @@ mod tests {
         assert_eq!(entries[0].introduced_by().len(), 1);
         assert_eq!(entries[0].introduced_by()[0].package_name(), "requests");
         assert_eq!(entries[0].introduced_by()[0].version(), "2.28.0");
+        assert_eq!(entries[0].dependency_chains().len(), 1);
+        assert_eq!(
+            entries[0].dependency_chains()[0],
+            ["requests", "urllib3"]
+        );
     }
 
     #[test]
@@ -217,6 +236,11 @@ mod tests {
         // Sorted alphabetically
         assert_eq!(entries[0].introduced_by()[0].package_name(), "httpx");
         assert_eq!(entries[0].introduced_by()[1].package_name(), "requests");
+        // Both direct deps produce a chain to urllib3
+        assert_eq!(entries[0].dependency_chains().len(), 2);
+        let chains = entries[0].dependency_chains();
+        assert!(chains.contains(&vec!["requests".to_string(), "urllib3".to_string()]));
+        assert!(chains.contains(&vec!["httpx".to_string(), "urllib3".to_string()]));
     }
 
     #[test]
@@ -310,5 +334,60 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].introduced_by()[0].package_name(), "requests");
         assert_eq!(entries[0].introduced_by()[0].version(), "unknown");
+    }
+
+    #[test]
+    fn test_analyze_populates_dependency_chains_deep_transitive() {
+        // a -> b -> vuln (two-hop chain)
+        let graph = make_graph(
+            vec!["a"],
+            vec![("a", vec!["b"]), ("b", vec!["vuln"])],
+        );
+        let vulns = vec![make_pkg_vulns(
+            "vuln",
+            "0.1.0",
+            vec![make_vuln("CVE-2024-1111", Severity::High, None)],
+        )];
+        let packages = vec![
+            make_enriched("a", "1.0.0"),
+            make_enriched("b", "2.0.0"),
+            make_enriched("vuln", "0.1.0"),
+        ];
+
+        let entries = ResolutionAnalyzer::analyze(&graph, &vulns, &packages);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].dependency_chains().len(), 1);
+        assert_eq!(
+            entries[0].dependency_chains()[0],
+            ["a", "b", "vuln"]
+        );
+    }
+
+    #[test]
+    fn test_analyze_dependency_chains_shared_across_multiple_vulns_same_package() {
+        let graph = make_graph(
+            vec!["requests"],
+            vec![("requests", vec!["urllib3"])],
+        );
+        let vulns = vec![make_pkg_vulns(
+            "urllib3",
+            "1.26.5",
+            vec![
+                make_vuln("CVE-2023-43804", Severity::High, Some("1.26.18")),
+                make_vuln("CVE-2023-45803", Severity::Medium, Some("2.0.7")),
+            ],
+        )];
+        let packages = vec![
+            make_enriched("requests", "2.28.0"),
+            make_enriched("urllib3", "1.26.5"),
+        ];
+
+        let entries = ResolutionAnalyzer::analyze(&graph, &vulns, &packages);
+
+        assert_eq!(entries.len(), 2);
+        // Both entries for the same package share the same chains
+        assert_eq!(entries[0].dependency_chains(), entries[1].dependency_chains());
+        assert_eq!(entries[0].dependency_chains()[0], ["requests", "urllib3"]);
     }
 }

--- a/src/sbom_generation/domain/services/resolution_analyzer.rs
+++ b/src/sbom_generation/domain/services/resolution_analyzer.rs
@@ -61,15 +61,16 @@ impl ResolutionAnalyzer {
 
             // Compute full dependency chains. If PackageName construction fails for a
             // malformed name, default to empty chains to preserve the entry.
-            let dependency_chains: Vec<Vec<String>> = PackageName::new(pkg_vuln.package_name().to_string())
-                .map(|pkg_name| {
-                    dependency_graph
-                        .find_paths_to(&pkg_name)
-                        .into_iter()
-                        .map(|path| path.iter().map(|p| p.as_str().to_string()).collect())
-                        .collect()
-                })
-                .unwrap_or_default();
+            let dependency_chains: Vec<Vec<String>> =
+                PackageName::new(pkg_vuln.package_name().to_string())
+                    .map(|pkg_name| {
+                        dependency_graph
+                            .find_paths_to(&pkg_name)
+                            .into_iter()
+                            .map(|path| path.iter().map(|p| p.as_str().to_string()).collect())
+                            .collect()
+                    })
+                    .unwrap_or_default();
 
             for vuln in pkg_vuln.vulnerabilities() {
                 entries.push(ResolutionEntry::new(
@@ -184,10 +185,7 @@ mod tests {
         assert_eq!(entries[0].introduced_by()[0].package_name(), "requests");
         assert_eq!(entries[0].introduced_by()[0].version(), "2.28.0");
         assert_eq!(entries[0].dependency_chains().len(), 1);
-        assert_eq!(
-            entries[0].dependency_chains()[0],
-            ["requests", "urllib3"]
-        );
+        assert_eq!(entries[0].dependency_chains()[0], ["requests", "urllib3"]);
     }
 
     #[test]
@@ -339,10 +337,7 @@ mod tests {
     #[test]
     fn test_analyze_populates_dependency_chains_deep_transitive() {
         // a -> b -> vuln (two-hop chain)
-        let graph = make_graph(
-            vec!["a"],
-            vec![("a", vec!["b"]), ("b", vec!["vuln"])],
-        );
+        let graph = make_graph(vec!["a"], vec![("a", vec!["b"]), ("b", vec!["vuln"])]);
         let vulns = vec![make_pkg_vulns(
             "vuln",
             "0.1.0",
@@ -358,18 +353,12 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].dependency_chains().len(), 1);
-        assert_eq!(
-            entries[0].dependency_chains()[0],
-            ["a", "b", "vuln"]
-        );
+        assert_eq!(entries[0].dependency_chains()[0], ["a", "b", "vuln"]);
     }
 
     #[test]
     fn test_analyze_dependency_chains_shared_across_multiple_vulns_same_package() {
-        let graph = make_graph(
-            vec!["requests"],
-            vec![("requests", vec!["urllib3"])],
-        );
+        let graph = make_graph(vec!["requests"], vec![("requests", vec!["urllib3"])]);
         let vulns = vec![make_pkg_vulns(
             "urllib3",
             "1.26.5",
@@ -387,7 +376,10 @@ mod tests {
 
         assert_eq!(entries.len(), 2);
         // Both entries for the same package share the same chains
-        assert_eq!(entries[0].dependency_chains(), entries[1].dependency_chains());
+        assert_eq!(
+            entries[0].dependency_chains(),
+            entries[1].dependency_chains()
+        );
         assert_eq!(entries[0].dependency_chains()[0], ["requests", "urllib3"]);
     }
 }

--- a/src/sbom_generation/domain/services/upgrade_advisor.rs
+++ b/src/sbom_generation/domain/services/upgrade_advisor.rs
@@ -304,6 +304,7 @@ mod tests {
             Severity::High,
             vuln_id.to_string(),
             introduced,
+            vec![],
         )
     }
 


### PR DESCRIPTION
## Summary
- Add `dependency_chains: Vec<Vec<String>>` field to `ResolutionEntry` (domain) and `ResolutionEntryView` (read model)
- Populate chains in `ResolutionAnalyzer::analyze` via `DependencyGraph::find_paths_to` introduced in #497
- Remove the now-unnecessary `#[allow(dead_code)]` annotation from `find_paths_to`

## Related Issue
Closes #498
Part of #416

## Changes Made
- `src/sbom_generation/domain/resolution_guide.rs` — add `dependency_chains` field and accessor to `ResolutionEntry`
- `src/sbom_generation/domain/services/resolution_analyzer.rs` — call `find_paths_to` per vulnerable package and pass chains to `ResolutionEntry::new`
- `src/sbom_generation/domain/dependency_graph.rs` — remove `#[allow(dead_code)]` from `find_paths_to`
- `src/application/read_models/resolution_guide_view.rs` — add `dependency_chains` field to `ResolutionEntryView` (annotated with `#[allow(dead_code)]` until Issue #499 adds rendering)
- `src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs` — map chains from domain entry to view; add builder tests
- Adapter test fixtures updated with `dependency_chains: vec![]` to compile after struct extension

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New tests: deep transitive chain, multi-vuln same package, accessor, builder mapping

## Notes
`ResolutionEntryView.dependency_chains` carries `#[allow(dead_code)]` because no formatter renders it yet. Rendering is tracked in Issue #499.

---
Generated with [Claude Code](https://claude.com/claude-code)