### PR TITLE
feat(adapters): render Dependency Chains subsection in Markdown Resolution Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dependency Chains subsection in Markdown Resolution Guide**: When at least one vulnerable package is introduced via a multi-hop dependency chain (chain length > 2), a "### Dependency Chains" subsection is now rendered after the vulnerability resolution table. Each chain is displayed as `` `node1` → `node2` → **`pkg version`** ⚠️ ``. The subsection is omitted when all vulnerabilities are direct introductions (#499)
+
 ## [2.2.0] - 2026-04-18
 
 ### Added

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -79,6 +79,52 @@ pub(in super::super) fn render(
         output.push_str(&format!("| {} |\n", cells.join(" | ")));
     }
     output.push('\n');
+
+    // Dependency Chains subsection: only render entries that contain at least
+    // one multi-hop chain (len > 2). A 2-element chain means the vulnerable
+    // package is a direct dependency, which the main table already makes
+    // obvious, so listing it here would be noise.
+    let has_multi_hop = guide
+        .entries
+        .iter()
+        .any(|e| e.dependency_chains.iter().any(|c| c.len() > 2));
+
+    if has_multi_hop {
+        output.push_str(messages.section_dependency_chains);
+        output.push_str("\n\n");
+
+        for entry in &guide.entries {
+            if !entry.dependency_chains.iter().any(|c| c.len() > 2) {
+                continue;
+            }
+
+            output.push_str(&format!(
+                "**`{} {}`** — {} ({})\n",
+                entry.vulnerable_package,
+                entry.current_version,
+                entry.vulnerability_id,
+                entry.severity.as_str(),
+            ));
+
+            for chain in entry.dependency_chains.iter().filter(|c| c.len() > 2) {
+                let last_idx = chain.len() - 1;
+                let rendered = chain
+                    .iter()
+                    .enumerate()
+                    .map(|(i, node)| {
+                        if i == last_idx {
+                            format!("**`{} {}`** ⚠️", node, entry.current_version)
+                        } else {
+                            format!("`{}`", node)
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" → ");
+                output.push_str(&format!("- {}\n", rendered));
+            }
+            output.push('\n');
+        }
+    }
 }
 
 #[cfg(test)]
@@ -337,6 +383,197 @@ mod tests {
 
         assert!(markdown.contains("Recommended Action"));
         assert!(markdown.contains("❓ Could not analyze: dependency resolution timed out"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_rendered_when_multi_hop() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: Some(">= 2.0.7".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-XXXXX".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![vec![
+                    "requests".to_string(),
+                    "httpcore".to_string(),
+                    "urllib3".to_string(),
+                ]],
+            }],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("### Dependency Chains"));
+        assert!(markdown.contains("**`urllib3 1.26.15`** — CVE-2024-XXXXX (HIGH)"));
+        assert!(markdown.contains("- `requests` → `httpcore` → **`urllib3 1.26.15`** ⚠️"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_omitted_when_direct_only() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "requests".to_string(),
+                current_version: "2.31.0".to_string(),
+                fixed_version: Some(">= 2.32.0".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-ABCDE".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![vec!["requests".to_string(), "requests".to_string()]],
+            }],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("## Vulnerability Resolution Guide"));
+        assert!(!markdown.contains("### Dependency Chains"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_multiple_paths_as_bullets() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: Some(">= 2.0.7".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-XXXXX".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![
+                    vec![
+                        "requests".to_string(),
+                        "httpcore".to_string(),
+                        "urllib3".to_string(),
+                    ],
+                    vec![
+                        "httpx".to_string(),
+                        "httpcore".to_string(),
+                        "urllib3".to_string(),
+                    ],
+                ],
+            }],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("- `requests` → `httpcore` → **`urllib3 1.26.15`** ⚠️"));
+        assert!(markdown.contains("- `httpx` → `httpcore` → **`urllib3 1.26.15`** ⚠️"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_filters_direct_only_entries() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![
+                ResolutionEntryView {
+                    vulnerable_package: "requests".to_string(),
+                    current_version: "2.31.0".to_string(),
+                    fixed_version: Some(">= 2.32.0".to_string()),
+                    severity: SeverityView::High,
+                    vulnerability_id: "CVE-DIRECT".to_string(),
+                    introduced_by: vec![IntroducedByView {
+                        package_name: "requests".to_string(),
+                        version: "2.31.0".to_string(),
+                    }],
+                    dependency_chains: vec![vec!["requests".to_string(), "requests".to_string()]],
+                },
+                ResolutionEntryView {
+                    vulnerable_package: "urllib3".to_string(),
+                    current_version: "1.26.15".to_string(),
+                    fixed_version: Some(">= 2.0.7".to_string()),
+                    severity: SeverityView::High,
+                    vulnerability_id: "CVE-TRANSITIVE".to_string(),
+                    introduced_by: vec![IntroducedByView {
+                        package_name: "requests".to_string(),
+                        version: "2.31.0".to_string(),
+                    }],
+                    dependency_chains: vec![vec![
+                        "requests".to_string(),
+                        "httpcore".to_string(),
+                        "urllib3".to_string(),
+                    ]],
+                },
+            ],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("### Dependency Chains"));
+        assert!(!markdown.contains("**`requests 2.31.0`** — CVE-DIRECT"));
+        assert!(markdown.contains("**`urllib3 1.26.15`** — CVE-TRANSITIVE (HIGH)"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_ja_locale() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: Some(">= 2.0.7".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-XXXXX".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![vec![
+                    "requests".to_string(),
+                    "httpcore".to_string(),
+                    "urllib3".to_string(),
+                ]],
+            }],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::Ja);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("### 依存チェーン"));
+        assert!(!markdown.contains("### Dependency Chains"));
+        assert!(markdown.contains("- `requests` → `httpcore` → **`urllib3 1.26.15`** ⚠️"));
+        assert!(markdown.contains("(HIGH)"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_omitted_when_chains_empty() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: Some(">= 2.0.7".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-XXXXX".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![],
+            }],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("## Vulnerability Resolution Guide"));
+        assert!(!markdown.contains("### Dependency Chains"));
     }
 
     #[test]

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -81,20 +81,27 @@ pub(in super::super) fn render(
     output.push('\n');
 
     // Dependency Chains subsection: only render entries that contain at least
-    // one multi-hop chain (len > 2). A 2-element chain means the vulnerable
-    // package is a direct dependency, which the main table already makes
-    // obvious, so listing it here would be noise.
-    let has_multi_hop = guide
-        .entries
-        .iter()
-        .any(|e| e.dependency_chains.iter().any(|c| c.len() > 2));
+    // one multi-hop chain. A 2-element chain [direct_dep, vulnerable_pkg]
+    // means the vulnerable package is a direct dependency, which the main
+    // table already makes obvious, so listing it here would be noise.
+    const DIRECT_CHAIN_LEN: usize = 2;
+
+    let has_multi_hop = guide.entries.iter().any(|e| {
+        e.dependency_chains
+            .iter()
+            .any(|c| c.len() > DIRECT_CHAIN_LEN)
+    });
 
     if has_multi_hop {
         output.push_str(messages.section_dependency_chains);
         output.push_str("\n\n");
 
         for entry in &guide.entries {
-            if !entry.dependency_chains.iter().any(|c| c.len() > 2) {
+            if !entry
+                .dependency_chains
+                .iter()
+                .any(|c| c.len() > DIRECT_CHAIN_LEN)
+            {
                 continue;
             }
 
@@ -106,7 +113,11 @@ pub(in super::super) fn render(
                 entry.severity.as_str(),
             ));
 
-            for chain in entry.dependency_chains.iter().filter(|c| c.len() > 2) {
+            for chain in entry
+                .dependency_chains
+                .iter()
+                .filter(|c| c.len() > DIRECT_CHAIN_LEN)
+            {
                 let last_idx = chain.len() - 1;
                 let rendered = chain
                     .iter()
@@ -566,6 +577,31 @@ mod tests {
                     version: "2.31.0".to_string(),
                 }],
                 dependency_chains: vec![],
+            }],
+        });
+
+        let formatter = super::super::super::MarkdownFormatter::new(Locale::En);
+        let markdown = formatter.format(&model).unwrap();
+
+        assert!(markdown.contains("## Vulnerability Resolution Guide"));
+        assert!(!markdown.contains("### Dependency Chains"));
+    }
+
+    #[test]
+    fn test_dependency_chains_subsection_omitted_when_single_node_chain() {
+        let mut model = create_test_read_model();
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "urllib3".to_string(),
+                current_version: "1.26.15".to_string(),
+                fixed_version: Some(">= 2.0.7".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-XXXXX".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "urllib3".to_string(),
+                    version: "1.26.15".to_string(),
+                }],
+                dependency_chains: vec![vec!["urllib3".to_string()]],
             }],
         });
 

