### PR TITLE
feat(cli): add --check-abandoned and --abandoned-threshold-days flags with config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
+
 ## [2.3.0] - 2026-05-02
 
 ### Added

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -35,6 +35,11 @@ pub struct SbomRequest {
     /// Whether to suggest direct dependency upgrade versions to fix transitive vulnerabilities.
     /// Only meaningful when `check_cve` is true.
     pub suggest_fix: bool,
+    /// Whether to check for abandoned/unmaintained packages.
+    pub check_abandoned: bool,
+    /// Inactivity threshold in days for abandoned-package detection.
+    /// Only meaningful when `check_abandoned` is true.
+    pub abandoned_threshold_days: u64,
     /// Output locale for human-readable formats
     pub locale: Locale,
 }
@@ -97,6 +102,8 @@ pub struct SbomRequestBuilder {
     check_license: bool,
     license_policy: Option<LicensePolicy>,
     suggest_fix: bool,
+    check_abandoned: bool,
+    abandoned_threshold_days: u64,
     locale: Locale,
 }
 
@@ -124,6 +131,8 @@ impl SbomRequestBuilder {
             check_license: false,
             license_policy: None,
             suggest_fix: false,
+            check_abandoned: false,
+            abandoned_threshold_days: 730,
             locale: Locale::default(),
         }
     }
@@ -202,6 +211,18 @@ impl SbomRequestBuilder {
         self
     }
 
+    /// Sets whether to check for abandoned/unmaintained packages.
+    pub fn check_abandoned(mut self, check: bool) -> Self {
+        self.check_abandoned = check;
+        self
+    }
+
+    /// Sets the inactivity threshold in days for abandoned-package detection.
+    pub fn abandoned_threshold_days(mut self, days: u64) -> Self {
+        self.abandoned_threshold_days = days;
+        self
+    }
+
     /// Sets the output locale for human-readable formats.
     pub fn locale(mut self, locale: Locale) -> Self {
         self.locale = locale;
@@ -230,6 +251,8 @@ impl SbomRequestBuilder {
             check_license: self.check_license,
             license_policy: self.license_policy,
             suggest_fix: self.suggest_fix,
+            check_abandoned: self.check_abandoned,
+            abandoned_threshold_days: self.abandoned_threshold_days,
             locale: self.locale,
         })
     }

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -74,6 +74,9 @@ where
     /// # Returns
     /// SbomResponse containing enriched packages, optional dependency graph, and metadata
     pub async fn execute(&self, request: SbomRequest) -> Result<SbomResponse> {
+        // Acknowledge --check-abandoned flag; detection logic ships in a follow-up issue.
+        self.notify_abandoned_check_deferred_if_requested(&request);
+
         // Step 1: Read and parse lockfile
         let (packages, dependency_map) = self.read_and_report_lockfile(&request)?;
 
@@ -129,6 +132,23 @@ where
             license_compliance_result,
             upgrade_recommendations,
         ))
+    }
+
+    /// Emits a localised notice when `check_abandoned` is enabled.
+    /// Detection logic ships in a follow-up issue; this method is the current consumer of
+    /// `request.check_abandoned` and `request.abandoned_threshold_days`.
+    fn notify_abandoned_check_deferred_if_requested(&self, request: &SbomRequest) {
+        if !request.check_abandoned {
+            return;
+        }
+        let msgs = Messages::for_locale(self.locale);
+        eprintln!(
+            "{}",
+            Messages::format(
+                msgs.info_check_abandoned_deferred,
+                &[&request.abandoned_threshold_days.to_string()]
+            )
+        );
     }
 
     /// Reads and parses the lockfile, reporting progress

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -702,4 +702,24 @@ mod tests_regression {
         let graph = response.dependency_graph.unwrap();
         assert_eq!(graph.direct_dependency_count(), 2);
     }
