### PR TITLE
refactor(i18n): move upgrade advisor progress messages to i18n catalog

### DIFF
--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -395,16 +395,22 @@ where
             return Some(vec![]);
         }
 
+        let msgs = Messages::for_locale(self.locale);
+
         let unique_dep_count = entries
             .iter()
             .flat_map(|e| e.introduced_by())
             .map(|i| i.package_name())
             .collect::<std::collections::HashSet<_>>()
             .len();
-        self.progress_reporter.report(&format!(
-            "🔍 Analyzing upgrade paths for {} direct dependenc{}...",
-            unique_dep_count,
-            if unique_dep_count == 1 { "y" } else { "ies" },
+        let unit = if unique_dep_count == 1 {
+            msgs.label_dependency_singular
+        } else {
+            msgs.label_dependency_plural
+        };
+        self.progress_reporter.report(&Messages::format(
+            msgs.progress_analyzing_upgrade_paths,
+            &[&unique_dep_count.to_string(), unit],
         ));
 
         let simulator = UvLockAdapter::new();
@@ -421,13 +427,15 @@ where
                     vulnerability_id,
                     ..
                 } => {
-                    self.progress_reporter.report(&format!(
-                        "  ✓ Upgrade {} → {} resolves {} to {} ({})",
-                        direct_dep_name,
-                        direct_dep_target_version,
-                        transitive_dep_name,
-                        transitive_resolved_version,
-                        vulnerability_id,
+                    self.progress_reporter.report(&Messages::format(
+                        msgs.progress_upgrade_resolves,
+                        &[
+                            direct_dep_name,
+                            direct_dep_target_version,
+                            transitive_dep_name,
+                            transitive_resolved_version,
+                            vulnerability_id,
+                        ],
                     ));
                 }
                 UpgradeRecommendation::Unresolvable {
@@ -435,18 +443,18 @@ where
                     reason,
                     vulnerability_id,
                 } => {
-                    self.progress_reporter.report(&format!(
-                        "  ✗ Cannot resolve via {}: {} ({})",
-                        direct_dep_name, reason, vulnerability_id,
+                    self.progress_reporter.report(&Messages::format(
+                        msgs.progress_upgrade_unresolvable,
+                        &[direct_dep_name, reason, vulnerability_id],
                     ));
                 }
                 UpgradeRecommendation::SimulationFailed {
                     direct_dep_name,
                     error,
                 } => {
-                    self.progress_reporter.report(&format!(
-                        "  ❓ Simulation failed for {}: {}",
-                        direct_dep_name, error,
+                    self.progress_reporter.report(&Messages::format(
+                        msgs.progress_upgrade_simulation_failed,
+                        &[direct_dep_name, error],
                     ));
                 }
             }

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -75,6 +75,16 @@ pub struct Messages {
     pub progress_license_no_violations: &'static str,
     pub progress_license_unknown_packages: &'static str,
 
+    // Upgrade advisor progress messages (use case layer)
+    pub progress_analyzing_upgrade_paths: &'static str,
+    pub progress_upgrade_resolves: &'static str,
+    pub progress_upgrade_unresolvable: &'static str,
+    pub progress_upgrade_simulation_failed: &'static str,
+
+    // Singular/plural unit labels for direct dependency count
+    pub label_dependency_singular: &'static str,
+    pub label_dependency_plural: &'static str,
+
     // Warning messages
     pub warn_check_cve_no_effect: &'static str,
     pub warn_check_license_no_effect: &'static str,
@@ -235,6 +245,16 @@ static EN_MESSAGES: Messages = Messages {
     progress_license_no_violations: "✅ License compliance: No violations found",
     progress_license_unknown_packages: "⚠️  License compliance: {} package(s) with unknown license",
 
+    // Upgrade advisor progress messages (use case layer)
+    progress_analyzing_upgrade_paths: "🔍 Analyzing upgrade paths for {} direct {}...",
+    progress_upgrade_resolves: "  ✓ Upgrade {} → {} resolves {} to {} ({})",
+    progress_upgrade_unresolvable: "  ✗ Cannot resolve via {}: {} ({})",
+    progress_upgrade_simulation_failed: "  ❓ Simulation failed for {}: {}",
+
+    // Singular/plural unit labels for direct dependency count
+    label_dependency_singular: "dependency",
+    label_dependency_plural: "dependencies",
+
     // Warning messages
     warn_check_cve_no_effect: "⚠️  Warning: --check-cve has no effect with JSON format.",
     warn_check_license_no_effect: "⚠️  Warning: --check-license has no effect with JSON format.",
@@ -361,6 +381,17 @@ static JA_MESSAGES: Messages = Messages {
     progress_license_violations_found: "⚠️  ライセンスコンプライアンス: {}件の違反が見つかりました",
     progress_license_no_violations: "✅ ライセンスコンプライアンス: 違反は見つかりませんでした",
     progress_license_unknown_packages: "⚠️  ライセンスコンプライアンス: ライセンス不明のパッケージが{}件あります",
+
+    // Upgrade advisor progress messages (use case layer)
+    // JA: only first {} (count) is used; second {} (unit word) is ignored
+    progress_analyzing_upgrade_paths: "🔍 {}個の直接依存パッケージのアップグレード経路を解析中...",
+    progress_upgrade_resolves: "  ✓ {}を{}にアップグレードすると{}が{}に解決されます ({})",
+    progress_upgrade_unresolvable: "  ✗ {}経由で解決できません: {} ({})",
+    progress_upgrade_simulation_failed: "  ❓ {}のシミュレーションに失敗しました: {}",
+
+    // Singular/plural unit labels (no distinction in Japanese; unused by JA template)
+    label_dependency_singular: "個の直接依存パッケージ",
+    label_dependency_plural: "個の直接依存パッケージ",
 
     // Warning messages
     warn_check_cve_no_effect: "⚠️  警告: JSON形式では --check-cve は効果がありません。",
@@ -746,6 +777,125 @@ mod tests {
             result,
             "### ⚠️Warning Found 2 vulnerabilities in 1 package."
         );
+    }
+
+    #[test]
+    fn test_messages_upgrade_advisor_progress_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(
+            msgs.progress_analyzing_upgrade_paths,
+            "🔍 Analyzing upgrade paths for {} direct {}..."
+        );
+        assert_eq!(
+            msgs.progress_upgrade_resolves,
+            "  ✓ Upgrade {} → {} resolves {} to {} ({})"
+        );
+        assert_eq!(
+            msgs.progress_upgrade_unresolvable,
+            "  ✗ Cannot resolve via {}: {} ({})"
+        );
+        assert_eq!(
+            msgs.progress_upgrade_simulation_failed,
+            "  ❓ Simulation failed for {}: {}"
+        );
+        assert_eq!(msgs.label_dependency_singular, "dependency");
+        assert_eq!(msgs.label_dependency_plural, "dependencies");
+    }
+
+    #[test]
+    fn test_messages_upgrade_advisor_progress_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(
+            msgs.progress_analyzing_upgrade_paths,
+            "🔍 {}個の直接依存パッケージのアップグレード経路を解析中..."
+        );
+        assert_eq!(
+            msgs.progress_upgrade_resolves,
+            "  ✓ {}を{}にアップグレードすると{}が{}に解決されます ({})"
+        );
+        assert_eq!(
+            msgs.progress_upgrade_unresolvable,
+            "  ✗ {}経由で解決できません: {} ({})"
+        );
+        assert_eq!(
+            msgs.progress_upgrade_simulation_failed,
+            "  ❓ {}のシミュレーションに失敗しました: {}"
+        );
+    }
+
+    #[test]
+    fn test_progress_analyzing_upgrade_paths_en_singular() {
+        let msgs = Messages::for_locale(Locale::En);
+        let result = Messages::format(
+            msgs.progress_analyzing_upgrade_paths,
+            &["1", msgs.label_dependency_singular],
+        );
+        assert_eq!(
+            result,
+            "🔍 Analyzing upgrade paths for 1 direct dependency..."
+        );
+    }
+
+    #[test]
+    fn test_progress_analyzing_upgrade_paths_en_plural() {
+        let msgs = Messages::for_locale(Locale::En);
+        let result = Messages::format(
+            msgs.progress_analyzing_upgrade_paths,
+            &["3", msgs.label_dependency_plural],
+        );
+        assert_eq!(
+            result,
+            "🔍 Analyzing upgrade paths for 3 direct dependencies..."
+        );
+    }
+
+    #[test]
+    fn test_progress_analyzing_upgrade_paths_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        let result = Messages::format(
+            msgs.progress_analyzing_upgrade_paths,
+            &["3", msgs.label_dependency_plural],
+        );
+        assert_eq!(
+            result,
+            "🔍 3個の直接依存パッケージのアップグレード経路を解析中..."
+        );
+    }
+
+    #[test]
+    fn test_progress_upgrade_resolves_en_format() {
+        let msgs = Messages::for_locale(Locale::En);
+        let result = Messages::format(
+            msgs.progress_upgrade_resolves,
+            &["requests", "2.32.3", "urllib3", "2.2.1", "GHSA-xxxx"],
+        );
+        assert_eq!(
+            result,
+            "  ✓ Upgrade requests → 2.32.3 resolves urllib3 to 2.2.1 (GHSA-xxxx)"
+        );
+    }
+
+    #[test]
+    fn test_progress_upgrade_unresolvable_en_format() {
+        let msgs = Messages::for_locale(Locale::En);
+        let result = Messages::format(
+            msgs.progress_upgrade_unresolvable,
+            &["pkg-a", "no compatible version", "GHSA-yyyy"],
+        );
+        assert_eq!(
+            result,
+            "  ✗ Cannot resolve via pkg-a: no compatible version (GHSA-yyyy)"
+        );
+    }
+
+    #[test]
+    fn test_progress_upgrade_simulation_failed_en_format() {
+        let msgs = Messages::for_locale(Locale::En);
+        let result = Messages::format(
+            msgs.progress_upgrade_simulation_failed,
+            &["pkg-b", "uv lock failed"],
+        );
+        assert_eq!(result, "  ❓ Simulation failed for pkg-b: uv lock failed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace four hardcoded English `format!()` strings in `advise_upgrades_if_requested` with `Messages::format()` calls using new catalog keys
- Add EN and JA translations for all four upgrade advisor progress messages
- Add `label_dependency_singular` / `label_dependency_plural` unit labels for the singular/plural pluralization pattern

## Related Issue
Closes #538

## Changes Made
- `src/i18n/mod.rs`: Add 6 new fields to `Messages` struct (`progress_analyzing_upgrade_paths`, `progress_upgrade_resolves`, `progress_upgrade_unresolvable`, `progress_upgrade_simulation_failed`, `label_dependency_singular`, `label_dependency_plural`); populate EN and JA static instances; add 8 unit tests
- `src/application/use_cases/generate_sbom/mod.rs`: Replace 4 hardcoded `format!()` calls in `advise_upgrades_if_requested` with `Messages::format()` calls, consistent with all other progress messages in the use case

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] 8 new unit tests covering EN/JA static values, singular/plural rendering, and end-to-end format substitution

---
Generated with [Claude Code](https://claude.com/claude-code)