### PR TITLE
refactor(application): relocate component_builder and dependency_builder tests to their modules

### DIFF
--- a/src/application/read_models/sbom_read_model_builder/component_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/component_builder.rs
@@ -48,3 +48,105 @@ fn build_component(enriched: &EnrichedPackage, graph: Option<&DependencyGraph>) 
         is_direct_dependency: is_direct,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers as th;
+    use super::*;
+    use crate::ports::outbound::EnrichedPackage;
+    use crate::sbom_generation::domain::Package;
+
+    #[test]
+    fn test_build_components_generates_bom_ref() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = build_components(&packages, None);
+
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].bom_ref, "requests-2.31.0");
+    }
+
+    #[test]
+    fn test_build_components_generates_purl() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = build_components(&packages, None);
+
+        assert_eq!(components[0].purl, "pkg:pypi/requests@2.31.0");
+    }
+
+    #[test]
+    fn test_build_components_with_license() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = build_components(&packages, None);
+
+        let license = components[0].license.as_ref().unwrap();
+        assert_eq!(license.name, "MIT");
+        assert_eq!(license.spdx_id, Some("MIT".to_string()));
+    }
+
+    #[test]
+    fn test_build_components_without_license() {
+        let package = EnrichedPackage::new(
+            Package::new("requests".to_string(), "2.31.0".to_string()).unwrap(),
+            None,
+            None,
+        );
+        let components = build_components(&[package], None);
+
+        assert!(components[0].license.is_none());
+        assert!(components[0].description.is_none());
+    }
+
+    #[test]
+    fn test_build_components_with_description() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = build_components(&packages, None);
+
+        assert_eq!(
+            components[0].description,
+            Some("A test package".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_components_is_direct_dependency_with_graph() {
+        let packages = vec![
+            th::package("requests", "2.31.0"),
+            th::package("urllib3", "2.0.0"),
+        ];
+        let graph = th::graph();
+        let components = build_components(&packages, Some(&graph));
+
+        // requests is in direct_dependencies
+        let requests = components.iter().find(|c| c.name == "requests").unwrap();
+        assert!(requests.is_direct_dependency);
+
+        // urllib3 is not in direct_dependencies
+        let urllib3 = components.iter().find(|c| c.name == "urllib3").unwrap();
+        assert!(!urllib3.is_direct_dependency);
+    }
+
+    #[test]
+    fn test_build_components_is_direct_dependency_without_graph() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = build_components(&packages, None);
+
+        assert!(!components[0].is_direct_dependency);
+    }
+
+    #[test]
+    fn test_build_components_with_sha256_hash() {
+        let mut package = th::package("requests", "2.31.0");
+        package.sha256_hash = Some("abc123def456".to_string());
+        let components = build_components(&[package], None);
+
+        assert_eq!(components[0].sha256_hash, Some("abc123def456".to_string()));
+    }
+
+    #[test]
+    fn test_build_components_without_sha256_hash() {
+        let package = th::package("requests", "2.31.0");
+        let components = build_components(&[package], None);
+
+        assert!(components[0].sha256_hash.is_none());
+    }
+}