+
+    #[tokio::test]
+    async fn test_execute_with_check_abandoned_enabled_completes_successfully() {
+        // Exercises the check_abandoned=true path through execute().
+        // Detection is deferred; the use case must complete without error and
+        // consume both check_abandoned and abandoned_threshold_days.
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("certifi", "2024.8.30")])
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+        assert_eq!(response.enriched_packages.len(), 1);
+    }
 }

--- a/src/cli/config_resolver.rs
+++ b/src/cli/config_resolver.rs
@@ -18,6 +18,8 @@ pub struct MergedConfig {
     pub check_license: bool,
     pub license_policy: Option<LicensePolicy>,
     pub suggest_fix: bool,
+    pub check_abandoned: bool,
+    pub abandoned_threshold_days: u64,
 }
 
 /// Load a config file from an explicit path or via auto-discovery.
@@ -129,6 +131,8 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
                 check_license: args.check_license,
                 license_policy,
                 suggest_fix: args.suggest_fix,
+                check_abandoned: args.check_abandoned,
+                abandoned_threshold_days: args.abandoned_threshold_days.unwrap_or(730),
             };
         }
     };
@@ -233,6 +237,17 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
     // suggest_fix: CLI flag takes priority over config value
     let suggest_fix = args.suggest_fix || config.suggest_fix.unwrap_or(false);
 
+    // check_abandoned: CLI flag || config value (mirrors check_license / suggest_fix)
+    let check_abandoned = args.check_abandoned || config.check_abandoned.unwrap_or(false);
+
+    // abandoned_threshold_days: CLI > config > default 730.
+    // args.abandoned_threshold_days is Option<u64>: None when the flag was not passed, Some when
+    // the user explicitly provided a value. This cleanly expresses "not provided" vs "provided."
+    let abandoned_threshold_days = args
+        .abandoned_threshold_days
+        .or(config.abandoned_threshold_days)
+        .unwrap_or(730);
+
     MergedConfig {
         format,
         exclude_patterns,
@@ -243,6 +258,8 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
         check_license,
         license_policy,
         suggest_fix,
+        check_abandoned,
+        abandoned_threshold_days,
     }
 }
 
