### PR TITLE
refactor(tests): extract UseCaseBuilder and redesign MockLockfileReader in generate_sbom tests

### DIFF
--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -1,72 +1,22 @@
 use super::*;
 use crate::application::use_cases::test_doubles::MockVulnerabilityRepository;
-use crate::i18n::Locale;
-use crate::ports::outbound::LockfileParseResult;
+use crate::ports::outbound::{LockfileParseResult, PyPiMetadata};
 use crate::sbom_generation::domain::Package;
 use std::collections::HashMap;
 use std::path::Path;
 
-// Mock implementations for testing
 struct MockLockfileReader {
-    content: String,
+    packages: Vec<Package>,
+    deps: HashMap<String, Vec<String>>,
 }
 
 impl LockfileReader for MockLockfileReader {
     fn read_lockfile(&self, _path: &Path) -> Result<String> {
-        Ok(self.content.clone())
+        Ok(String::new())
     }
 
     fn read_and_parse_lockfile(&self, _path: &Path) -> Result<LockfileParseResult> {
-        // Parse the mock content
-        use serde::Deserialize;
-
-        #[derive(Debug, Deserialize)]
-        struct UvLock {
-            package: Vec<UvPackage>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvPackage {
-            name: String,
-            version: String,
-            #[serde(default)]
-            dependencies: Vec<UvDependency>,
-            #[serde(default, rename = "dev-dependencies")]
-            dev_dependencies: Option<DevDependencies>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvDependency {
-            name: String,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct DevDependencies {
-            #[serde(default)]
-            dev: Vec<UvDependency>,
-        }
-
-        let lockfile: UvLock = toml::from_str(&self.content)?;
-
-        let mut packages = Vec::new();
-        let mut dependency_map = HashMap::new();
-
-        for pkg in lockfile.package {
-            packages.push(Package::new(pkg.name.clone(), pkg.version.clone())?);
-
-            let mut deps = Vec::new();
-            for dep in &pkg.dependencies {
-                deps.push(dep.name.clone());
-            }
-            if let Some(dev_deps) = &pkg.dev_dependencies {
-                for dep in &dev_deps.dev {
-                    deps.push(dep.name.clone());
-                }
-            }
-            dependency_map.insert(pkg.name, deps);
-        }
-
-        Ok((packages, dependency_map))
+        Ok((self.packages.clone(), self.deps.clone()))
     }
 
     fn read_and_parse_lockfile_for_member(
@@ -74,7 +24,7 @@ impl LockfileReader for MockLockfileReader {
         _path: &Path,
         _member_name: &str,
     ) -> Result<LockfileParseResult> {
-        unimplemented!("not needed for current mock usage")
+        Ok((self.packages.clone(), self.deps.clone()))
     }
 }
 
@@ -87,8 +37,6 @@ impl ProjectConfigReader for MockProjectConfigReader {
         Ok(self.project_name.clone())
     }
 }
-
-use crate::ports::outbound::PyPiMetadata;
 
 #[derive(Clone)]
 struct MockLicenseRepository;
@@ -118,898 +66,640 @@ impl ProgressReporter for MockProgressReporter {
     fn report_completion(&self, _message: &str) {}
 }
 
-#[tokio::test]
-async fn test_execute_without_dependencies() {
-    let lockfile_content = r#"
-[[package]]
-name = "certifi"
-version = "2024.8.30"
+mod test_helpers {
+    use super::*;
+    use crate::i18n::Locale;
 
-[[package]]
-name = "charset-normalizer"
-version = "3.4.0"
-"#;
+    pub(super) type TestUseCase = GenerateSbomUseCase<
+        MockLockfileReader,
+        MockProjectConfigReader,
+        MockLicenseRepository,
+        MockProgressReporter,
+        MockVulnerabilityRepository,
+    >;
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: lockfile_content.to_string(),
-            },
-            MockProjectConfigReader {
+    pub(super) struct UseCaseBuilder {
+        packages: Vec<Package>,
+        deps: HashMap<String, Vec<String>>,
+        project_name: String,
+        vuln: Option<MockVulnerabilityRepository>,
+    }
+
+    impl Default for UseCaseBuilder {
+        fn default() -> Self {
+            Self {
+                packages: Vec::new(),
+                deps: HashMap::new(),
                 project_name: "test-project".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .build()
-        .unwrap();
-
-    let response = use_case.execute(request).await.unwrap();
-
-    assert_eq!(response.enriched_packages.len(), 2);
-    assert!(response.dependency_graph.is_none());
-    assert!(!response.metadata.serial_number().is_empty());
-}
-
-#[tokio::test]
-async fn test_execute_with_dependencies() {
-    let lockfile_content = r#"
-[[package]]
-name = "myproject"
-version = "1.0.0"
-dependencies = [
-    { name = "requests" }
-]
-
-[[package]]
-name = "requests"
-version = "2.31.0"
-dependencies = [
-    { name = "urllib3" }
-]
-
-[[package]]
-name = "urllib3"
-version = "1.26.0"
-"#;
-
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: lockfile_content.to_string(),
-            },
-            MockProjectConfigReader {
-                project_name: "myproject".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .include_dependency_info(true)
-        .build()
-        .unwrap();
-
-    let response = use_case.execute(request).await.unwrap();
-
-    assert_eq!(response.enriched_packages.len(), 3);
-    assert!(response.dependency_graph.is_some());
-
-    let graph = response.dependency_graph.unwrap();
-    assert_eq!(graph.direct_dependency_count(), 1);
-    assert_eq!(graph.transitive_dependency_count(), 1);
-}
-
-#[tokio::test]
-async fn test_execute_with_cve_check_enabled() {
-    let lockfile_content = r#"
-[[package]]
-name = "certifi"
-version = "2024.8.30"
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.0"
-"#;
-
-    let use_case = GenerateSbomUseCase::new(
-        MockLockfileReader {
-            content: lockfile_content.to_string(),
-        },
-        MockProjectConfigReader {
-            project_name: "test-project".to_string(),
-        },
-        MockLicenseRepository,
-        MockProgressReporter,
-        Some(MockVulnerabilityRepository::new()),
-        Locale::default(),
-    );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .check_cve(true)
-        .build()
-        .unwrap();
-
-    let response = use_case.execute(request).await.unwrap();
-
-    assert_eq!(response.enriched_packages.len(), 2);
-    assert!(response.vulnerability_check_result.is_some());
-}
-
-#[tokio::test]
-async fn test_execute_with_cve_check_but_no_repository() {
-    let lockfile_content = r#"
-[[package]]
-name = "certifi"
-version = "2024.8.30"
-"#;
-
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: lockfile_content.to_string(),
-            },
-            MockProjectConfigReader {
-                project_name: "test-project".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None, // No vulnerability repository
-            Locale::default(),
-        );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .check_cve(true)
-        .build()
-        .unwrap();
-
-    let response = use_case.execute(request).await.unwrap();
-
-    assert_eq!(response.enriched_packages.len(), 1);
-    assert!(response.vulnerability_check_result.is_none());
-}
-
-#[tokio::test]
-async fn test_execute_with_cve_check_disabled() {
-    let lockfile_content = r#"
-[[package]]
-name = "certifi"
-version = "2024.8.30"
-"#;
-
-    let use_case = GenerateSbomUseCase::new(
-        MockLockfileReader {
-            content: lockfile_content.to_string(),
-        },
-        MockProjectConfigReader {
-            project_name: "test-project".to_string(),
-        },
-        MockLicenseRepository,
-        MockProgressReporter,
-        Some(MockVulnerabilityRepository::new()),
-        Locale::default(),
-    );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .build()
-        .unwrap();
-
-    let response = use_case.execute(request).await.unwrap();
-
-    assert_eq!(response.enriched_packages.len(), 1);
-    assert!(response.vulnerability_check_result.is_none());
-}
-
-#[tokio::test]
-async fn test_execute_with_cve_check_in_dry_run_mode() {
-    let lockfile_content = r#"
-[[package]]
-name = "certifi"
-version = "2024.8.30"
-"#;
-
-    let use_case = GenerateSbomUseCase::new(
-        MockLockfileReader {
-            content: lockfile_content.to_string(),
-        },
-        MockProjectConfigReader {
-            project_name: "test-project".to_string(),
-        },
-        MockLicenseRepository,
-        MockProgressReporter,
-        Some(MockVulnerabilityRepository::new()),
-        Locale::default(),
-    );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .dry_run(true)
-        .check_cve(true)
-        .build()
-        .unwrap();
-
-    let response = use_case.execute(request).await.unwrap();
-
-    assert_eq!(response.enriched_packages.len(), 0); // dry-run returns empty
-    assert!(response.vulnerability_check_result.is_none()); // CVE check skipped
-}
-
-// ===== Tests for extracted methods =====
-
-#[test]
-fn test_apply_exclusion_filters_empty_patterns() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let packages = vec![
-        Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap(),
-        Package::new("pkg2".to_string(), "2.0.0".to_string()).unwrap(),
-    ];
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .build()
-        .unwrap();
-
-    let filtered_pkgs = use_case
-        .apply_exclusion_filters(packages.clone(), &request)
-        .unwrap();
-
-    assert_eq!(filtered_pkgs.len(), 2);
-}
-
-#[test]
-fn test_apply_exclusion_filters_with_patterns() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let packages = vec![
-        Package::new("requests".to_string(), "1.0.0".to_string()).unwrap(),
-        Package::new("urllib3".to_string(), "2.0.0".to_string()).unwrap(),
-        Package::new("certifi".to_string(), "3.0.0".to_string()).unwrap(),
-    ];
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .exclude_patterns(vec!["requests".to_string()])
-        .build()
-        .unwrap();
-
-    let filtered_pkgs = use_case
-        .apply_exclusion_filters(packages, &request)
-        .unwrap();
-
-    assert_eq!(filtered_pkgs.len(), 2);
-    assert!(!filtered_pkgs.iter().any(|p| p.name() == "requests"));
-}
-
-#[test]
-fn test_apply_exclusion_filters_all_excluded_error() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let packages = vec![Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap()];
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .exclude_patterns(vec!["pkg1".to_string()])
-        .build()
-        .unwrap();
-
-    let result = use_case.apply_exclusion_filters(packages, &request);
-
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("All 1 package(s) were excluded"));
-}
-
-#[test]
-fn test_analyze_dependencies_disabled() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .build()
-        .unwrap();
-    let dependency_map: HashMap<String, Vec<String>> = HashMap::new();
-
-    let result = use_case
-        .analyze_dependencies_if_requested(&request, &dependency_map)
-        .unwrap();
-
-    assert!(result.is_none());
-}
-
-#[test]
-fn test_analyze_dependencies_enabled() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "myproject".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .include_dependency_info(true)
-        .build()
-        .unwrap();
-    let mut dependency_map: HashMap<String, Vec<String>> = HashMap::new();
-    dependency_map.insert("myproject".to_string(), vec!["requests".to_string()]);
-    dependency_map.insert("requests".to_string(), vec![]);
-
-    let result = use_case
-        .analyze_dependencies_if_requested(&request, &dependency_map)
-        .unwrap();
-
-    assert!(result.is_some());
-    let graph = result.unwrap();
-    assert_eq!(graph.direct_dependency_count(), 1);
-}
-
-#[test]
-fn test_build_response() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let package = Package::new("test-pkg".to_string(), "1.0.0".to_string()).unwrap();
-    let enriched_packages = vec![EnrichedPackage::new(
-        package,
-        Some("MIT".to_string()),
-        Some("Test description".to_string()),
-    )];
-
-    let response = use_case.build_response(enriched_packages.clone(), None, None, None, None);
-
-    assert_eq!(response.enriched_packages.len(), 1);
-    assert!(response.dependency_graph.is_none());
-    assert!(response.vulnerability_check_result.is_none());
-    assert!(response.vulnerability_check_result.is_none());
-    assert!(!response.metadata.serial_number().is_empty());
-    assert!(!response.metadata.timestamp().is_empty());
-}
-
-#[tokio::test]
-async fn test_fetch_license_info() {
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let packages = vec![
-        Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap(),
-        Package::new("pkg2".to_string(), "2.0.0".to_string()).unwrap(),
-    ];
-
-    let enriched = use_case.fetch_license_info(packages).await.unwrap();
-
-    assert_eq!(enriched.len(), 2);
-    // MockLicenseRepository always returns MIT license
-    assert!(enriched[0].license.is_some());
-    assert_eq!(enriched[0].license.as_ref().unwrap(), "MIT");
-}
-
-#[tokio::test]
-async fn test_check_vulnerabilities_if_requested_disabled() {
-    let use_case = GenerateSbomUseCase::new(
-        MockLockfileReader {
-            content: String::new(),
-        },
-        MockProjectConfigReader {
-            project_name: "test".to_string(),
-        },
-        MockLicenseRepository,
-        MockProgressReporter,
-        Some(MockVulnerabilityRepository::new()),
-        Locale::default(),
-    );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .build()
-        .unwrap();
-    let packages = vec![Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap()];
-
-    let result = use_case
-        .check_vulnerabilities_if_requested(&request, &packages)
-        .await
-        .unwrap();
-
-    assert!(result.is_none());
-}
-
-#[tokio::test]
-async fn test_check_vulnerabilities_if_requested_enabled() {
-    let use_case = GenerateSbomUseCase::new(
-        MockLockfileReader {
-            content: String::new(),
-        },
-        MockProjectConfigReader {
-            project_name: "test".to_string(),
-        },
-        MockLicenseRepository,
-        MockProgressReporter,
-        Some(MockVulnerabilityRepository::new()),
-        Locale::default(),
-    );
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .check_cve(true)
-        .build()
-        .unwrap();
-    let packages = vec![Package::new("pkg1".to_string(), "1.0.0".to_string()).unwrap()];
-
-    let result = use_case
-        .check_vulnerabilities_if_requested(&request, &packages)
-        .await
-        .unwrap();
-
-    assert!(result.is_some());
-}
-
-// ===== Tests for threshold configuration =====
-
-#[test]
-fn test_build_threshold_config_none() {
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .check_cve(true)
-        .build()
-        .unwrap();
-
-    let config = GenerateSbomUseCase::<
-        MockLockfileReader,
-        MockProjectConfigReader,
-        MockLicenseRepository,
-        MockProgressReporter,
-        MockVulnerabilityRepository,
-    >::build_threshold_config(&request);
-
-    assert_eq!(config, ThresholdConfig::None);
-}
-
-#[test]
-fn test_build_threshold_config_severity() {
-    use crate::sbom_generation::domain::vulnerability::Severity;
-
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .check_cve(true)
-        .severity_threshold_opt(Some(Severity::High))
-        .build()
-        .unwrap();
-
-    let config = GenerateSbomUseCase::<
-        MockLockfileReader,
-        MockProjectConfigReader,
-        MockLicenseRepository,
-        MockProgressReporter,
-        MockVulnerabilityRepository,
-    >::build_threshold_config(&request);
-
-    assert_eq!(config, ThresholdConfig::Severity(Severity::High));
-}
-
-#[test]
-fn test_build_threshold_config_cvss() {
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .check_cve(true)
-        .cvss_threshold_opt(Some(7.0))
-        .build()
-        .unwrap();
-
-    let config = GenerateSbomUseCase::<
-        MockLockfileReader,
-        MockProjectConfigReader,
-        MockLicenseRepository,
-        MockProgressReporter,
-        MockVulnerabilityRepository,
-    >::build_threshold_config(&request);
-
-    assert_eq!(config, ThresholdConfig::Cvss(7.0));
-}
-
-#[test]
-fn test_build_response_with_threshold_exceeded() {
-    use crate::sbom_generation::domain::vulnerability::{CvssScore, Severity, Vulnerability};
-
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
-
-    let package = Package::new("test-pkg".to_string(), "1.0.0".to_string()).unwrap();
-    let enriched_packages = vec![EnrichedPackage::new(
-        package,
-        Some("MIT".to_string()),
-        Some("Test description".to_string()),
-    )];
-
-    // Create a vulnerability check result with threshold exceeded
-    let vuln = Vulnerability::new(
-        "CVE-2024-001".to_string(),
-        Some(CvssScore::new(9.0).unwrap()),
-        Severity::Critical,
-        None,
-        None,
-    )
-    .unwrap();
-    let pkg_vulns = crate::sbom_generation::domain::PackageVulnerabilities::new(
-        "test-pkg".to_string(),
-        "1.0.0".to_string(),
-        vec![vuln],
-    );
-    let check_result = VulnerabilityCheckResult {
-        above_threshold: vec![pkg_vulns],
-        below_threshold: vec![],
-        threshold_exceeded: true,
-    };
-
-    let response = use_case.build_response(enriched_packages, None, Some(check_result), None, None);
-
-    assert!(response.has_vulnerabilities_above_threshold);
-    assert!(response.vulnerability_check_result.is_some());
-    assert!(
-        response
-            .vulnerability_check_result
+                vuln: None,
+            }
+        }
+    }
+
+    impl UseCaseBuilder {
+        pub(super) fn with_lockfile(mut self, packages: Vec<Package>) -> Self {
+            self.packages = packages;
+            self
+        }
+
+        pub(super) fn with_lockfile_and_deps(
+            mut self,
+            packages: Vec<Package>,
+            deps: HashMap<String, Vec<String>>,
+        ) -> Self {
+            self.packages = packages;
+            self.deps = deps;
+            self
+        }
+
+        pub(super) fn with_project_name(mut self, name: impl Into<String>) -> Self {
+            self.project_name = name.into();
+            self
+        }
+
+        pub(super) fn with_vuln_repo(mut self) -> Self {
+            self.vuln = Some(MockVulnerabilityRepository::new());
+            self
+        }
+
+        pub(super) fn build(self) -> TestUseCase {
+            GenerateSbomUseCase::new(
+                MockLockfileReader {
+                    packages: self.packages,
+                    deps: self.deps,
+                },
+                MockProjectConfigReader {
+                    project_name: self.project_name,
+                },
+                MockLicenseRepository,
+                MockProgressReporter,
+                self.vuln,
+                Locale::default(),
+            )
+        }
+    }
+
+    pub(super) fn default_request() -> SbomRequest {
+        SbomRequest::builder()
+            .project_path("/test/project")
+            .build()
             .unwrap()
-            .threshold_exceeded
-    );
+    }
+
+    pub(super) fn pkg(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
 }
 