--- a/src/application/read_models/sbom_read_model_builder/dependency_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/dependency_builder.rs
@@ -40,3 +40,93 @@ pub(super) fn build_dependencies(
 
     DependencyView { direct, transitive }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::component_builder;
+    use super::super::test_helpers as th;
+    use super::*;
+    use crate::sbom_generation::domain::{DependencyGraph, PackageName};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_build_dependencies_maps_direct_to_bom_refs() {
+        let packages = vec![
+            th::package("requests", "2.31.0"),
+            th::package("urllib3", "2.0.0"),
+        ];
+        let components = component_builder::build_components(&packages, None);
+
+        let direct_deps = vec![
+            PackageName::new("requests".to_string()).unwrap(),
+            PackageName::new("urllib3".to_string()).unwrap(),
+        ];
+        let graph = DependencyGraph::new(direct_deps, HashMap::new(), HashMap::new());
+
+        let deps = build_dependencies(&graph, &components);
+
+        assert_eq!(deps.direct.len(), 2);
+        assert!(deps.direct.contains(&"requests-2.31.0".to_string()));
+        assert!(deps.direct.contains(&"urllib3-2.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_build_dependencies_builds_transitive_map() {
+        let packages = vec![
+            th::package("requests", "2.31.0"),
+            th::package("urllib3", "2.0.0"),
+            th::package("certifi", "2023.7.22"),
+        ];
+        let components = component_builder::build_components(&packages, None);
+
+        let direct_deps = vec![PackageName::new("requests".to_string()).unwrap()];
+        let mut transitive = HashMap::new();
+        transitive.insert(
+            PackageName::new("requests".to_string()).unwrap(),
+            vec![
+                PackageName::new("urllib3".to_string()).unwrap(),
+                PackageName::new("certifi".to_string()).unwrap(),
+            ],
+        );
+        let graph = DependencyGraph::new(direct_deps, transitive, HashMap::new());
+
+        let deps = build_dependencies(&graph, &components);
+
+        assert_eq!(deps.direct.len(), 1);
+        assert!(deps.transitive.contains_key("requests-2.31.0"));
+        let requests_deps = deps.transitive.get("requests-2.31.0").unwrap();
+        assert_eq!(requests_deps.len(), 2);
+        assert!(requests_deps.contains(&"urllib3-2.0.0".to_string()));
+        assert!(requests_deps.contains(&"certifi-2023.7.22".to_string()));
+    }
+
+    #[test]
+    fn test_build_dependencies_filters_unknown_packages() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = component_builder::build_components(&packages, None);
+
+        // unknown-pkg is not in components
+        let direct_deps = vec![
+            PackageName::new("requests".to_string()).unwrap(),
+            PackageName::new("unknown-pkg".to_string()).unwrap(),
+        ];
+        let graph = DependencyGraph::new(direct_deps, HashMap::new(), HashMap::new());
+
+        let deps = build_dependencies(&graph, &components);
+
+        assert_eq!(deps.direct.len(), 1);
+        assert!(deps.direct.contains(&"requests-2.31.0".to_string()));
+    }
+
+    #[test]
+    fn test_build_dependencies_empty_graph() {
+        let packages = vec![th::package("requests", "2.31.0")];
+        let components = component_builder::build_components(&packages, None);
+        let graph = DependencyGraph::new(vec![], HashMap::new(), HashMap::new());
+
+        let deps = build_dependencies(&graph, &components);
+
+        assert!(deps.direct.is_empty());
+        assert!(deps.transitive.is_empty());
+    }
+}

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -180,74 +180,10 @@ mod tests {
     use super::super::vulnerability_view::SeverityView;
     use super::*;
     use crate::sbom_generation::domain::vulnerability::Severity;
-    use crate::sbom_generation::domain::{Package, PackageName};
+    use crate::sbom_generation::domain::PackageName;
     use std::collections::HashMap;
 
     use super::test_helpers as th;
-
-    #[test]
-    fn test_build_components_generates_bom_ref() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-
-        assert_eq!(components.len(), 1);
-        assert_eq!(components[0].bom_ref, "requests-2.31.0");
-    }
-
-    #[test]
-    fn test_build_components_generates_purl() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-
-        assert_eq!(components[0].purl, "pkg:pypi/requests@2.31.0");
-    }
-
-    #[test]
-    fn test_build_components_with_license() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-
-        let license = components[0].license.as_ref().unwrap();
-        assert_eq!(license.name, "MIT");
-        assert_eq!(license.spdx_id, Some("MIT".to_string()));
-    }
-
-    #[test]
-    fn test_build_components_with_description() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-
-        assert_eq!(
-            components[0].description,
-            Some("A test package".to_string())
-        );
-    }
-
-    #[test]
-    fn test_build_components_is_direct_dependency_with_graph() {
-        let packages = vec![
-            th::package("requests", "2.31.0"),
-            th::package("urllib3", "2.0.0"),
-        ];
-        let graph = th::graph();
-        let components = component_builder::build_components(&packages, Some(&graph));
-
-        // requests is in direct_dependencies
-        let requests = components.iter().find(|c| c.name == "requests").unwrap();
-        assert!(requests.is_direct_dependency);
-
-        // urllib3 is not in direct_dependencies
-        let urllib3 = components.iter().find(|c| c.name == "urllib3").unwrap();
-        assert!(!urllib3.is_direct_dependency);
-    }
-
-    #[test]
-    fn test_build_components_is_direct_dependency_without_graph() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-
-        assert!(!components[0].is_direct_dependency);
-    }
 
     #[test]
     fn test_build_full_read_model() {
@@ -287,100 +223,6 @@ mod tests {
         );
 
         assert!(read_model.components.is_empty());
-    }
-
-    #[test]
-    fn test_build_components_without_license() {
-        let package = EnrichedPackage::new(
-            Package::new("requests".to_string(), "2.31.0".to_string()).unwrap(),
-            None,
-            None,
-        );
-        let components = component_builder::build_components(&[package], None);
-
-        assert!(components[0].license.is_none());
-        assert!(components[0].description.is_none());
-    }
-
-    #[test]
-    fn test_build_dependencies_maps_direct_to_bom_refs() {
-        let packages = vec![
-            th::package("requests", "2.31.0"),
-            th::package("urllib3", "2.0.0"),
-        ];
-        let components = component_builder::build_components(&packages, None);
-
-        let direct_deps = vec![
-            PackageName::new("requests".to_string()).unwrap(),
-            PackageName::new("urllib3".to_string()).unwrap(),
-        ];
-        let graph = DependencyGraph::new(direct_deps, HashMap::new(), HashMap::new());
-
-        let deps = dependency_builder::build_dependencies(&graph, &components);
-
-        assert_eq!(deps.direct.len(), 2);
-        assert!(deps.direct.contains(&"requests-2.31.0".to_string()));
-        assert!(deps.direct.contains(&"urllib3-2.0.0".to_string()));
-    }
-
-    #[test]
-    fn test_build_dependencies_builds_transitive_map() {
-        let packages = vec![
-            th::package("requests", "2.31.0"),
-            th::package("urllib3", "2.0.0"),
-            th::package("certifi", "2023.7.22"),
-        ];
-        let components = component_builder::build_components(&packages, None);
-
-        let direct_deps = vec![PackageName::new("requests".to_string()).unwrap()];
-        let mut transitive = HashMap::new();
-        transitive.insert(
-            PackageName::new("requests".to_string()).unwrap(),
-            vec![
-                PackageName::new("urllib3".to_string()).unwrap(),
-                PackageName::new("certifi".to_string()).unwrap(),
-            ],
-        );
-        let graph = DependencyGraph::new(direct_deps, transitive, HashMap::new());
-
-        let deps = dependency_builder::build_dependencies(&graph, &components);
-
-        assert_eq!(deps.direct.len(), 1);
-        assert!(deps.transitive.contains_key("requests-2.31.0"));
-        let requests_deps = deps.transitive.get("requests-2.31.0").unwrap();
-        assert_eq!(requests_deps.len(), 2);
-        assert!(requests_deps.contains(&"urllib3-2.0.0".to_string()));
-        assert!(requests_deps.contains(&"certifi-2023.7.22".to_string()));
-    }
-
-    #[test]
-    fn test_build_dependencies_filters_unknown_packages() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-
-        // unknown-pkg is not in components
-        let direct_deps = vec![
-            PackageName::new("requests".to_string()).unwrap(),
-            PackageName::new("unknown-pkg".to_string()).unwrap(),
-        ];
-        let graph = DependencyGraph::new(direct_deps, HashMap::new(), HashMap::new());
-
-        let deps = dependency_builder::build_dependencies(&graph, &components);
-
-        assert_eq!(deps.direct.len(), 1);
-        assert!(deps.direct.contains(&"requests-2.31.0".to_string()));
-    }
-
-    #[test]
-    fn test_build_dependencies_empty_graph() {
-        let packages = vec![th::package("requests", "2.31.0")];
-        let components = component_builder::build_components(&packages, None);
-        let graph = DependencyGraph::new(vec![], HashMap::new(), HashMap::new());
-
-        let deps = dependency_builder::build_dependencies(&graph, &components);
-
-        assert!(deps.direct.is_empty());
-        assert!(deps.transitive.is_empty());
     }
 
     #[test]
