### PR TITLE
chore(release): prepare v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-02
+
 ### Added
 - **Dependency Chains subsection in Markdown Resolution Guide**: When at least one vulnerable package is introduced via a multi-hop dependency chain (chain length > 2), a "### Dependency Chains" subsection is now rendered after the vulnerability resolution table. Each chain is displayed as `` `node1` → `node2` → **`pkg version`** ⚠️ ``. The subsection is omitted when all vulnerabilities are direct introductions (#499)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.2.0"
+version = "2.3.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.2.0"
+UV_SBOM_VERSION = "2.3.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v2.3.0
- Update version numbers in all required files
- Update CHANGELOG with release date

## Version Files Updated
- `Cargo.toml`: version = "2.3.0"
- `python-wrapper/pyproject.toml`: version = "2.3.0"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "2.3.0"

## CHANGELOG
- Converted [Unreleased] to [2.3.0] - 2026-05-02
- Added empty [Unreleased] section

### Changes in this release
**Added**
- Dependency Chains subsection in Markdown Resolution Guide (#499)

**Security**
- Updated `rustls-webpki` to 0.103.13 to fix GHSA-82j2-j2ch-gfr8 (#508)

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] All version strings are consistent

## Post-Merge Manual Steps
After merging this PR into `develop`:
1. Open a PR: `develop` → `main`
2. Merge the PR to main
3. Create tag: `git tag v2.3.0`
4. Push tag: `git push origin v2.3.0`
5. Verify CI release workflow completes successfully

Closes #549

---
Generated with [Claude Code](https://claude.com/claude-code)