-#[test]
-fn test_build_response_with_threshold_not_exceeded() {
-    use crate::sbom_generation::domain::vulnerability::{CvssScore, Severity, Vulnerability};
+mod tests_execute {
+    use super::test_helpers::*;
+    use super::*;
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: String::new(),
-            },
-            MockProjectConfigReader {
-                project_name: "test".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
+    #[tokio::test]
+    async fn test_execute_without_dependencies() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![
+                pkg("certifi", "2024.8.30"),
+                pkg("charset-normalizer", "3.4.0"),
+            ])
+            .build();
 
-    let package = Package::new("test-pkg".to_string(), "1.0.0".to_string()).unwrap();
-    let enriched_packages = vec![EnrichedPackage::new(
-        package,
-        Some("MIT".to_string()),
-        Some("Test description".to_string()),
-    )];
+        let response = use_case.execute(default_request()).await.unwrap();
 
-    // Create a vulnerability check result with threshold NOT exceeded
-    let vuln = Vulnerability::new(
-        "CVE-2024-001".to_string(),
-        Some(CvssScore::new(3.0).unwrap()),
-        Severity::Low,
-        None,
-        None,
-    )
-    .unwrap();
-    let pkg_vulns = crate::sbom_generation::domain::PackageVulnerabilities::new(
-        "test-pkg".to_string(),
-        "1.0.0".to_string(),
-        vec![vuln],
-    );
-    let check_result = VulnerabilityCheckResult {
-        above_threshold: vec![],
-        below_threshold: vec![pkg_vulns],
-        threshold_exceeded: false,
-    };
+        assert_eq!(response.enriched_packages.len(), 2);
+        assert!(response.dependency_graph.is_none());
+        assert!(!response.metadata.serial_number().is_empty());
+    }
 