@@ -761,23 +603,6 @@ mod tests {
 
         // requests is a direct dep, so ResolutionAnalyzer skips it → empty → None
         assert!(read_model.resolution_guide.is_none());
-    }
-
-    #[test]
-    fn test_build_components_with_sha256_hash() {
-        let mut package = th::package("requests", "2.31.0");
-        package.sha256_hash = Some("abc123def456".to_string());
-        let components = component_builder::build_components(&[package], None);
-
-        assert_eq!(components[0].sha256_hash, Some("abc123def456".to_string()));
-    }
-
-    #[test]
-    fn test_build_components_without_sha256_hash() {
-        let package = th::package("requests", "2.31.0");
-        let components = component_builder::build_components(&[package], None);
-
-        assert!(components[0].sha256_hash.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move 9 `component_builder` unit tests from `mod.rs` into `component_builder.rs`
- Move 4 `dependency_builder` unit tests from `mod.rs` into `dependency_builder.rs`
- Remove the now-relocated 13 tests from `mod.rs` and clean up the unused `Package` import

## Related Issue
Closes #532

## Changes Made
- `component_builder.rs`: added `#[cfg(test)] mod tests` with 9 tests covering `build_components` (bom_ref, purl, license, description, direct-dependency, sha256 hash)
- `dependency_builder.rs`: added `#[cfg(test)] mod tests` with 4 tests covering `build_dependencies` (direct mapping, transitive map, unknown-package filtering, empty graph)
- `mod.rs`: removed the 13 relocated tests; replaced `use crate::sbom_generation::domain::{Package, PackageName}` with `use crate::sbom_generation::domain::PackageName` (Package was only used by the relocated test)

## Test Plan
- [x] `cargo test --all` passes — 39 tests in `sbom_read_model_builder`, all ok
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)