### PR TITLE
refactor(application): create FetchLicensesUseCase and wire into GenerateSbomUseCase

### DIFF
--- a/src/adapters/outbound/network/caching_pypi_client.rs
+++ b/src/adapters/outbound/network/caching_pypi_client.rs
@@ -30,6 +30,7 @@ impl CacheKey {
 /// In hexagonal architecture, caching is an implementation detail of the adapter layer.
 /// The domain layer only cares about fetching license information - whether it comes
 /// from cache or API is transparent to the domain.
+#[derive(Clone)]
 pub struct CachingPyPiLicenseRepository<R: LicenseRepository> {
     inner: R,
     cache: Arc<DashMap<CacheKey, PyPiMetadata>>,

--- a/src/adapters/outbound/network/pypi_client.rs
+++ b/src/adapters/outbound/network/pypi_client.rs
@@ -44,6 +44,7 @@ struct PyPiInfo {
 /// # Async Support
 /// Uses async reqwest client for non-blocking HTTP requests, enabling parallel
 /// license fetching for improved performance.
+#[derive(Clone)]
 pub struct PyPiLicenseRepository {
     client: reqwest::Client,
     max_retries: u32,

--- a/src/application/use_cases/fetch_licenses.rs
+++ b/src/application/use_cases/fetch_licenses.rs
@@ -1,0 +1,230 @@
+use crate::ports::outbound::{EnrichedPackage, LicenseRepository};
+use crate::sbom_generation::domain::Package;
+use crate::shared::Result;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Rate limiting: delay between license fetch requests (ms)
+const LICENSE_FETCH_DELAY_MS: u64 = 100;
+
+/// Use case for fetching license information for a list of packages.
+///
+/// Handles progress bar display and rate limiting, delegating the actual
+/// license retrieval to the injected `LicenseRepository`.
+///
+/// # Type Parameters
+/// * `LREPO` - `LicenseRepository` implementation
+pub struct FetchLicensesUseCase<LREPO: LicenseRepository> {
+    license_repository: LREPO,
+}
+
+impl<LREPO: LicenseRepository> FetchLicensesUseCase<LREPO> {
+    /// Creates a new `FetchLicensesUseCase` with the given repository.
+    pub fn new(license_repository: LREPO) -> Self {
+        Self { license_repository }
+    }
+
+    /// Fetches license information for all packages with a progress bar.
+    ///
+    /// Returns `(enriched_packages, errors)` where errors is a list of
+    /// `(package_name, error_message)` pairs for packages whose fetch failed.
+    /// Failed packages are included in `enriched_packages` with `license: None`.
+    pub async fn fetch_with_progress(
+        &self,
+        packages: Vec<Package>,
+    ) -> Result<(Vec<EnrichedPackage>, Vec<(String, String)>)> {
+        let total = packages.len();
+        let progress_current = Arc::new(AtomicUsize::new(0));
+        let is_done = Arc::new(AtomicBool::new(false));
+
+        let progress_handle = {
+            let cur = progress_current.clone();
+            let done = is_done.clone();
+            thread::spawn(move || {
+                let pb = ProgressBar::new(total as u64);
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template("   {spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} - {msg}")
+                        .expect("Failed to set progress bar template")
+                        .progress_chars("=>-"),
+                );
+                pb.set_message("Fetching license information..."); // i18n-ok: internal progress bar label, consistent with CheckVulnerabilitiesUseCase
+                while !done.load(Ordering::Relaxed) {
+                    pb.set_position(cur.load(Ordering::Relaxed) as u64);
+                    thread::sleep(Duration::from_millis(50));
+                }
+                pb.finish_and_clear();
+            })
+        };
+
+        let mut enriched = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
+
+        for (idx, package) in packages.into_iter().enumerate() {
+            let name = package.name().to_string();
+            match self
+                .license_repository
+                .enrich_with_license(&name, package.version())
+                .await
+            {
+                Ok(info) => enriched.push(
+                    EnrichedPackage::new(
+                        package,
+                        info.license_text().map(String::from),
+                        info.description().map(String::from),
+                    )
+                    .with_sha256_hash(info.sha256_hash().map(String::from)),
+                ),
+                Err(e) => {
+                    errors.push((name, e.to_string()));
+                    enriched.push(EnrichedPackage::new(package, None, None));
+                }
+            }
+            progress_current.store(idx + 1, Ordering::Relaxed);
+            if idx < total - 1 {
+                tokio::time::sleep(Duration::from_millis(LICENSE_FETCH_DELAY_MS)).await;
+            }
+        }
+
+        is_done.store(true, Ordering::Relaxed);
+        let _ = progress_handle.join();
+
+        Ok((enriched, errors))
+    }
+
+    /// Returns a summary of the fetch results: (successful_count, total_count, failed_count)
+    pub fn summarize(
+        enriched: &[EnrichedPackage],
+        errors: &[(String, String)],
+    ) -> (usize, usize, usize) {
+        let total = enriched.len();
+        let failed = errors.len();
+        let successful = total - failed;
+        (successful, total, failed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::outbound::PyPiMetadata;
+
+    struct MockLicenseRepository;
+
+    #[async_trait::async_trait]
+    impl LicenseRepository for MockLicenseRepository {
+        async fn fetch_license_info(
+            &self,
+            _package_name: &str,
+            _version: &str,
+        ) -> Result<PyPiMetadata> {
+            Ok((
+                Some("MIT".to_string()),
+                None,
+                vec![],
+                Some("A test package".to_string()),
+                None,
+            ))
+        }
+    }
+
+    struct FailingLicenseRepository;
+
+    #[async_trait::async_trait]
+    impl LicenseRepository for FailingLicenseRepository {
+        async fn fetch_license_info(
+            &self,
+            _package_name: &str,
+            _version: &str,
+        ) -> Result<PyPiMetadata> {
+            Err(anyhow::anyhow!("network error"))
+        }
+    }
+
+    fn make_package(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    // ========== summarize() tests ==========
+
+    #[test]
+    fn test_summarize_empty() {
+        let (successful, total, failed) =
+            FetchLicensesUseCase::<MockLicenseRepository>::summarize(&[], &[]);
+        assert_eq!(successful, 0);
+        assert_eq!(total, 0);
+        assert_eq!(failed, 0);
+    }
+
+    #[test]
+    fn test_summarize_all_successful() {
+        let pkg = make_package("requests", "2.31.0");
+        let enriched = vec![EnrichedPackage::new(pkg, Some("MIT".to_string()), None)];
+        let errors: Vec<(String, String)> = vec![];
+
+        let (successful, total, failed) =
+            FetchLicensesUseCase::<MockLicenseRepository>::summarize(&enriched, &errors);
+        assert_eq!(successful, 1);
+        assert_eq!(total, 1);
+        assert_eq!(failed, 0);
+    }
+
+    #[test]
+    fn test_summarize_with_failures() {
+        let pkg1 = make_package("requests", "2.31.0");
+        let pkg2 = make_package("urllib3", "1.26.0");
+        let enriched = vec![
+            EnrichedPackage::new(pkg1, Some("MIT".to_string()), None),
+            EnrichedPackage::new(pkg2, None, None),
+        ];
+        let errors = vec![("urllib3".to_string(), "network error".to_string())];
+
+        let (successful, total, failed) =
+            FetchLicensesUseCase::<MockLicenseRepository>::summarize(&enriched, &errors);
+        assert_eq!(successful, 1);
+        assert_eq!(total, 2);
+        assert_eq!(failed, 1);
+    }
+
+    // ========== fetch_with_progress() tests ==========
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_success() {
+        let use_case = FetchLicensesUseCase::new(MockLicenseRepository);
+        let packages = vec![make_package("requests", "2.31.0")];
+
+        let (enriched, errors) = use_case.fetch_with_progress(packages).await.unwrap();
+
+        assert_eq!(enriched.len(), 1);
+        assert!(errors.is_empty());
+        assert_eq!(enriched[0].license.as_deref(), Some("MIT"));
+        assert_eq!(enriched[0].description.as_deref(), Some("A test package"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_failure() {
+        let use_case = FetchLicensesUseCase::new(FailingLicenseRepository);
+        let packages = vec![make_package("requests", "2.31.0")];
+
+        let (enriched, errors) = use_case.fetch_with_progress(packages).await.unwrap();
+
+        assert_eq!(enriched.len(), 1);
+        assert_eq!(errors.len(), 1);
+        assert!(enriched[0].license.is_none());
+        assert_eq!(errors[0].0, "requests");
+        assert!(errors[0].1.contains("network error"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_empty() {
+        let use_case = FetchLicensesUseCase::new(MockLicenseRepository);
+
+        let (enriched, errors) = use_case.fetch_with_progress(vec![]).await.unwrap();
+
+        assert!(enriched.is_empty());
+        assert!(errors.is_empty());
+    }
+}

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -1,6 +1,6 @@
 use crate::adapters::outbound::uv::UvLockAdapter;
 use crate::application::dto::{SbomRequest, SbomResponse};
-use crate::application::use_cases::CheckVulnerabilitiesUseCase;
+use crate::application::use_cases::{CheckVulnerabilitiesUseCase, FetchLicensesUseCase};
 use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::{
     EnrichedPackage, LicenseRepository, LockfileReader, ProgressReporter, ProjectConfigReader,
@@ -14,19 +14,10 @@ use crate::sbom_generation::domain::services::{
 use crate::sbom_generation::domain::{Package, PackageName, UpgradeRecommendation};
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
-use indicatif::{ProgressBar, ProgressStyle};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
 
 /// Type alias for package list with dependency map
 /// Used to simplify complex return types and satisfy clippy::type_complexity
 type PackagesWithDependencyMap = (Vec<Package>, std::collections::HashMap<String, Vec<String>>);
-
-/// Rate limiting: Delay between license fetch requests to prevent DoS (milliseconds)
-/// This limits requests to ~10 per second (100ms delay = 10 requests/second)
-const LICENSE_FETCH_DELAY_MS: u64 = 100;
 
 /// GenerateSbomUseCase - Core use case for SBOM generation
 ///
@@ -52,7 +43,7 @@ impl<LR, PCR, LREPO, PR, VREPO> GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO>
 where
     LR: LockfileReader,
     PCR: ProjectConfigReader,
-    LREPO: LicenseRepository,
+    LREPO: LicenseRepository + Clone,
     PR: ProgressReporter,
     VREPO: VulnerabilityRepository + Clone,
 {
@@ -282,10 +273,34 @@ where
     /// # Returns
     /// Vector of EnrichedPackage with license information
     async fn fetch_license_info(&self, packages: Vec<Package>) -> Result<Vec<EnrichedPackage>> {
+        let msgs = Messages::for_locale(self.locale);
         self.progress_reporter
-            .report(Messages::for_locale(self.locale).progress_fetching_license);
+            .report(msgs.progress_fetching_license);
 
-        self.enrich_packages_with_licenses(packages).await
+        let fetch_use_case = FetchLicensesUseCase::new(self.license_repository.clone());
+        let (enriched, errors) = fetch_use_case.fetch_with_progress(packages).await?;
+
+        eprintln!(); // Add newline after progress bar
+
+        for (package_name, error_msg) in &errors {
+            self.progress_reporter.report_error(&Messages::format(
+                msgs.warn_license_fetch_failed,
+                &[package_name, error_msg],
+            ));
+        }
+
+        let (successful, total, failed) =
+            FetchLicensesUseCase::<LREPO>::summarize(&enriched, &errors);
+        self.progress_reporter.report_completion(&Messages::format(
+            msgs.progress_license_complete,
+            &[
+                &successful.to_string(),
+                &total.to_string(),
+                &failed.to_string(),
+            ],
+        ));
+
+        Ok(enriched)
     }
 
     /// Checks vulnerabilities if CVE check is requested
@@ -528,119 +543,6 @@ where
         }
 
         builder.build().expect("response build should not fail")
-    }
-
-    /// Enriches packages with license information from the repository
-    ///
-    /// Security: This method implements rate limiting to prevent DoS attacks
-    /// via unbounded PyPI API requests. A delay is added between requests
-    /// to limit the rate to approximately 10 requests per second.
-    async fn enrich_packages_with_licenses(
-        &self,
-        packages: Vec<Package>,
-    ) -> Result<Vec<EnrichedPackage>> {
-        let total = packages.len();
-
-        // Create atomic counters for thread-safe progress sharing
-        let progress_current = Arc::new(AtomicUsize::new(0));
-        let progress_total = Arc::new(AtomicUsize::new(total));
-        let is_done = Arc::new(AtomicBool::new(false));
-
-        // Clone references for the progress bar update thread
-        let current_clone = progress_current.clone();
-        let total_clone = progress_total.clone();
-        let done_clone = is_done.clone();
-
-        // Spawn a thread to update the progress bar
-        let progress_handle = thread::spawn(move || {
-            let pb = ProgressBar::new(total_clone.load(Ordering::Relaxed) as u64);
-            pb.set_style(
-                ProgressStyle::default_bar()
-                    .template("   {spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} - {msg}")
-                    .expect("Failed to set progress bar template")
-                    .progress_chars("=>-"),
-            );
-            pb.set_message("Fetching license information...");
-
-            // Poll for updates until done
-            while !done_clone.load(Ordering::Relaxed) {
-                let current = current_clone.load(Ordering::Relaxed);
-                pb.set_position(current as u64);
-                thread::sleep(Duration::from_millis(50));
-            }
-
-            pb.finish_and_clear();
-        });
-
-        // Fetch licenses sequentially with rate limiting
-        // Collect errors to report after async loop (since progress_reporter may not be Send)
-        let mut enriched = Vec::new();
-        let mut successful = 0;
-        let mut failed = 0;
-        let mut errors: Vec<(String, String)> = Vec::new(); // (package_name, error_message)
-
-        for (idx, package) in packages.into_iter().enumerate() {
-            let package_name = package.name().to_string();
-            match self
-                .license_repository
-                .enrich_with_license(package.name(), package.version())
-                .await
-            {
-                Ok(license_info) => {
-                    enriched.push(
-                        EnrichedPackage::new(
-                            package,
-                            license_info.license_text().map(String::from),
-                            license_info.description().map(String::from),
-                        )
-                        .with_sha256_hash(license_info.sha256_hash().map(String::from)),
-                    );
-                    successful += 1;
-                }
-                Err(e) => {
-                    // Collect error for reporting after async loop
-                    errors.push((package_name, e.to_string()));
-                    // Include package without license information
-                    enriched.push(EnrichedPackage::new(package, None, None));
-                    failed += 1;
-                }
-            }
-
-            // Update progress
-            progress_current.store(idx + 1, Ordering::Relaxed);
-
-            // Security: Rate limiting to prevent DoS via unbounded API requests
-            // Add delay between requests (except after the last one)
-            if idx < total - 1 {
-                tokio::time::sleep(Duration::from_millis(LICENSE_FETCH_DELAY_MS)).await;
-            }
-        }
-
-        // Signal completion and wait for progress bar thread
-        is_done.store(true, Ordering::Relaxed);
-        let _ = progress_handle.join();
-
-        eprintln!(); // Add newline after progress bar
-
-        // Report errors collected during async execution
-        let msgs = Messages::for_locale(self.locale);
-        for (package_name, error_msg) in errors {
-            self.progress_reporter.report_error(&Messages::format(
-                msgs.warn_license_fetch_failed,
-                &[&package_name, &error_msg],
-            ));
-        }
-
-        self.progress_reporter.report_completion(&Messages::format(
-            msgs.progress_license_complete,
-            &[
-                &successful.to_string(),
-                &total.to_string(),
-                &failed.to_string(),
-            ],
-        ));
-
-        Ok(enriched)
     }
 }
 

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -89,6 +89,7 @@ impl ProjectConfigReader for MockProjectConfigReader {
 
 use crate::ports::outbound::PyPiMetadata;
 
+#[derive(Clone)]
 struct MockLicenseRepository;
 
 #[async_trait::async_trait]

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -1,7 +1,9 @@
 /// Use cases module containing application business logic orchestration
 mod check_vulnerabilities;
+mod fetch_licenses;
 mod generate_sbom;
 
 #[allow(unused_imports)]
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
+pub use fetch_licenses::FetchLicensesUseCase;
 pub use generate_sbom::GenerateSbomUseCase;

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -608,12 +608,13 @@ mod lang_option_tests {
 
 // Helper function to create a test license repository
 // In real tests, we would use a mock to avoid network calls
-fn create_test_license_repository() -> impl LicenseRepository {
+fn create_test_license_repository() -> impl LicenseRepository + Clone {
     use std::collections::HashMap;
 
     // Type alias for license data: (license, license_expression, classifiers, description)
     type LicenseData = (Option<String>, Option<String>, Vec<String>, Option<String>);
 
+    #[derive(Clone)]
     struct TestLicenseRepository {
         licenses: HashMap<String, LicenseData>,
     }

--- a/tests/test_utilities/mocks/mock_license_repository.rs
+++ b/tests/test_utilities/mocks/mock_license_repository.rs
@@ -4,6 +4,7 @@ use uv_sbom::ports::outbound::PyPiMetadata;
 use uv_sbom::prelude::*;
 
 /// Mock LicenseRepository for testing
+#[derive(Clone)]
 pub struct MockLicenseRepository {
     pub licenses: HashMap<String, PyPiMetadata>,
     pub should_fail: bool,


### PR DESCRIPTION
## Summary

- Add `FetchLicensesUseCase` in `src/application/use_cases/fetch_licenses.rs` with `fetch_with_progress()` and `summarize()` methods, mirroring the `CheckVulnerabilitiesUseCase` pattern
- Delegate `GenerateSbomUseCase::fetch_license_info` to `FetchLicensesUseCase`, removing the inline `enrich_packages_with_licenses` method (108 lines)
- Add `Clone` derive to `PyPiLicenseRepository`, `CachingPyPiLicenseRepository`, and all test mocks to satisfy the `LREPO: Clone` bound

## Related Issue

Closes #540
Part of #537

## Changes Made

- **New**: `src/application/use_cases/fetch_licenses.rs` — `FetchLicensesUseCase<LREPO>` with `fetch_with_progress()`, `summarize()`, and unit tests (6 tests)
- **Modified**: `src/application/use_cases/mod.rs` — register `pub mod fetch_licenses` and re-export `FetchLicensesUseCase`
- **Modified**: `src/application/use_cases/generate_sbom/mod.rs` — add `LREPO: Clone` bound; delegate `fetch_license_info` to `FetchLicensesUseCase`; remove `enrich_packages_with_licenses`
- **Modified**: `src/adapters/outbound/network/pypi_client.rs` — add `#[derive(Clone)]` to `PyPiLicenseRepository`
- **Modified**: `src/adapters/outbound/network/caching_pypi_client.rs` — add `#[derive(Clone)]` to `CachingPyPiLicenseRepository`
- **Modified**: test mocks — add `#[derive(Clone)]` to `MockLicenseRepository` in unit and integration tests

## Test Plan

- [x] `cargo test --all` passes (607 unit + integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)