### PR TITLE
fix(domain): add package_edges to DependencyGraph for correct multi-hop BFS

### DIFF
--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -110,7 +110,7 @@ mod tests {
     fn create_test_graph() -> DependencyGraph {
         let direct_deps = vec![PackageName::new("requests".to_string()).unwrap()];
         let transitive: HashMap<PackageName, Vec<PackageName>> = HashMap::new();
-        DependencyGraph::new(direct_deps, transitive)
+        DependencyGraph::new(direct_deps, transitive, HashMap::new())
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod tests {
             PackageName::new("requests".to_string()).unwrap(),
             PackageName::new("urllib3".to_string()).unwrap(),
         ];
-        let graph = DependencyGraph::new(direct_deps, HashMap::new());
+        let graph = DependencyGraph::new(direct_deps, HashMap::new(), HashMap::new());
 
         let deps = dependency_builder::build_dependencies(&graph, &components);
 
@@ -294,7 +294,7 @@ mod tests {
                 PackageName::new("certifi".to_string()).unwrap(),
             ],
         );
-        let graph = DependencyGraph::new(direct_deps, transitive);
+        let graph = DependencyGraph::new(direct_deps, transitive, HashMap::new());
 
         let deps = dependency_builder::build_dependencies(&graph, &components);
 
@@ -316,7 +316,7 @@ mod tests {
             PackageName::new("requests".to_string()).unwrap(),
             PackageName::new("unknown-pkg".to_string()).unwrap(),
         ];
-        let graph = DependencyGraph::new(direct_deps, HashMap::new());
+        let graph = DependencyGraph::new(direct_deps, HashMap::new(), HashMap::new());
 
         let deps = dependency_builder::build_dependencies(&graph, &components);
 
@@ -329,7 +329,7 @@ mod tests {
     fn test_build_dependencies_empty_graph() {
         let packages = vec![create_test_package("requests", "2.31.0")];
         let components = component_builder::build_components(&packages, None);
-        let graph = DependencyGraph::new(vec![], HashMap::new());
+        let graph = DependencyGraph::new(vec![], HashMap::new(), HashMap::new());
 
         let deps = dependency_builder::build_dependencies(&graph, &components);
 
@@ -686,6 +686,7 @@ mod tests {
         let graph = DependencyGraph::new(
             vec![PackageName::new("requests".to_string()).unwrap()],
             transitive,
+            HashMap::new(),
         );
 
         let vuln = create_vulnerability("CVE-2023-43804", Some(7.5), Severity::High);

--- a/src/sbom_generation/domain/dependency_graph.rs
+++ b/src/sbom_generation/domain/dependency_graph.rs
@@ -5,17 +5,28 @@ use std::collections::{HashMap, HashSet, VecDeque};
 #[derive(Debug, Clone)]
 pub struct DependencyGraph {
     direct_dependencies: Vec<PackageName>,
+    /// direct_dep → flat list of all reachable transitives (used by resolution_analyzer for membership checks)
     transitive_dependencies: HashMap<PackageName, Vec<PackageName>>,
+    /// pkg → immediate children for ALL packages (used by find_paths_to for BFS traversal)
+    package_edges: HashMap<PackageName, Vec<PackageName>>,
 }
 
 impl DependencyGraph {
+    /// Creates a new `DependencyGraph`.
+    ///
+    /// - `transitive_dependencies`: maps each direct dependency to a **flat list of all
+    ///   reachable transitives** (used by [`ResolutionAnalyzer`] for membership checks).
+    /// - `package_edges`: maps **every package** (excluding the project root) to its
+    ///   **immediate children** (used by [`find_paths_to`] for multi-hop BFS traversal).
     pub fn new(
         direct_dependencies: Vec<PackageName>,
         transitive_dependencies: HashMap<PackageName, Vec<PackageName>>,
+        package_edges: HashMap<PackageName, Vec<PackageName>>,
     ) -> Self {
         Self {
             direct_dependencies,
             transitive_dependencies,
+            package_edges,
         }
     }
 
@@ -55,7 +66,7 @@ impl DependencyGraph {
         }
 
         while let Some((current, path, visited)) = queue.pop_front() {
-            let Some(children) = self.transitive_dependencies.get(&current) else {
+            let Some(children) = self.package_edges.get(&current) else {
                 continue;
             };
 
@@ -91,11 +102,12 @@ mod tests {
 
     fn make_graph(direct: Vec<&str>, edges: Vec<(&str, Vec<&str>)>) -> DependencyGraph {
         let direct_deps = direct.into_iter().map(pkg).collect();
-        let transitive = edges
+        let package_edges: HashMap<PackageName, Vec<PackageName>> = edges
             .into_iter()
             .map(|(parent, children)| (pkg(parent), children.into_iter().map(pkg).collect()))
             .collect();
-        DependencyGraph::new(direct_deps, transitive)
+        // These tests only exercise find_paths_to (BFS), so transitive_dependencies is unused.
+        DependencyGraph::new(direct_deps, HashMap::new(), package_edges)
     }
 
     #[test]
@@ -107,7 +119,7 @@ mod tests {
             vec![PackageName::new("pkg2".to_string()).unwrap()],
         );
 
-        let graph = DependencyGraph::new(direct_deps, transitive);
+        let graph = DependencyGraph::new(direct_deps, transitive, HashMap::new());
 
         assert_eq!(graph.direct_dependency_count(), 1);
         assert_eq!(graph.transitive_dependency_count(), 1);
@@ -115,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_dependency_graph_empty() {
-        let graph = DependencyGraph::new(vec![], HashMap::new());
+        let graph = DependencyGraph::new(vec![], HashMap::new(), HashMap::new());
 
         assert_eq!(graph.direct_dependency_count(), 0);
         assert_eq!(graph.transitive_dependency_count(), 0);

--- a/src/sbom_generation/domain/services/resolution_analyzer.rs
+++ b/src/sbom_generation/domain/services/resolution_analyzer.rs
@@ -106,7 +106,7 @@ mod tests {
     use crate::sbom_generation::domain::package::PackageName;
     use crate::sbom_generation::domain::vulnerability::{Severity, Vulnerability};
     use crate::sbom_generation::domain::Package;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet, VecDeque};
 
     fn make_vuln(id: &str, severity: Severity, fixed: Option<&str>) -> Vulnerability {
         Vulnerability::new(
@@ -137,11 +137,11 @@ mod tests {
 
     fn make_graph(direct: Vec<&str>, transitive: Vec<(&str, Vec<&str>)>) -> DependencyGraph {
         let direct_deps: Vec<PackageName> = direct
-            .into_iter()
+            .iter()
             .map(|n| PackageName::new(n.to_string()).unwrap())
             .collect();
 
-        let trans_deps: HashMap<PackageName, Vec<PackageName>> = transitive
+        let package_edges: HashMap<PackageName, Vec<PackageName>> = transitive
             .into_iter()
             .map(|(key, vals)| {
                 let k = PackageName::new(key.to_string()).unwrap();
@@ -153,7 +153,38 @@ mod tests {
             })
             .collect();
 
-        DependencyGraph::new(direct_deps, trans_deps)
+        // Build flat transitive closure (direct_dep → all reachable non-direct packages)
+        // to match the semantics expected by ResolutionAnalyzer::introduced_by lookup.
+        let direct_set: HashSet<&PackageName> = direct_deps.iter().collect();
+        let mut flat_transitive: HashMap<PackageName, Vec<PackageName>> = HashMap::new();
+        for dep in &direct_deps {
+            let mut reachable: Vec<PackageName> = Vec::new();
+            let mut visited: HashSet<PackageName> = HashSet::new();
+            let mut queue: VecDeque<PackageName> = VecDeque::new();
+            if let Some(children) = package_edges.get(dep) {
+                for child in children {
+                    if !direct_set.contains(child) && visited.insert(child.clone()) {
+                        reachable.push(child.clone());
+                        queue.push_back(child.clone());
+                    }
+                }
+            }
+            while let Some(current) = queue.pop_front() {
+                if let Some(children) = package_edges.get(&current) {
+                    for child in children {
+                        if !direct_set.contains(child) && visited.insert(child.clone()) {
+                            reachable.push(child.clone());
+                            queue.push_back(child.clone());
+                        }
+                    }
+                }
+            }
+            if !reachable.is_empty() {
+                flat_transitive.insert(dep.clone(), reachable);
+            }
+        }
+
+        DependencyGraph::new(direct_deps, flat_transitive, package_edges)
     }
 
     #[test]

--- a/src/sbom_generation/services/dependency_analyzer.rs
+++ b/src/sbom_generation/services/dependency_analyzer.rs
@@ -59,10 +59,35 @@ impl DependencyAnalyzer {
             }
         }
 
+        let package_edges = Self::build_package_edges(project_name, dependency_map)?;
+
         Ok(DependencyGraph::new(
             direct_deps_names,
             transitive_dependencies,
+            package_edges,
         ))
+    }
+
+    /// Builds an edge map of `pkg → immediate children` for every package in
+    /// `dependency_map` except the project root. This map is consumed by
+    /// [`DependencyGraph::find_paths_to`] for multi-hop BFS path traversal.
+    fn build_package_edges(
+        project_name: &PackageName,
+        dependency_map: &HashMap<String, Vec<String>>,
+    ) -> Result<HashMap<PackageName, Vec<PackageName>>> {
+        let mut package_edges: HashMap<PackageName, Vec<PackageName>> = HashMap::new();
+        for (parent, children) in dependency_map {
+            if parent == project_name.as_str() {
+                continue;
+            }
+            let parent_name = PackageName::new(parent.clone())?;
+            let child_names: Vec<PackageName> = children
+                .iter()
+                .map(|n| PackageName::new(n.clone()))
+                .collect::<Result<Vec<_>>>()?;
+            package_edges.insert(parent_name, child_names);
+        }
+        Ok(package_edges)
     }
 
     /// Maximum recursion depth to prevent stack overflow attacks
@@ -239,5 +264,80 @@ mod tests {
 
         assert_eq!(graph.direct_dependency_count(), 0);
         assert_eq!(graph.transitive_dependency_count(), 0);
+    }
+
+    #[test]
+    fn test_analyze_builds_edge_map_for_multi_hop_paths() {
+        // project -> a -> b -> c (three hops)
+        let mut dependency_map = HashMap::new();
+        dependency_map.insert("myproject".to_string(), vec!["a".to_string()]);
+        dependency_map.insert("a".to_string(), vec!["b".to_string()]);
+        dependency_map.insert("b".to_string(), vec!["c".to_string()]);
+        dependency_map.insert("c".to_string(), vec![]);
+
+        let project_name = PackageName::new("myproject".to_string()).unwrap();
+        let graph = DependencyAnalyzer::analyze(&project_name, &dependency_map).unwrap();
+
+        let target = PackageName::new("c".to_string()).unwrap();
+        let paths = graph.find_paths_to(&target);
+
+        assert_eq!(paths.len(), 1);
+        assert_eq!(
+            paths[0],
+            vec![
+                PackageName::new("a".to_string()).unwrap(),
+                PackageName::new("b".to_string()).unwrap(),
+                PackageName::new("c".to_string()).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_analyze_excludes_project_root_from_package_edges() {
+        let mut dependency_map = HashMap::new();
+        dependency_map.insert("myproject".to_string(), vec!["requests".to_string()]);
+        dependency_map.insert("requests".to_string(), vec!["urllib3".to_string()]);
+
+        let project_name = PackageName::new("myproject".to_string()).unwrap();
+        let graph = DependencyAnalyzer::analyze(&project_name, &dependency_map).unwrap();
+
+        let target = PackageName::new("urllib3".to_string()).unwrap();
+        let paths = graph.find_paths_to(&target);
+
+        assert_eq!(
+            paths,
+            vec![vec![
+                PackageName::new("requests".to_string()).unwrap(),
+                PackageName::new("urllib3".to_string()).unwrap(),
+            ]]
+        );
+        for path in &paths {
+            assert_ne!(path[0].as_str(), "myproject");
+        }
+    }
+
+    #[test]
+    fn test_analyze_finds_multiple_paths_via_diamond() {
+        // myproject -> a, b; a -> shared -> target; b -> shared -> target
+        let mut dependency_map = HashMap::new();
+        dependency_map.insert(
+            "myproject".to_string(),
+            vec!["a".to_string(), "b".to_string()],
+        );
+        dependency_map.insert("a".to_string(), vec!["shared".to_string()]);
+        dependency_map.insert("b".to_string(), vec!["shared".to_string()]);
+        dependency_map.insert("shared".to_string(), vec!["target".to_string()]);
+        dependency_map.insert("target".to_string(), vec![]);
+
+        let project_name = PackageName::new("myproject".to_string()).unwrap();
+        let graph = DependencyAnalyzer::analyze(&project_name, &dependency_map).unwrap();
+        let paths = graph.find_paths_to(&PackageName::new("target".to_string()).unwrap());
+
+        assert_eq!(paths.len(), 2);
+        for p in &paths {
+            assert_eq!(p.len(), 3);
+            assert_eq!(p[2].as_str(), "target");
+            assert_eq!(p[1].as_str(), "shared");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `DependencyGraph.find_paths_to` was using `transitive_dependencies` (a flat closure: direct_dep → all reachable transitives) as if it were an edge map (pkg → immediate children). BFS could never descend past depth 1, so all dependency chains had length 2 and the `len() > 2` guard in the Markdown formatter always filtered them out — making the **Dependency Chains subsection never appear** in real output since PR #502.
- Fix adds a `package_edges` field (pkg → immediate children for all non-root packages) to `DependencyGraph`, populated from the raw `dependency_map` via a new `build_package_edges` helper in `DependencyAnalyzer`. `find_paths_to` now traverses `package_edges`.
- Also fixes a masked `introduced_by` attribution bug in the `resolution_analyzer` test helper for chains deeper than one hop.

## Related Issue

Closes #509

## Changes Made

- `src/sbom_generation/domain/dependency_graph.rs` — add `package_edges` field and parameter to `DependencyGraph::new`; update `find_paths_to` to use it; add doc comment; fix test helper
- `src/sbom_generation/services/dependency_analyzer.rs` — extract `build_package_edges` private method; populate and pass `package_edges` to `DependencyGraph::new`; add 3 new integration tests
- `src/sbom_generation/domain/services/resolution_analyzer.rs` — fix `make_graph` test helper to build proper flat transitive closure for `transitive_dependencies` separately from `package_edges`
- `src/application/read_models/sbom_read_model_builder/mod.rs` — update all `DependencyGraph::new` call sites to pass the new third argument

## Test Plan

- [x] `cargo test --all` passes (603 unit tests + integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] 3 new integration tests added: `test_analyze_builds_edge_map_for_multi_hop_paths`, `test_analyze_excludes_project_root_from_package_edges`, `test_analyze_finds_multiple_paths_via_diamond`

⚠️ CHANGELOG not updated — to be included in v2.3.0 release notes.

---
Generated with [Claude Code](https://claude.com/claude-code)