### PR TITLE
docs(skills): improve /split — auto-execute issues and always keep parent open

### DIFF
--- a/.claude/skills/split/SKILL.md
+++ b/.claude/skills/split/SKILL.md
@@ -74,6 +74,8 @@ If the user cancels, stop and report "Split cancelled."
 
 ### Step 4: Create Subtask Issues
 
+**Once the user confirms in Step 3, execute all `gh issue create` commands immediately without additional prompts or pauses between issues. Do not ask for permission again.**
+
 For each confirmed subtask, create a GitHub Issue using this template:
 
 ```markdown
@@ -128,16 +130,14 @@ EOF
 )"
 ```
 
-Then ask the user:
-
-> All subtasks have been created. Would you like to close the parent Issue #<number> now, or keep it open as a tracking issue?
+The parent Issue is always left open as a tracking issue. Do not close it.
 
 ### Step 6: Report Completion
 
 Output:
 - Parent Issue number
 - List of created subtask Issue numbers and URLs
-- Whether the parent was closed or left open
+- Confirmation that the parent Issue remains open as a tracking issue
 
 ## Subtask Issue Template Reference
 


### PR DESCRIPTION
## Summary
- Step 4: directs Claude to execute all `gh issue create` commands immediately after the user confirms the decomposition plan, without additional prompts between issues
- Step 5: removes the "close parent issue?" question; parent is always kept open as a tracking issue
- Step 6: updates the output description to reflect the always-open parent behaviour

## Related Issue
Closes #542

## Changes Made
- `.claude/skills/split/SKILL.md`: 3 targeted edits — added auto-execution directive, removed closing question, updated completion output

## Test Plan
- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes

---
Generated with [Claude Code](https://claude.com/claude-code)