### PR TITLE
feat(ports): add MaintenanceRepository port and AbandonedPackages read models

### DIFF
--- a/src/application/read_models/abandoned_package.rs
+++ b/src/application/read_models/abandoned_package.rs
@@ -18,9 +18,16 @@ pub struct AbandonedPackageView {
     pub name: String,
     /// Package version as listed in the lockfile
     pub version: String,
-    /// Date of the most recent upstream release
+    /// Date of the most recent upstream release.
+    ///
+    /// Packages whose `MaintenanceInfo.last_release_date` is `None` (unknown release
+    /// date) are excluded at report construction time and never appear in this struct.
     pub last_release_date: NaiveDate,
-    /// Number of days between `last_release_date` and the report's reference date
+    /// Number of days between `last_release_date` and the report's reference date.
+    ///
+    /// Uses `i64` to match `chrono::Duration::num_days()` return type directly,
+    /// avoiding a lossy cast in the use case. Negative values are theoretically
+    /// possible for future-dated releases but are never classified as abandoned.
     pub days_inactive: i64,
     /// Whether the package is a direct dependency of the current project
     pub is_direct: bool,
@@ -32,12 +39,25 @@ pub struct AbandonedPackageView {
 /// threshold used to classify them. The threshold is captured so downstream
 /// formatters can render messages like "abandoned (>730 days inactive)".
 #[allow(dead_code)]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct AbandonedPackagesReport {
     /// Packages classified as abandoned
     pub packages: Vec<AbandonedPackageView>,
     /// Inactivity threshold (in days) used to build this report
     pub threshold_days: u64,
+}
+
+impl Default for AbandonedPackagesReport {
+    /// Returns a report with no packages and the standard 730-day threshold.
+    ///
+    /// The threshold matches the application default configured in `MergedConfig`.
+    /// Use explicit construction when a different threshold is required.
+    fn default() -> Self {
+        Self {
+            packages: Vec::new(),
+            threshold_days: 730,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -84,7 +104,7 @@ mod tests {
         assert_eq!(report.total_count(), 0);
         assert_eq!(report.direct_count(), 0);
         assert_eq!(report.transitive_count(), 0);
-        assert_eq!(report.threshold_days, 0);
+        assert_eq!(report.threshold_days, 730);
     }
 
     #[test]

--- a/src/application/read_models/abandoned_package.rs
+++ b/src/application/read_models/abandoned_package.rs
@@ -1,0 +1,133 @@
+//! Abandoned package view structs for read model
+//!
+//! These structs provide a query-optimized view of abandoned-package data
+//! with pre-computed inactivity duration for efficient reporting.
+
+use chrono::NaiveDate;
+
+/// View representation of a single abandoned package
+///
+/// All fields are pre-computed at construction time so consumers (formatters,
+/// presenters) do not need to perform date arithmetic or re-derive directness.
+// Consumed by the Markdown formatter (#556) and use case integration (#555).
+// Suppressed here because this is a foundational subtask with no binary consumer yet.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbandonedPackageView {
+    /// Package name as listed in the lockfile
+    pub name: String,
+    /// Package version as listed in the lockfile
+    pub version: String,
+    /// Date of the most recent upstream release
+    pub last_release_date: NaiveDate,
+    /// Number of days between `last_release_date` and the report's reference date
+    pub days_inactive: i64,
+    /// Whether the package is a direct dependency of the current project
+    pub is_direct: bool,
+}
+
+/// View representation of an abandoned-packages report
+///
+/// Holds the pre-categorized list of abandoned packages along with the
+/// threshold used to classify them. The threshold is captured so downstream
+/// formatters can render messages like "abandoned (>730 days inactive)".
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default)]
+pub struct AbandonedPackagesReport {
+    /// Packages classified as abandoned
+    pub packages: Vec<AbandonedPackageView>,
+    /// Inactivity threshold (in days) used to build this report
+    pub threshold_days: u64,
+}
+
+#[allow(dead_code)]
+impl AbandonedPackagesReport {
+    /// Returns the total number of abandoned packages.
+    pub fn total_count(&self) -> usize {
+        self.packages.len()
+    }
+
+    /// Returns the number of abandoned packages that are direct dependencies.
+    pub fn direct_count(&self) -> usize {
+        self.packages.iter().filter(|p| p.is_direct).count()
+    }
+
+    /// Returns the number of abandoned packages that are transitive dependencies.
+    pub fn transitive_count(&self) -> usize {
+        self.packages.iter().filter(|p| !p.is_direct).count()
+    }
+
+    /// Returns `true` when no packages were classified as abandoned.
+    pub fn is_empty(&self) -> bool {
+        self.packages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_view(name: &str, days_inactive: i64, is_direct: bool) -> AbandonedPackageView {
+        AbandonedPackageView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+            days_inactive,
+            is_direct,
+        }
+    }
+
+    #[test]
+    fn test_default_report_is_empty() {
+        let report = AbandonedPackagesReport::default();
+        assert!(report.is_empty());
+        assert_eq!(report.total_count(), 0);
+        assert_eq!(report.direct_count(), 0);
+        assert_eq!(report.transitive_count(), 0);
+        assert_eq!(report.threshold_days, 0);
+    }
+
+    #[test]
+    fn test_total_count() {
+        let report = AbandonedPackagesReport {
+            packages: vec![
+                make_view("a", 400, true),
+                make_view("b", 500, false),
+                make_view("c", 600, false),
+            ],
+            threshold_days: 365,
+        };
+        assert_eq!(report.total_count(), 3);
+        assert!(!report.is_empty());
+    }
+
+    #[test]
+    fn test_direct_and_transitive_counts() {
+        let report = AbandonedPackagesReport {
+            packages: vec![
+                make_view("a", 400, true),
+                make_view("b", 500, true),
+                make_view("c", 600, false),
+            ],
+            threshold_days: 365,
+        };
+        assert_eq!(report.direct_count(), 2);
+        assert_eq!(report.transitive_count(), 1);
+    }
+
+    #[test]
+    fn test_view_clone_and_eq() {
+        let a = make_view("requests", 800, true);
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_threshold_days_preserved() {
+        let report = AbandonedPackagesReport {
+            packages: vec![],
+            threshold_days: 730,
+        };
+        assert_eq!(report.threshold_days, 730);
+    }
+}

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains view-optimized structs that provide
 //! a denormalized representation of domain data for queries.
 
+pub mod abandoned_package;
 pub mod component_view;
 pub mod dependency_view;
 pub mod license_compliance_view;
@@ -12,6 +13,8 @@ pub mod sbom_read_model_builder;
 pub mod upgrade_recommendation_view;
 pub mod vulnerability_view;
 
+#[allow(unused_imports)]
+pub use abandoned_package::{AbandonedPackageView, AbandonedPackagesReport};
 #[allow(unused_imports)]
 pub use component_view::{ComponentView, LicenseView};
 #[allow(unused_imports)]

--- a/src/ports/outbound/maintenance_repository.rs
+++ b/src/ports/outbound/maintenance_repository.rs
@@ -1,0 +1,125 @@
+use crate::shared::Result;
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+/// Maintenance information for a single package
+///
+/// Captures the latest signal of upstream activity used to detect
+/// abandoned/unmaintained packages.
+///
+/// # Notes
+/// - `last_release_date` is `None` when the package has no published releases
+///   on the upstream registry (extremely rare for installed packages, but
+///   possible for yanked-only or pre-release-only packages).
+// Consumed by the PyPI maintenance adapter (#553) and use case integration (#555).
+// Suppressed here because this is a foundational subtask with no binary consumer yet.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaintenanceInfo {
+    /// Date of the most recent release on the upstream registry (UTC).
+    /// `None` when no release date is available.
+    pub last_release_date: Option<NaiveDate>,
+}
+
+/// Port for fetching package maintenance information from external sources
+///
+/// This trait defines the interface for querying upstream registries
+/// (e.g., PyPI JSON API) to determine when a package was last released,
+/// which is used to detect abandoned/unmaintained dependencies.
+///
+/// # Security Considerations
+/// - Implementations must not send internal/private package names to public APIs
+/// - Implementations should implement rate limiting to prevent DoS
+/// - Implementations should have timeout mechanisms
+///
+/// # Implementation Notes
+/// - All methods are async to enable parallel fetching across packages
+/// - Implementations should treat "package not found" as an error, not as
+///   `MaintenanceInfo { last_release_date: None }`
+///
+/// # Example
+/// ```no_run
+/// # use uv_sbom::ports::outbound::MaintenanceRepository;
+/// # use async_trait::async_trait;
+/// # struct MockRepo;
+/// # #[async_trait]
+/// # impl MaintenanceRepository for MockRepo {
+/// #     async fn fetch_maintenance_info(
+/// #         &self,
+/// #         _package_name: &str,
+/// #     ) -> uv_sbom::shared::Result<uv_sbom::ports::outbound::MaintenanceInfo> {
+/// #         Ok(uv_sbom::ports::outbound::MaintenanceInfo { last_release_date: None })
+/// #     }
+/// # }
+/// # async fn example() -> uv_sbom::shared::Result<()> {
+/// # let repo = MockRepo;
+/// let info = repo.fetch_maintenance_info("requests").await?;
+/// if let Some(date) = info.last_release_date {
+///     println!("Last released on {}", date);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+// Implemented by PyPiMaintenanceRepository in #553; used in GenerateSbomUseCase in #555.
+#[allow(dead_code)]
+#[async_trait]
+pub trait MaintenanceRepository: Send + Sync {
+    /// Fetches maintenance information for a single package
+    ///
+    /// # Arguments
+    /// * `package_name` - Canonical package name (case-insensitive on PyPI)
+    ///
+    /// # Returns
+    /// `MaintenanceInfo` describing the package's most recent upstream activity.
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Network request fails
+    /// - Package is not found on the upstream registry
+    /// - API response is invalid
+    /// - Timeout occurs
+    async fn fetch_maintenance_info(&self, package_name: &str) -> Result<MaintenanceInfo>;
+}
+
+/// Dummy implementation of MaintenanceRepository for the unit type.
+/// Mirrors the `impl ... for ()` pattern in `VulnerabilityRepository`,
+/// allowing `Option<()>` when no maintenance checking is configured.
+#[async_trait]
+impl MaintenanceRepository for () {
+    async fn fetch_maintenance_info(&self, _package_name: &str) -> Result<MaintenanceInfo> {
+        unreachable!("MaintenanceRepository not configured")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_maintenance_info_with_date() {
+        let info = MaintenanceInfo {
+            last_release_date: Some(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()),
+        };
+        assert_eq!(
+            info.last_release_date,
+            Some(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_maintenance_info_without_date() {
+        let info = MaintenanceInfo {
+            last_release_date: None,
+        };
+        assert!(info.last_release_date.is_none());
+    }
+
+    #[test]
+    fn test_maintenance_info_clone_and_eq() {
+        let a = MaintenanceInfo {
+            last_release_date: Some(NaiveDate::from_ymd_opt(2025, 6, 1).unwrap()),
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -6,6 +6,7 @@ pub mod enriched_package;
 pub mod formatter;
 pub mod license_repository;
 pub mod lockfile_reader;
+pub mod maintenance_repository;
 pub mod output_presenter;
 pub mod progress_reporter;
 pub mod project_config_reader;
@@ -17,6 +18,9 @@ pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};
 pub use lockfile_reader::{LockfileParseResult, LockfileReader};
+// Note: Will be used in subsequent subtasks (abandoned package detection)
+#[allow(unused_imports)]
+pub use maintenance_repository::{MaintenanceInfo, MaintenanceRepository};
 pub use output_presenter::OutputPresenter;
 pub use progress_reporter::{ProgressCallback, ProgressReporter};
 pub use project_config_reader::ProjectConfigReader;


### PR DESCRIPTION
## Summary
- Define `MaintenanceRepository` outbound port trait and `MaintenanceInfo` struct for querying upstream registry maintenance data
- Define `AbandonedPackageView` and `AbandonedPackagesReport` read models for the abandoned package detection feature
- Register and re-export both modules through their respective `mod.rs` files

## Related Issue
Closes #552
Part of #511

## Changes Made
- **New**: `src/ports/outbound/maintenance_repository.rs` — `MaintenanceInfo` struct and `MaintenanceRepository` async trait with `Send + Sync` bounds; includes dummy `impl for ()` following the existing `VulnerabilityRepository` pattern
- **New**: `src/application/read_models/abandoned_package.rs` — `AbandonedPackageView` and `AbandonedPackagesReport` with helper methods (`total_count`, `direct_count`, `transitive_count`, `is_empty`)
- **Modified**: `src/ports/outbound/mod.rs` — module declaration and re-export for `MaintenanceInfo`, `MaintenanceRepository`
- **Modified**: `src/application/read_models/mod.rs` — module declaration and re-export for `AbandonedPackageView`, `AbandonedPackagesReport`

## Notes
- `#[allow(dead_code)]` is applied to the new types because they have no binary consumer until subtasks #553–#556 are merged. This is a foundational subtask in the planned split of #511; the suppression is intentional and tracked.
- CHANGELOG not updated — this PR introduces no user-visible behavior (pure type definitions). CHANGELOG entry will be added in the final feature subtask.

## Test Plan
- [x] `cargo test --all` passes (8 new unit tests added across both files)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)