### PR TITLE
refactor(tests): consolidate duplicate MockVulnerabilityRepository into shared test_doubles module

### DIFF
--- a/src/application/use_cases/check_vulnerabilities.rs
+++ b/src/application/use_cases/check_vulnerabilities.rs
@@ -126,31 +126,8 @@ impl<R: VulnerabilityRepository> CheckVulnerabilitiesUseCase<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ports::outbound::ProgressCallback;
+    use crate::application::use_cases::test_doubles::MockVulnerabilityRepository;
     use crate::sbom_generation::domain::vulnerability::{CvssScore, Severity, Vulnerability};
-    use async_trait::async_trait;
-
-    struct MockVulnerabilityRepository {
-        vulnerabilities: Vec<PackageVulnerabilities>,
-    }
-
-    #[async_trait]
-    impl VulnerabilityRepository for MockVulnerabilityRepository {
-        async fn fetch_vulnerabilities(
-            &self,
-            _packages: Vec<Package>,
-        ) -> Result<Vec<PackageVulnerabilities>> {
-            Ok(self.vulnerabilities.clone())
-        }
-
-        async fn fetch_vulnerabilities_with_progress(
-            &self,
-            _packages: Vec<Package>,
-            _progress_callback: ProgressCallback<'static>,
-        ) -> Result<Vec<PackageVulnerabilities>> {
-            Ok(self.vulnerabilities.clone())
-        }
-    }
 
     fn create_test_package(name: &str, version: &str) -> Package {
         Package::new(name.to_string(), version.to_string()).unwrap()

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::application::use_cases::test_doubles::MockVulnerabilityRepository;
 use crate::i18n::Locale;
 use crate::ports::outbound::LockfileParseResult;
 use crate::sbom_generation::domain::Package;
@@ -207,19 +208,6 @@ version = "1.26.0"
     assert_eq!(graph.transitive_dependency_count(), 1);
 }
 
-#[derive(Clone)]
-struct MockVulnerabilityRepository;
-
-#[async_trait::async_trait]
-impl VulnerabilityRepository for MockVulnerabilityRepository {
-    async fn fetch_vulnerabilities(
-        &self,
-        _packages: Vec<Package>,
-    ) -> Result<Vec<crate::sbom_generation::domain::PackageVulnerabilities>> {
-        Ok(vec![])
-    }
-}
-
 #[tokio::test]
 async fn test_execute_with_cve_check_enabled() {
     let lockfile_content = r#"
@@ -241,7 +229,7 @@ version = "3.4.0"
         },
         MockLicenseRepository,
         MockProgressReporter,
-        Some(MockVulnerabilityRepository),
+        Some(MockVulnerabilityRepository::new()),
         Locale::default(),
     );
 
@@ -308,7 +296,7 @@ version = "2024.8.30"
         },
         MockLicenseRepository,
         MockProgressReporter,
-        Some(MockVulnerabilityRepository),
+        Some(MockVulnerabilityRepository::new()),
         Locale::default(),
     );
 
@@ -340,7 +328,7 @@ version = "2024.8.30"
         },
         MockLicenseRepository,
         MockProgressReporter,
-        Some(MockVulnerabilityRepository),
+        Some(MockVulnerabilityRepository::new()),
         Locale::default(),
     );
 
@@ -592,7 +580,7 @@ async fn test_check_vulnerabilities_if_requested_disabled() {
         },
         MockLicenseRepository,
         MockProgressReporter,
-        Some(MockVulnerabilityRepository),
+        Some(MockVulnerabilityRepository::new()),
         Locale::default(),
     );
 
@@ -621,7 +609,7 @@ async fn test_check_vulnerabilities_if_requested_enabled() {
         },
         MockLicenseRepository,
         MockProgressReporter,
-        Some(MockVulnerabilityRepository),
+        Some(MockVulnerabilityRepository::new()),
         Locale::default(),
     );
 

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -3,6 +3,9 @@ mod check_vulnerabilities;
 mod fetch_licenses;
 mod generate_sbom;
 
+#[cfg(test)]
+pub(crate) mod test_doubles;
+
 #[allow(unused_imports)]
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
 pub use fetch_licenses::FetchLicensesUseCase;

--- a/src/application/use_cases/test_doubles.rs
+++ b/src/application/use_cases/test_doubles.rs
@@ -1,0 +1,37 @@
+use crate::ports::outbound::{ProgressCallback, VulnerabilityRepository};
+use crate::sbom_generation::domain::{Package, PackageVulnerabilities};
+use crate::shared::Result;
+use async_trait::async_trait;
+
+/// Configurable in-memory mock implementing `VulnerabilityRepository`.
+///
+/// Use `MockVulnerabilityRepository::new()` for the empty variant returning `Ok(vec![])`.
+/// Use `MockVulnerabilityRepository { vulnerabilities: ... }` for tests that need pre-loaded data.
+#[derive(Clone, Default)]
+pub(crate) struct MockVulnerabilityRepository {
+    pub vulnerabilities: Vec<PackageVulnerabilities>,
+}
+
+impl MockVulnerabilityRepository {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl VulnerabilityRepository for MockVulnerabilityRepository {
+    async fn fetch_vulnerabilities(
+        &self,
+        _packages: Vec<Package>,
+    ) -> Result<Vec<PackageVulnerabilities>> {
+        Ok(self.vulnerabilities.clone())
+    }
+
+    async fn fetch_vulnerabilities_with_progress(
+        &self,
+        _packages: Vec<Package>,
+        _progress_callback: ProgressCallback<'static>,
+    ) -> Result<Vec<PackageVulnerabilities>> {
+        Ok(self.vulnerabilities.clone())
+    }
+}


### PR DESCRIPTION
## Summary
- Create `src/application/use_cases/test_doubles.rs` with a single configurable `MockVulnerabilityRepository` gated behind `#[cfg(test)]`
- Remove the two incompatible local mock definitions from `generate_sbom/tests.rs` and `check_vulnerabilities.rs`
- Both consumers now import from the shared module, eliminating duplication

## Related Issue
Closes #539

## Changes Made
- **New**: `src/application/use_cases/test_doubles.rs` — shared `MockVulnerabilityRepository` with `Clone + Default`, `new()` constructor, and both `VulnerabilityRepository` methods implemented
- **Modified**: `src/application/use_cases/mod.rs` — register `test_doubles` module under `#[cfg(test)]`
- **Modified**: `src/application/use_cases/check_vulnerabilities.rs` — replace local mock definition with import from shared module
- **Modified**: `src/application/use_cases/generate_sbom/tests.rs` — replace local mock definition with import; update 5 value-construction sites to `MockVulnerabilityRepository::new()`

## Test Plan
- [x] `cargo test --all` passes (615 unit + integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] No production code changes — test-only refactor

---
Generated with [Claude Code](https://claude.com/claude-code)