@@ -263,6 +280,8 @@ mod tests {
         assert!(result.severity_threshold.is_none());
         assert!(result.cvss_threshold.is_none());
         assert!(result.ignore_cves.is_empty());
+        assert!(!result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
     }
 
     #[test]
@@ -288,6 +307,8 @@ mod tests {
         assert_eq!(result.cvss_threshold, Some(7.0));
         assert_eq!(result.ignore_cves.len(), 1);
         assert_eq!(result.ignore_cves[0].id, "CVE-2024-1");
+        assert!(!result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
     }
 
     #[test]
@@ -543,5 +564,109 @@ mod tests {
         assert_eq!(result[0].id, "CVE-2024-1");
         assert_eq!(result[0].reason.as_deref(), Some("cli reason"));
         assert_eq!(result[1].id, "CVE-2024-2");
+    }
+
+    // --- check_abandoned / abandoned_threshold_days merge tests ---
+
+    #[test]
+    fn test_merge_config_check_abandoned_default_false() {
+        // No CLI flag, no config → defaults: check_abandoned=false, threshold=730
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(!result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
+    }
+
+    #[test]
+    fn test_merge_config_check_abandoned_from_config() {
+        // config: true, no CLI flag → check_abandoned=true
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            check_abandoned: Some(true),
+            abandoned_threshold_days: Some(365),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 365);
+    }
+
+    #[test]
+    fn test_merge_config_check_abandoned_cli_flag() {
+        // CLI: --check-abandoned, no config → check_abandoned=true, threshold=730 (default)
+        let args = Args::parse_from(["uv-sbom", "--check-abandoned"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
+    }
+
+    #[test]
+    fn test_merge_config_check_abandoned_cli_wins_over_config_false() {
+        // CLI flag + config: false → CLI wins, check_abandoned=true
+        let args = Args::parse_from(["uv-sbom", "--check-abandoned"]);
+        let config = Some(ConfigFile {
+            check_abandoned: Some(false),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.check_abandoned);
+    }
+
+    #[test]
+    fn test_merge_config_abandoned_threshold_from_config() {
+        // config: 365, no explicit CLI → uses config value
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            abandoned_threshold_days: Some(365),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.abandoned_threshold_days, 365);
+    }
+
+    #[test]
+    fn test_merge_config_abandoned_threshold_cli_wins() {
+        // CLI: --abandoned-threshold-days 90 + config: 365 → CLI wins (Some(90) overrides config)
+        let args = Args::parse_from([
+            "uv-sbom",
+            "--check-abandoned",
+            "--abandoned-threshold-days",
+            "90",
+        ]);
+        let config = Some(ConfigFile {
+            check_abandoned: Some(true),
+            abandoned_threshold_days: Some(365),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.abandoned_threshold_days, 90);
+    }
+
+    #[test]
+    fn test_merge_config_abandoned_threshold_default_when_neither() {
+        // No CLI, no config → default 730
+        let args = Args::parse_from(["uv-sbom"]);
+        let result = merge_config(&args, &None);
+        assert_eq!(result.abandoned_threshold_days, 730);
+    }
+
+    #[test]
+    fn test_merge_config_no_config_file_uses_cli_abandoned() {
+        // No config file; exercises the early-return branch
+        let args = Args::parse_from([
+            "uv-sbom",
+            "--check-abandoned",
+            "--abandoned-threshold-days",
+            "180",
+        ]);
+        let result = merge_config(&args, &None);
+        assert!(result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 180);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,6 +72,14 @@ pub struct Args {
     #[arg(long)]
     pub check_license: bool,
 
+    /// Check for abandoned/unmaintained packages (no upstream release within threshold days)
+    #[arg(long)]
+    pub check_abandoned: bool,
+
+    /// Inactivity threshold in days for abandoned-package detection (default: 730)
+    #[arg(long, value_name = "DAYS", requires = "check_abandoned")]
+    pub abandoned_threshold_days: Option<u64>,
+
     /// Allowed license patterns (comma-separated, requires --check-license)
     /// Supports wildcards: "MIT,Apache-2.0,BSD-*"
     #[arg(long, value_delimiter = ',', requires = "check_license")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,12 @@ const CONFIG_TEMPLATE: &str = r#"# uv-sbom configuration file
 
 # Enable workspace mode: generate per-member SBOMs for uv workspaces (equivalent to --workspace flag)
 # workspace: false
+
+# Enable abandoned/unmaintained package detection
+# check_abandoned: false
+
+# Inactivity threshold in days for abandoned-package detection (default: 730)
+# abandoned_threshold_days: 730
 "#;
 
 /// Generate a config template file in the specified directory.
@@ -101,6 +107,8 @@ pub struct ConfigFile {
     pub check_license: Option<bool>,
     pub license_policy: Option<LicensePolicyConfig>,
     pub suggest_fix: Option<bool>,
+    pub check_abandoned: Option<bool>,
+    pub abandoned_threshold_days: Option<u64>,
     /// Captures unknown fields for warnings.
     #[serde(flatten)]
     pub unknown_fields: HashMap<String, serde_yaml_ng::Value>,
@@ -365,6 +373,8 @@ another_unknown: value
         assert!(config.severity_threshold.is_none());
         assert!(config.cvss_threshold.is_none());
         assert!(config.ignore_cves.is_none());
+        assert!(config.check_abandoned.is_none());
+        assert!(config.abandoned_threshold_days.is_none());
         assert!(config.unknown_fields.is_empty());
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -89,6 +89,7 @@ pub struct Messages {
     pub warn_check_cve_no_effect: &'static str,
     pub warn_check_license_no_effect: &'static str,
     pub warn_verify_links_no_effect: &'static str,
+    pub info_check_abandoned_deferred: &'static str,
 
     // Section description paragraphs
     pub desc_sbom_report: &'static str,
@@ -259,6 +260,7 @@ static EN_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  Warning: --check-cve has no effect with JSON format.",
     warn_check_license_no_effect: "⚠️  Warning: --check-license has no effect with JSON format.",
     warn_verify_links_no_effect: "⚠️  Warning: --verify-links has no effect with JSON format.",
+    info_check_abandoned_deferred: "ℹ️  --check-abandoned acknowledged (threshold: {} days). Detection arrives in a future release.",
 
     // Section description paragraphs
     desc_sbom_report: "A comprehensive list of all software components and libraries included in this project.",
@@ -397,6 +399,7 @@ static JA_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  警告: JSON形式では --check-cve は効果がありません。",
     warn_check_license_no_effect: "⚠️  警告: JSON形式では --check-license は効果がありません。",
     warn_verify_links_no_effect: "⚠️  警告: JSON形式では --verify-links は効果がありません。",
+    info_check_abandoned_deferred: "ℹ️  --check-abandoned を確認しました（閾値: {} 日）。検出機能は今後のリリースで追加されます。",
 
     // Section description paragraphs
     desc_sbom_report: "このプロジェクトに含まれるすべてのソフトウェアコンポーネントとライブラリの一覧です。",

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,8 @@ async fn run(args: Args) -> Result<bool> {
         .check_license(merged.check_license)
         .license_policy(merged.license_policy)
         .suggest_fix(suggest_fix)
+        .check_abandoned(merged.check_abandoned)
+        .abandoned_threshold_days(merged.abandoned_threshold_days)
         .locale(locale)
         .build()?;
 
@@ -403,6 +405,8 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             .check_license(merged.check_license)
             .license_policy(merged.license_policy.clone())
             .suggest_fix(false)
+            .check_abandoned(merged.check_abandoned)
+            .abandoned_threshold_days(merged.abandoned_threshold_days)
             .locale(locale)
             .build()?;
 


### PR DESCRIPTION
## Summary
- Add `--check-abandoned` boolean flag and `--abandoned-threshold-days <DAYS>` integer flag to the CLI, following the same pattern as `--check-license` and `--suggest-fix`
- Add `check_abandoned` and `abandoned_threshold_days` fields to `ConfigFile`, `MergedConfig`, and `SbomRequest`, wired through both `main.rs` call sites
- Emits a localised notice (EN + JA via i18n) when `--check-abandoned` is used; full detection logic ships in a follow-up issue

## Related Issue
Closes #554

## Changes Made
- `src/cli/mod.rs`: add `check_abandoned: bool` and `abandoned_threshold_days: Option<u64>` to `Args`; `requires = "check_abandoned"` enforces the dependency at CLI level
- `src/config.rs`: add `Option<bool>` / `Option<u64>` fields to `ConfigFile`; update `CONFIG_TEMPLATE` with commented-out entries
- `src/cli/config_resolver.rs`: add fields to `MergedConfig`; resolve via `Option` chaining (CLI > config > default 730) — no magic-number comparison
- `src/application/dto/sbom_request.rs`: propagate fields through `SbomRequest` and its builder
- `src/main.rs`: pass `check_abandoned` and `abandoned_threshold_days` at both builder call sites
- `src/application/use_cases/generate_sbom/mod.rs`: add `notify_abandoned_check_deferred_if_requested` as the real consumer — reads both fields, emits localised i18n notice
- `src/i18n/mod.rs`: add `info_check_abandoned_deferred` key to `EN_MESSAGES` and `JA_MESSAGES`
- 8 new unit tests in `config_resolver` covering all resolution branches; 1 smoke test in `generate_sbom/tests.rs`
- `CHANGELOG.md`: add `[Unreleased]` entry

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (0 warnings)
- [x] `cargo test --all` passes (1255+ tests, 0 failed)
- [x] `--help` output shows both flags with correct descriptions and default value

---
Generated with [Claude Code](https://claude.com/claude-code)