--- a/src/application/read_models/resolution_guide_view.rs
+++ b/src/application/read_models/resolution_guide_view.rs
@@ -35,9 +35,8 @@ pub struct ResolutionEntryView {
     pub introduced_by: Vec<IntroducedByView>,
     /// Full dependency chains from direct deps to the vulnerable package.
     /// Each inner Vec is [direct_dep, ..., vulnerable_package].
-    /// Populated by the builder (Issue #498) but not yet rendered by formatters;
-    /// rendering will be added in Issue #499.
-    #[allow(dead_code)]
+    /// Populated by the builder (Issue #498) and rendered in the Markdown
+    /// "Dependency Chains" subsection when chains are multi-hop (len > 2).
     pub dependency_chains: Vec<Vec<String>>,
 }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -39,6 +39,7 @@ pub struct Messages {
     pub section_vuln_report: &'static str,
     pub section_license_compliance: &'static str,
     pub section_resolution_guide: &'static str,
+    pub section_dependency_chains: &'static str,
 
     // Table column headers
     pub col_package: &'static str,
@@ -197,6 +198,7 @@ static EN_MESSAGES: Messages = Messages {
     section_vuln_report: "## Vulnerability Report",
     section_license_compliance: "## License Compliance Report",
     section_resolution_guide: "## Vulnerability Resolution Guide",
+    section_dependency_chains: "### Dependency Chains",
 
     // Table column headers
     col_package: "Package",
@@ -324,6 +326,7 @@ static JA_MESSAGES: Messages = Messages {
     section_vuln_report: "## 脆弱性レポート",
     section_license_compliance: "## ライセンスコンプライアンスレポート",
     section_resolution_guide: "## 脆弱性解決ガイド",
+    section_dependency_chains: "### 依存チェーン",
 
     // Table column headers
     col_package: "パッケージ",
@@ -607,6 +610,18 @@ mod tests {
     #[test]
     fn test_messages_format_fewer_args_than_placeholders() {
         assert_eq!(Messages::format("{} of {} done", &["3"]), "3 of {} done");
+    }
+
+    #[test]
+    fn test_section_dependency_chains_i18n() {
+        assert_eq!(
+            Messages::for_locale(Locale::En).section_dependency_chains,
+            "### Dependency Chains"
+        );
+        assert_eq!(
+            Messages::for_locale(Locale::Ja).section_dependency_chains,
+            "### 依存チェーン"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a \"### Dependency Chains\" subsection after the main vulnerability resolution table in Markdown output
- Subsection is shown only when at least one entry has a multi-hop chain (`len > 2`); omitted when all vulnerabilities are direct introductions
- Each chain is rendered as `` `node1` → `node2` → **`pkg version`** ⚠️ `` with multi-path support (diamond dependencies shown as separate bullets)

## Related Issue
Closes #499

## Changes Made
- `src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs`: append Dependency Chains block after the table; filter chains by `len > 2` at section gate, per-entry, and per-chain loop to prevent direct chains from appearing in the subsection
- `src/application/read_models/resolution_guide_view.rs`: remove `#[allow(dead_code)]` from `dependency_chains` (now has a live consumer); update doc comment
- `src/i18n/mod.rs`: add `section_dependency_chains` key (`"### Dependency Chains"` / `"### 依存チェーン"`) with i18n tests for both locales
- `CHANGELOG.md`: add `[Unreleased]` entry for this feature

## Test Plan
- [x] `cargo test --all` passes (6 new tests added covering: multi-hop renders subsection, direct-only omits subsection, multiple paths as bullets, mixed entries filtering, JA locale, empty chains regression)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)