-    let response = use_case.build_response(enriched_packages, None, Some(check_result), None, None);
+    #[tokio::test]
+    async fn test_execute_with_dependencies() {
+        let packages = vec![
+            pkg("myproject", "1.0.0"),
+            pkg("requests", "2.31.0"),
+            pkg("urllib3", "1.26.0"),
+        ];
+        let deps = HashMap::from([
+            ("myproject".to_string(), vec!["requests".to_string()]),
+            ("requests".to_string(), vec!["urllib3".to_string()]),
+            ("urllib3".to_string(), vec![]),
+        ]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_project_name("myproject")
+            .build();
 
-    assert!(!response.has_vulnerabilities_above_threshold);
-    assert!(response.vulnerability_check_result.is_some());
-    assert!(
-        !response
-            .vulnerability_check_result
-            .unwrap()
-            .threshold_exceeded
-    );
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .include_dependency_info(true)
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 3);
+        assert!(response.dependency_graph.is_some());
+        let graph = response.dependency_graph.unwrap();
+        assert_eq!(graph.direct_dependency_count(), 1);
+        assert_eq!(graph.transitive_dependency_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_cve_check_enabled() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![
+                pkg("certifi", "2024.8.30"),
+                pkg("charset-normalizer", "3.4.0"),
+            ])
+            .with_vuln_repo()
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_cve(true)
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 2);
+        assert!(response.vulnerability_check_result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_cve_check_but_no_repository() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("certifi", "2024.8.30")])
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_cve(true)
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 1);
+        assert!(response.vulnerability_check_result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_cve_check_disabled() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("certifi", "2024.8.30")])
+            .with_vuln_repo()
+            .build();
+
+        let response = use_case.execute(default_request()).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 1);
+        assert!(response.vulnerability_check_result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_cve_check_in_dry_run_mode() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("certifi", "2024.8.30")])
+            .with_vuln_repo()
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .dry_run(true)
+            .check_cve(true)
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 0);
+        assert!(response.vulnerability_check_result.is_none());
+    }
 }
 
