### PR TITLE
docs: add Dependency Chains subsection to README Markdown output example

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -16,7 +16,7 @@
 - 🔍 PyPIからライセンス情報を自動取得（リトライロジック付き）
 - 🛡️ OSV APIを使用した既知の脆弱性チェック（Markdownフォーマットのみ）
 - 📋 許可/拒否リストとワイルドカード対応のライセンスコンプライアンスポリシーチェック
-- 🔎 **脆弱性解決ガイド** - 脆弱な推移的パッケージを導入している直接依存関係を特定
+- 🔎 **脆弱性解決ガイド** - 脆弱な推移的パッケージを導入している直接依存関係を特定し、マルチホップの推移的脆弱性に対しては**完全な依存チェーン**を表示
 - 📊 複数のフォーマットに対応:
   - **CycloneDX 1.6** JSON形式（標準SBOM形式）
   - **Markdown**形式（直接依存と推移的依存を明確に分離）
@@ -518,8 +518,15 @@ The following transitive dependencies have known vulnerabilities. The table show
 | Vulnerable Package | Current | Fixed Version | Severity | Introduced By (Direct Dep) | Vulnerability ID |
 |--------------------|---------|---------------|----------|---------------------------|-----------------|
 | urllib3 | 1.26.15 | >= 2.0.7 | 🟠 HIGH | requests (2.31.0) | [CVE-2024-XXXXX](https://nvd.nist.gov/vuln/detail/CVE-2024-XXXXX) |
-| certifi | 2023.7.22 | >= 2024.2.2 | 🟠 HIGH | requests (2.31.0), httpx (0.25.0) | [CVE-2024-YYYYY](https://nvd.nist.gov/vuln/detail/CVE-2024-YYYYY) |
+| h11 | 0.14.0 | >= 0.14.4 | 🟠 HIGH | httpx (0.24.0) | [CVE-2024-ZZZZZ](https://nvd.nist.gov/vuln/detail/CVE-2024-ZZZZZ) |
+
+### 依存チェーン
+
+**`h11 0.14.0`** — CVE-2024-ZZZZZ (HIGH)
+- `httpcore` → `httpx` → **`h11 0.14.0`** ⚠️
 ```
+
+> **注:** `### 依存チェーン`サブセクションは、脆弱なパッケージがマルチホップチェーン（チェーン長 > 2）を経由して到達可能な場合にのみ表示されます。全ての脆弱なパッケージが直接依存関係から導入されている場合は省略されます。
 
 #### CycloneDX JSON出力
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Generate SBOMs (Software Bill of Materials) for Python projects managed by [uv](
 - 🔍 Automatically fetches license information from PyPI with retry logic
 - 🛡️ Checks for known vulnerabilities using OSV API (Markdown format only)
 - 📋 License compliance policy check with configurable allow/deny lists and wildcard support
-- 🔎 **Vulnerability Resolution Guide** - Identifies which direct dependency introduces each vulnerable transitive package
+- 🔎 **Vulnerability Resolution Guide** - Identifies which direct dependency introduces each vulnerable transitive package, and shows the **full dependency chain** for multi-hop transitive vulnerabilities
 - 📊 Outputs in multiple formats:
   - **CycloneDX 1.6** JSON format (standard SBOM format)
   - **Markdown** format with direct and transitive dependencies clearly separated
@@ -522,8 +522,15 @@ The following transitive dependencies have known vulnerabilities. The table show
 | Vulnerable Package | Current | Fixed Version | Severity | Introduced By (Direct Dep) | Vulnerability ID |
 |--------------------|---------|---------------|----------|---------------------------|-----------------|
 | urllib3 | 1.26.15 | >= 2.0.7 | 🟠 HIGH | requests (2.31.0) | [CVE-2024-XXXXX](https://nvd.nist.gov/vuln/detail/CVE-2024-XXXXX) |
-| certifi | 2023.7.22 | >= 2024.2.2 | 🟠 HIGH | requests (2.31.0), httpx (0.25.0) | [CVE-2024-YYYYY](https://nvd.nist.gov/vuln/detail/CVE-2024-YYYYY) |
+| h11 | 0.14.0 | >= 0.14.4 | 🟠 HIGH | httpx (0.24.0) | [CVE-2024-ZZZZZ](https://nvd.nist.gov/vuln/detail/CVE-2024-ZZZZZ) |
+
+### Dependency Chains
+
+**`h11 0.14.0`** — CVE-2024-ZZZZZ (HIGH)
+- `httpcore` → `httpx` → **`h11 0.14.0`** ⚠️
 ```
+
+> **Note:** The `### Dependency Chains` subsection is only rendered when at least one vulnerable package is reachable via a multi-hop chain (chain length > 2). It is omitted entirely when all vulnerable packages are introduced directly by a first-level dependency.
 
 #### CycloneDX JSON output
 


### PR DESCRIPTION
## Summary

- Update the feature bullet in `README.md` and `README-JP.md` to mention full dependency chain display for multi-hop transitive vulnerabilities
- Extend the Vulnerability Resolution Guide Markdown output example to include the new `### Dependency Chains` subsection (EN and JA)
- Add a prose Note explaining the conditional rendering rule (subsection omitted when all vulnerable packages are direct)

## Related Issue

Closes #506

## Changes Made

- `README.md` line 19: feature bullet now mentions full chain display for multi-hop vulnerabilities
- `README.md` Markdown output example: updated second row to show a multi-hop scenario (`h11` via `httpx`), added `### Dependency Chains` subsection with realistic chain example and conditional-render Note
- `README-JP.md`: same changes in Japanese

### Example output now shown in README

```markdown
### Dependency Chains

**`h11 0.14.0`** — CVE-2024-ZZZZZ (HIGH)
- `httpcore` → `httpx` → **`h11 0.14.0`** ⚠️
```

> **Note:** The `### Dependency Chains` subsection is only rendered when at least one vulnerable package is reachable via a multi-hop chain (chain length > 2). It is omitted entirely when all vulnerable packages are introduced directly by a first-level dependency.

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (0 warnings)
- [x] `cargo test --all` — all unit/integration tests pass; one pre-existing E2E test (`test_explicit_config_path_loads_successfully`) fails due to OSV API network access (403 Forbidden) in the CI environment — unrelated to this documentation-only change (introduced in commit `24e8564`, pre-dating Issue #416)
- [x] Documentation-only change; no Rust source files modified

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cyq9koHZEi8JDgqk1TAcdr)_