### PR TITLE
docs(changelog): add Security entry for GHSA-82j2-j2ch-gfr8 (rustls-webpki)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Dependency Chains subsection in Markdown Resolution Guide**: When at least one vulnerable package is introduced via a multi-hop dependency chain (chain length > 2), a "### Dependency Chains" subsection is now rendered after the vulnerability resolution table. Each chain is displayed as `` `node1` → `node2` → **`pkg version`** ⚠️ ``. The subsection is omitted when all vulnerabilities are direct introductions (#499)
 
+### Security
+- Updated `rustls-webpki` to 0.103.13 to fix GHSA-82j2-j2ch-gfr8 (DoS via panic on malformed CRL BIT STRING) (#508)
+
 ## [2.2.0] - 2026-04-18
 
 ### Added


### PR DESCRIPTION
## Summary

- Add a `### Security` entry under `[Unreleased]` in `CHANGELOG.md` for the `rustls-webpki` upgrade shipped in PR #508
- Documents the fix for GHSA-82j2-j2ch-gfr8 (Dependabot alert #62): DoS via panic on malformed CRL BIT STRING

## Related Issue

- Dependabot alert #62 (GHSA-82j2-j2ch-gfr8)
- Resolved by: #508 (`rustls-webpki` 0.103.12 → 0.103.13)

## Changes Made

- `CHANGELOG.md`: added `### Security` section under `[Unreleased]` referencing GHSA-82j2-j2ch-gfr8 and PR #508

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] CHANGELOG-only change; no runtime behaviour affected

---
Generated with [Claude Code](https://claude.com/claude-code)