-// ===== Tests for issue #206: Excluding root project preserves dependency classification =====
+mod tests_exclusion {
+    use super::test_helpers::*;
+    use super::*;
 
-#[tokio::test]
-async fn test_execute_with_root_excluded_preserves_dependency_classification() {
-    // This test verifies that when the root project is excluded using -e flag,
-    // the dependency classification (direct vs transitive) is preserved.
-    // See: https://github.com/Taketo-Yoda/uv-sbom/issues/206
-    let lockfile_content = r#"
-[[package]]
-name = "myproject"
-version = "1.0.0"
-dependencies = [
-    { name = "requests" },
-    { name = "numpy" }
-]
+    #[test]
+    fn test_apply_exclusion_filters_empty_patterns() {
+        let use_case = UseCaseBuilder::default().build();
+        let packages = vec![pkg("pkg1", "1.0.0"), pkg("pkg2", "2.0.0")];
 
-[[package]]
-name = "requests"
-version = "2.31.0"
-dependencies = [
-    { name = "urllib3" },
-    { name = "certifi" }
-]
+        let filtered = use_case
+            .apply_exclusion_filters(packages, &default_request())
+            .unwrap();
 
-[[package]]
-name = "urllib3"
-version = "1.26.0"
+        assert_eq!(filtered.len(), 2);
+    }
 
-[[package]]
-name = "certifi"
-version = "2024.8.30"
+    #[test]
+    fn test_apply_exclusion_filters_with_patterns() {
+        let use_case = UseCaseBuilder::default().build();
+        let packages = vec![
+            pkg("requests", "1.0.0"),
+            pkg("urllib3", "2.0.0"),
+            pkg("certifi", "3.0.0"),
+        ];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .exclude_patterns(vec!["requests".to_string()])
+            .build()
+            .unwrap();
 
-[[package]]
-name = "numpy"
-version = "1.26.0"
-"#;
+        let filtered = use_case
+            .apply_exclusion_filters(packages, &request)
+            .unwrap();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: lockfile_content.to_string(),
-            },
-            MockProjectConfigReader {
-                project_name: "myproject".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
+        assert_eq!(filtered.len(), 2);
+        assert!(!filtered.iter().any(|p| p.name() == "requests"));
+    }
+
+    #[test]
+    fn test_apply_exclusion_filters_all_excluded_error() {
+        let use_case = UseCaseBuilder::default().build();
+        let packages = vec![pkg("pkg1", "1.0.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .exclude_patterns(vec!["pkg1".to_string()])
+            .build()
+            .unwrap();
+
+        let result = use_case.apply_exclusion_filters(packages, &request);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("All 1 package(s) were excluded"));
+    }
+}
+
+mod tests_dependencies {
+    use super::test_helpers::*;
+    use super::*;
+
+    #[test]
+    fn test_analyze_dependencies_disabled() {
+        let use_case = UseCaseBuilder::default().build();
+        let dependency_map: HashMap<String, Vec<String>> = HashMap::new();
+
+        let result = use_case
+            .analyze_dependencies_if_requested(&default_request(), &dependency_map)
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_analyze_dependencies_enabled() {
+        let use_case = UseCaseBuilder::default()
+            .with_project_name("myproject")
+            .build();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .include_dependency_info(true)
+            .build()
+            .unwrap();
+        let dependency_map = HashMap::from([
+            ("myproject".to_string(), vec!["requests".to_string()]),
+            ("requests".to_string(), vec![]),
+        ]);
+
+        let result = use_case
+            .analyze_dependencies_if_requested(&request, &dependency_map)
+            .unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().direct_dependency_count(), 1);
+    }
+}
+
+mod tests_response {
+    use super::test_helpers::*;
+    use super::*;
+
+    #[test]
+    fn test_build_response() {
+        let use_case = UseCaseBuilder::default().build();
+        let enriched_packages = vec![EnrichedPackage::new(
+            pkg("test-pkg", "1.0.0"),
+            Some("MIT".to_string()),
+            Some("Test description".to_string()),
+        )];
+
+        let response = use_case.build_response(enriched_packages, None, None, None, None);
+
+        assert_eq!(response.enriched_packages.len(), 1);
+        assert!(response.dependency_graph.is_none());
+        assert!(response.vulnerability_check_result.is_none());
+        assert!(!response.metadata.serial_number().is_empty());
+        assert!(!response.metadata.timestamp().is_empty());
+    }
+
+    #[test]
+    fn test_build_response_with_threshold_exceeded() {
+        use crate::sbom_generation::domain::vulnerability::{CvssScore, Severity, Vulnerability};
+
+        let use_case = UseCaseBuilder::default().build();
+        let enriched_packages = vec![EnrichedPackage::new(
+            pkg("test-pkg", "1.0.0"),
+            Some("MIT".to_string()),
+            Some("Test description".to_string()),
+        )];
+        let vuln = Vulnerability::new(
+            "CVE-2024-001".to_string(),
+            Some(CvssScore::new(9.0).unwrap()),
+            Severity::Critical,
             None,
-            Locale::default(),
-        );
-
-    // Request with root project excluded but dependency info enabled
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .include_dependency_info(true)
-        .exclude_patterns(vec!["myproject".to_string()])
-        .build()
+            None,
+        )
         .unwrap();
+        let pkg_vulns = crate::sbom_generation::domain::PackageVulnerabilities::new(
+            "test-pkg".to_string(),
+            "1.0.0".to_string(),
+            vec![vuln],
+        );
+        let check_result = VulnerabilityCheckResult {
+            above_threshold: vec![pkg_vulns],
+            below_threshold: vec![],
+            threshold_exceeded: true,
+        };
 
-    let response = use_case.execute(request).await.unwrap();
+        let response =
+            use_case.build_response(enriched_packages, None, Some(check_result), None, None);
 
-    // Root project should be excluded from packages
-    // Original: myproject, requests, numpy, urllib3, certifi = 5 packages
-    // After excluding myproject: 4 packages
-    assert_eq!(response.enriched_packages.len(), 4);
-    assert!(!response
-        .enriched_packages
-        .iter()
-        .any(|p| p.package.name() == "myproject"));
+        assert!(response.has_vulnerabilities_above_threshold);
+        assert!(
+            response
+                .vulnerability_check_result
+                .unwrap()
+                .threshold_exceeded
+        );
+    }
 
-    // Dependency graph should still be present
-    assert!(response.dependency_graph.is_some());
-    let graph = response.dependency_graph.unwrap();
+    #[test]
+    fn test_build_response_with_threshold_not_exceeded() {
+        use crate::sbom_generation::domain::vulnerability::{CvssScore, Severity, Vulnerability};
 
-    // Direct dependencies should be preserved (requests, numpy)
-    assert_eq!(graph.direct_dependency_count(), 2);
-    let direct_dep_names: Vec<&str> = graph
-        .direct_dependencies()
-        .iter()
-        .map(|p| p.as_str())
-        .collect();
-    assert!(direct_dep_names.contains(&"requests"));
-    assert!(direct_dep_names.contains(&"numpy"));
+        let use_case = UseCaseBuilder::default().build();
+        let enriched_packages = vec![EnrichedPackage::new(
+            pkg("test-pkg", "1.0.0"),
+            Some("MIT".to_string()),
+            Some("Test description".to_string()),
+        )];
+        let vuln = Vulnerability::new(
+            "CVE-2024-001".to_string(),
+            Some(CvssScore::new(3.0).unwrap()),
+            Severity::Low,
+            None,
+            None,
+        )
+        .unwrap();
+        let pkg_vulns = crate::sbom_generation::domain::PackageVulnerabilities::new(
+            "test-pkg".to_string(),
+            "1.0.0".to_string(),
+            vec![vuln],
+        );
+        let check_result = VulnerabilityCheckResult {
+            above_threshold: vec![],
+            below_threshold: vec![pkg_vulns],
+            threshold_exceeded: false,
+        };
 
-    // Transitive dependencies should be preserved (urllib3, certifi)
-    assert_eq!(graph.transitive_dependency_count(), 2);
+        let response =
+            use_case.build_response(enriched_packages, None, Some(check_result), None, None);
+
+        assert!(!response.has_vulnerabilities_above_threshold);
+        assert!(
+            !response
+                .vulnerability_check_result
+                .unwrap()
+                .threshold_exceeded
+        );
+    }
 }
 
-#[tokio::test]
-async fn test_execute_without_root_excluded_baseline() {
-    // Baseline test: without exclusion, dependency classification should work
-    let lockfile_content = r#"
-[[package]]
-name = "myproject"
-version = "1.0.0"
-dependencies = [
-    { name = "requests" }
-]
+mod tests_vulnerabilities {
+    use super::test_helpers::*;
+    use super::*;
 
-[[package]]
-name = "requests"
-version = "2.31.0"
-dependencies = [
-    { name = "urllib3" }
-]
+    #[tokio::test]
+    async fn test_fetch_license_info() {
+        let use_case = UseCaseBuilder::default().build();
+        let packages = vec![pkg("pkg1", "1.0.0"), pkg("pkg2", "2.0.0")];
 
-[[package]]
-name = "urllib3"
-version = "1.26.0"
-"#;
+        let enriched = use_case.fetch_license_info(packages).await.unwrap();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: lockfile_content.to_string(),
-            },
-            MockProjectConfigReader {
-                project_name: "myproject".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
+        assert_eq!(enriched.len(), 2);
+        assert!(enriched[0].license.is_some());
+        assert_eq!(enriched[0].license.as_ref().unwrap(), "MIT");
+    }
 
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .include_dependency_info(true)
-        .build()
-        .unwrap();
+    #[tokio::test]
+    async fn test_check_vulnerabilities_if_requested_disabled() {
+        let use_case = UseCaseBuilder::default().with_vuln_repo().build();
+        let packages = vec![pkg("pkg1", "1.0.0")];
 
-    let response = use_case.execute(request).await.unwrap();
+        let result = use_case
+            .check_vulnerabilities_if_requested(&default_request(), &packages)
+            .await
+            .unwrap();
 
-    assert_eq!(response.enriched_packages.len(), 3);
-    assert!(response.dependency_graph.is_some());
+        assert!(result.is_none());
+    }
 
-    let graph = response.dependency_graph.unwrap();
-    assert_eq!(graph.direct_dependency_count(), 1);
-    assert_eq!(graph.transitive_dependency_count(), 1);
+    #[tokio::test]
+    async fn test_check_vulnerabilities_if_requested_enabled() {
+        let use_case = UseCaseBuilder::default().with_vuln_repo().build();
+        let packages = vec![pkg("pkg1", "1.0.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_cve(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_vulnerabilities_if_requested(&request, &packages)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_build_threshold_config_none() {
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_cve(true)
+            .build()
+            .unwrap();
+
+        let config = TestUseCase::build_threshold_config(&request);
+
+        assert_eq!(config, ThresholdConfig::None);
+    }
+
+    #[test]
+    fn test_build_threshold_config_severity() {
+        use crate::sbom_generation::domain::vulnerability::Severity;
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_cve(true)
+            .severity_threshold_opt(Some(Severity::High))
+            .build()
+            .unwrap();
+
+        let config = TestUseCase::build_threshold_config(&request);
+
+        assert_eq!(config, ThresholdConfig::Severity(Severity::High));
+    }
+
+    #[test]
+    fn test_build_threshold_config_cvss() {
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_cve(true)
+            .cvss_threshold_opt(Some(7.0))
+            .build()
+            .unwrap();
+
+        let config = TestUseCase::build_threshold_config(&request);
+
+        assert_eq!(config, ThresholdConfig::Cvss(7.0));
+    }
 }
 
-#[tokio::test]
-async fn test_execute_exclude_non_root_preserves_dependency_classification() {
-    // Test that excluding a non-root package still works correctly
-    let lockfile_content = r#"
-[[package]]
-name = "myproject"
-version = "1.0.0"
-dependencies = [
-    { name = "requests" },
-    { name = "pytest" }
-]
+// Tests for issue #206: Excluding root project preserves dependency classification
+mod tests_regression {
+    use super::test_helpers::*;
+    use super::*;
 
-[[package]]
-name = "requests"
-version = "2.31.0"
-dependencies = [
-    { name = "urllib3" }
-]
+    #[tokio::test]
+    async fn test_execute_with_root_excluded_preserves_dependency_classification() {
+        let packages = vec![
+            pkg("myproject", "1.0.0"),
+            pkg("requests", "2.31.0"),
+            pkg("urllib3", "1.26.0"),
+            pkg("certifi", "2024.8.30"),
+            pkg("numpy", "1.26.0"),
+        ];
+        let deps = HashMap::from([
+            (
+                "myproject".to_string(),
+                vec!["requests".to_string(), "numpy".to_string()],
+            ),
+            (
+                "requests".to_string(),
+                vec!["urllib3".to_string(), "certifi".to_string()],
+            ),
+            ("urllib3".to_string(), vec![]),
+            ("certifi".to_string(), vec![]),
+            ("numpy".to_string(), vec![]),
+        ]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_project_name("myproject")
+            .build();
 
-[[package]]
-name = "urllib3"
-version = "1.26.0"
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .include_dependency_info(true)
+            .exclude_patterns(vec!["myproject".to_string()])
+            .build()
+            .unwrap();
 
-[[package]]
-name = "pytest"
-version = "7.0.0"
-"#;
+        let response = use_case.execute(request).await.unwrap();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, MockVulnerabilityRepository> =
-        GenerateSbomUseCase::new(
-            MockLockfileReader {
-                content: lockfile_content.to_string(),
-            },
-            MockProjectConfigReader {
-                project_name: "myproject".to_string(),
-            },
-            MockLicenseRepository,
-            MockProgressReporter,
-            None,
-            Locale::default(),
-        );
+        assert_eq!(response.enriched_packages.len(), 4);
+        assert!(!response
+            .enriched_packages
+            .iter()
+            .any(|p| p.package.name() == "myproject"));
+        assert!(response.dependency_graph.is_some());
+        let graph = response.dependency_graph.unwrap();
+        assert_eq!(graph.direct_dependency_count(), 2);
+        let direct_dep_names: Vec<&str> = graph
+            .direct_dependencies()
+            .iter()
+            .map(|p| p.as_str())
+            .collect();
+        assert!(direct_dep_names.contains(&"requests"));
+        assert!(direct_dep_names.contains(&"numpy"));
+        assert_eq!(graph.transitive_dependency_count(), 2);
+    }
 
-    // Exclude pytest (a direct dependency)
-    let request = SbomRequest::builder()
-        .project_path("/test/project")
-        .include_dependency_info(true)
-        .exclude_patterns(vec!["pytest".to_string()])
-        .build()
-        .unwrap();
+    #[tokio::test]
+    async fn test_execute_without_root_excluded_baseline() {
+        let packages = vec![
+            pkg("myproject", "1.0.0"),
+            pkg("requests", "2.31.0"),
+            pkg("urllib3", "1.26.0"),
+        ];
+        let deps = HashMap::from([
+            ("myproject".to_string(), vec!["requests".to_string()]),
+            ("requests".to_string(), vec!["urllib3".to_string()]),
+            ("urllib3".to_string(), vec![]),
+        ]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_project_name("myproject")
+            .build();
 
-    let response = use_case.execute(request).await.unwrap();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .include_dependency_info(true)
+            .build()
+            .unwrap();
 
-    // pytest should be excluded from packages
-    // Original: myproject, requests, urllib3, pytest = 4 packages
-    // After excluding pytest: 3 packages
-    assert_eq!(response.enriched_packages.len(), 3);
-    assert!(!response
-        .enriched_packages
-        .iter()
-        .any(|p| p.package.name() == "pytest"));
+        let response = use_case.execute(request).await.unwrap();
 
-    // Dependency graph should still show both direct deps (requests and pytest are both direct)
-    // but pytest won't be in the filtered package list
-    assert!(response.dependency_graph.is_some());
-    let graph = response.dependency_graph.unwrap();
-    assert_eq!(graph.direct_dependency_count(), 2); // requests and pytest are direct deps
+        assert_eq!(response.enriched_packages.len(), 3);
+        assert!(response.dependency_graph.is_some());
+        let graph = response.dependency_graph.unwrap();
+        assert_eq!(graph.direct_dependency_count(), 1);
+        assert_eq!(graph.transitive_dependency_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_exclude_non_root_preserves_dependency_classification() {
+        let packages = vec![
+            pkg("myproject", "1.0.0"),
+            pkg("requests", "2.31.0"),
+            pkg("urllib3", "1.26.0"),
+            pkg("pytest", "7.0.0"),
+        ];
+        let deps = HashMap::from([
+            (
+                "myproject".to_string(),
+                vec!["requests".to_string(), "pytest".to_string()],
+            ),
+            ("requests".to_string(), vec!["urllib3".to_string()]),
+            ("urllib3".to_string(), vec![]),
+            ("pytest".to_string(), vec![]),
+        ]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_project_name("myproject")
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .include_dependency_info(true)
+            .exclude_patterns(vec!["pytest".to_string()])
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 3);
+        assert!(!response
+            .enriched_packages
+            .iter()
+            .any(|p| p.package.name() == "pytest"));
+        assert!(response.dependency_graph.is_some());
+        let graph = response.dependency_graph.unwrap();
+        assert_eq!(graph.direct_dependency_count(), 2);
+    }
 }


### PR DESCRIPTION
## Summary
- Replace `MockLockfileReader` TOML Fake with a direct-data stub that accepts `Vec<Package>` and `HashMap<String, Vec<String>>` directly, removing ~40 lines of adapter-layer logic duplicated inside the test double
- Add `mod test_helpers` with a `UseCaseBuilder` builder pattern, `TestUseCase` type alias, `default_request()`, and `pkg()` helpers — eliminating ~20 repeated `GenerateSbomUseCase::new(...)` blocks
- Group all 23 tests into 6 concern-based sub-modules (`tests_execute`, `tests_exclusion`, `tests_dependencies`, `tests_response`, `tests_vulnerabilities`, `tests_regression`)

## Related Issue
Closes #514

## Changes Made
- `MockLockfileReader`: removed TOML parsing; now a proper stub returning pre-built data
- `mod test_helpers`: `TestUseCase` alias, `UseCaseBuilder`, `default_request()`, `pkg()`
- All TOML raw-string fixtures replaced with direct `vec![pkg("name", "version"), ...]` construction
- `read_and_parse_lockfile_for_member`: replaced `unimplemented!()` with proper stub implementation
- File reduced from 1015 to 705 lines (−31%)

## Test Plan
- [x] `cargo test --all` passes (23/23 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)