### PR TITLE
feat(application): integrate abandoned package detection into GenerateSbomUseCase (#555)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -196,7 +196,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `MergedConfig` | `src/cli/config_resolver.rs` | Final resolved config (CLI > env > file > default) |
 | `ConfigFile` | `src/config.rs` | Raw deserialized config file struct |
 | `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
-| `GenerateSbomUseCase` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation |
+| `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555 |
+| `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
+- **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
 
 ## [2.3.0] - 2026-05-02
 

--- a/src/adapters/outbound/network/mod.rs
+++ b/src/adapters/outbound/network/mod.rs
@@ -5,7 +5,6 @@ mod pypi_client;
 mod pypi_maintenance_client;
 
 pub use caching_pypi_client::CachingPyPiLicenseRepository;
-// Note: This will be used in subsequent subtasks for CVE check feature
-#[allow(unused_imports)]
 pub use osv_client::OsvClient;
 pub use pypi_client::PyPiLicenseRepository;
+pub use pypi_maintenance_client::PyPiMaintenanceRepository;

--- a/src/adapters/outbound/network/pypi_maintenance_client.rs
+++ b/src/adapters/outbound/network/pypi_maintenance_client.rs
@@ -1,6 +1,3 @@
-// No binary consumer until Issue #555 wires this adapter into GenerateSbomUseCase.
-#![allow(dead_code)]
-
 use crate::ports::outbound::{MaintenanceInfo, MaintenanceRepository};
 use crate::shared::Result;
 use async_trait::async_trait;

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -1,3 +1,4 @@
+use crate::application::read_models::abandoned_package::AbandonedPackagesReport;
 use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
@@ -29,6 +30,9 @@ pub struct SbomResponse {
     /// Upgrade recommendations for vulnerable transitive dependencies.
     /// Populated only when `suggest_fix` was true in the request.
     pub upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
+    /// Abandoned packages report.
+    /// Populated only when `check_abandoned` was true in the request.
+    pub abandoned_packages_report: Option<AbandonedPackagesReport>,
 }
 
 impl SbomResponse {
@@ -46,6 +50,7 @@ pub struct SbomResponseBuilder {
     license_compliance_result: Option<LicenseComplianceResult>,
     has_license_violations: bool,
     upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
+    abandoned_packages_report: Option<AbandonedPackagesReport>,
 }
 
 impl SbomResponseBuilder {
@@ -59,6 +64,7 @@ impl SbomResponseBuilder {
             license_compliance_result: None,
             has_license_violations: false,
             upgrade_recommendations: None,
+            abandoned_packages_report: None,
         }
     }
 
@@ -108,6 +114,11 @@ impl SbomResponseBuilder {
         self
     }
 
+    pub fn abandoned_packages_report(mut self, report: AbandonedPackagesReport) -> Self {
+        self.abandoned_packages_report = Some(report);
+        self
+    }
+
     pub fn build(self) -> Result<SbomResponse, SbomError> {
         let metadata = self.metadata.ok_or_else(|| SbomError::Validation {
             message: "metadata is required".into(),
@@ -122,6 +133,7 @@ impl SbomResponseBuilder {
             license_compliance_result: self.license_compliance_result,
             has_license_violations: self.has_license_violations,
             upgrade_recommendations: self.upgrade_recommendations,
+            abandoned_packages_report: self.abandoned_packages_report,
         })
     }
 }

--- a/src/application/read_models/abandoned_package.rs
+++ b/src/application/read_models/abandoned_package.rs
@@ -9,9 +9,6 @@ use chrono::NaiveDate;
 ///
 /// All fields are pre-computed at construction time so consumers (formatters,
 /// presenters) do not need to perform date arithmetic or re-derive directness.
-// Consumed by the Markdown formatter (#556) and use case integration (#555).
-// Suppressed here because this is a foundational subtask with no binary consumer yet.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AbandonedPackageView {
     /// Package name as listed in the lockfile
@@ -38,7 +35,6 @@ pub struct AbandonedPackageView {
 /// Holds the pre-categorized list of abandoned packages along with the
 /// threshold used to classify them. The threshold is captured so downstream
 /// formatters can render messages like "abandoned (>730 days inactive)".
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AbandonedPackagesReport {
     /// Packages classified as abandoned
@@ -60,7 +56,6 @@ impl Default for AbandonedPackagesReport {
     }
 }
 
-#[allow(dead_code)]
 impl AbandonedPackagesReport {
     /// Returns the total number of abandoned packages.
     pub fn total_count(&self) -> usize {

--- a/src/application/use_cases/check_abandoned_packages.rs
+++ b/src/application/use_cases/check_abandoned_packages.rs
@@ -1,0 +1,176 @@
+use crate::ports::outbound::{MaintenanceInfo, MaintenanceRepository};
+use crate::sbom_generation::domain::Package;
+use crate::shared::Result;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Delay between maintenance info fetch requests (ms)
+const MAINTENANCE_FETCH_DELAY_MS: u64 = 100;
+
+/// Use case for fetching package maintenance information for a list of packages.
+///
+/// Handles progress bar display and sequential fetching, delegating the actual
+/// retrieval to the injected `MaintenanceRepository`. Errors per package are
+/// collected and surfaced as warnings rather than aborting the whole check.
+///
+/// # Type Parameters
+/// * `MR` - `MaintenanceRepository` implementation
+pub struct CheckAbandonedPackagesUseCase<MR: MaintenanceRepository> {
+    maintenance_repository: MR,
+}
+
+impl<MR: MaintenanceRepository> CheckAbandonedPackagesUseCase<MR> {
+    /// Creates a new `CheckAbandonedPackagesUseCase` with the given repository.
+    pub fn new(maintenance_repository: MR) -> Self {
+        Self {
+            maintenance_repository,
+        }
+    }
+
+    /// Fetches maintenance information for all packages with a progress bar.
+    ///
+    /// Returns `(results, errors)` where:
+    /// - `results` is `(Package, MaintenanceInfo)` pairs for successful fetches
+    /// - `errors` is `(package_name, error_message)` pairs for failed fetches
+    ///
+    /// Failed packages are omitted from `results` (no entry with `None` — callers
+    /// skip packages with unknown release dates anyway).
+    pub async fn fetch_with_progress(
+        &self,
+        packages: Vec<Package>,
+    ) -> Result<(Vec<(Package, MaintenanceInfo)>, Vec<(String, String)>)> {
+        let total = packages.len();
+        let progress_current = Arc::new(AtomicUsize::new(0));
+        let is_done = Arc::new(AtomicBool::new(false));
+
+        let progress_handle = {
+            let cur = progress_current.clone();
+            let done = is_done.clone();
+            thread::spawn(move || {
+                let pb = ProgressBar::new(total as u64);
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template("   {spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} - {msg}")
+                        .expect("Failed to set progress bar template")
+                        .progress_chars("=>-"),
+                );
+                pb.set_message("Fetching maintenance information..."); // i18n-ok: internal progress bar label
+                while !done.load(Ordering::Relaxed) {
+                    pb.set_position(cur.load(Ordering::Relaxed) as u64);
+                    thread::sleep(Duration::from_millis(50));
+                }
+                pb.finish_and_clear();
+            })
+        };
+
+        let mut results: Vec<(Package, MaintenanceInfo)> = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
+
+        for (idx, package) in packages.into_iter().enumerate() {
+            let name = package.name().to_string();
+            match self
+                .maintenance_repository
+                .fetch_maintenance_info(&name)
+                .await
+            {
+                Ok(info) => results.push((package, info)),
+                Err(e) => errors.push((name, e.to_string())),
+            }
+            progress_current.store(idx + 1, Ordering::Relaxed);
+            if idx < total - 1 {
+                tokio::time::sleep(Duration::from_millis(MAINTENANCE_FETCH_DELAY_MS)).await;
+            }
+        }
+
+        is_done.store(true, Ordering::Relaxed);
+        let _ = progress_handle.join();
+
+        Ok((results, errors))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::use_cases::test_doubles::MockMaintenanceRepository;
+    use chrono::NaiveDate;
+
+    fn pkg(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    fn info(date: Option<NaiveDate>) -> MaintenanceInfo {
+        MaintenanceInfo {
+            last_release_date: date,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_success() {
+        let repo = MockMaintenanceRepository::with_responses([Ok(info(Some(
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+        )))]);
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let (results, errors) = use_case
+            .fetch_with_progress(vec![pkg("requests", "2.31.0")])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(errors.is_empty());
+        assert_eq!(results[0].0.name(), "requests");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_error_collected() {
+        let repo = MockMaintenanceRepository::with_responses([Err("network error".to_string())]);
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let (results, errors) = use_case
+            .fetch_with_progress(vec![pkg("requests", "2.31.0")])
+            .await
+            .unwrap();
+
+        assert!(results.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, "requests");
+        assert!(errors[0].1.contains("network error"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_empty() {
+        let repo = MockMaintenanceRepository::new();
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let (results, errors) = use_case.fetch_with_progress(vec![]).await.unwrap();
+
+        assert!(results.is_empty());
+        assert!(errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_mixed_success_and_error() {
+        let repo = MockMaintenanceRepository::with_responses([
+            Ok(info(Some(NaiveDate::from_ymd_opt(2021, 6, 1).unwrap()))),
+            Err("not found".to_string()),
+            Ok(info(None)),
+        ]);
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let packages = vec![
+            pkg("requests", "2.31.0"),
+            pkg("unknown-pkg", "1.0.0"),
+            pkg("certifi", "2024.1.1"),
+        ];
+
+        let (results, errors) = use_case.fetch_with_progress(packages).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, "unknown-pkg");
+    }
+}

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -22,6 +22,7 @@ use crate::sbom_generation::domain::{
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
 use chrono::Utc;
+use std::cmp::Reverse;
 use std::collections::HashSet;
 
 /// Type alias for package list with dependency map
@@ -212,7 +213,7 @@ where
             })
             .collect();
 
-        abandoned_packages.sort_by(|a, b| b.days_inactive.cmp(&a.days_inactive));
+        abandoned_packages.sort_by_key(|p| Reverse(p.days_inactive));
 
         let report = AbandonedPackagesReport {
             packages: abandoned_packages,

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -1,19 +1,28 @@
 use crate::adapters::outbound::uv::UvLockAdapter;
 use crate::application::dto::{SbomRequest, SbomResponse};
-use crate::application::use_cases::{CheckVulnerabilitiesUseCase, FetchLicensesUseCase};
+use crate::application::read_models::abandoned_package::{
+    AbandonedPackageView, AbandonedPackagesReport,
+};
+use crate::application::use_cases::{
+    CheckAbandonedPackagesUseCase, CheckVulnerabilitiesUseCase, FetchLicensesUseCase,
+};
 use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::{
-    EnrichedPackage, LicenseRepository, LockfileReader, ProgressReporter, ProjectConfigReader,
-    VulnerabilityRepository,
+    EnrichedPackage, LicenseRepository, LockfileReader, MaintenanceRepository, ProgressReporter,
+    ProjectConfigReader, VulnerabilityRepository,
 };
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::{
     LicenseComplianceChecker, ResolutionAnalyzer, ThresholdConfig, UpgradeAdvisor,
     VulnerabilityCheckResult, VulnerabilityChecker,
 };
-use crate::sbom_generation::domain::{Package, PackageName, UpgradeRecommendation};
+use crate::sbom_generation::domain::{
+    DependencyGraph, Package, PackageName, UpgradeRecommendation,
+};
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
+use chrono::Utc;
+use std::collections::HashSet;
 
 /// Type alias for package list with dependency map
 /// Used to simplify complex return types and satisfy clippy::type_complexity
@@ -30,22 +39,25 @@ type PackagesWithDependencyMap = (Vec<Package>, std::collections::HashMap<String
 /// * `LREPO` - LicenseRepository implementation
 /// * `PR` - ProgressReporter implementation
 /// * `VREPO` - VulnerabilityRepository implementation (optional)
-pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO> {
+/// * `MREPO` - MaintenanceRepository implementation (optional)
+pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO> {
     lockfile_reader: LR,
     project_config_reader: PCR,
     license_repository: LREPO,
     progress_reporter: PR,
     vulnerability_repository: Option<VREPO>,
+    maintenance_repository: Option<MREPO>,
     locale: Locale,
 }
 
-impl<LR, PCR, LREPO, PR, VREPO> GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO>
+impl<LR, PCR, LREPO, PR, VREPO, MREPO> GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO>
 where
     LR: LockfileReader,
     PCR: ProjectConfigReader,
     LREPO: LicenseRepository + Clone,
     PR: ProgressReporter,
     VREPO: VulnerabilityRepository + Clone,
+    MREPO: MaintenanceRepository + Clone,
 {
     /// Creates a new GenerateSbomUseCase with injected dependencies
     pub fn new(
@@ -54,6 +66,7 @@ where
         license_repository: LREPO,
         progress_reporter: PR,
         vulnerability_repository: Option<VREPO>,
+        maintenance_repository: Option<MREPO>,
         locale: Locale,
     ) -> Self {
         Self {
@@ -62,6 +75,7 @@ where
             license_repository,
             progress_reporter,
             vulnerability_repository,
+            maintenance_repository,
             locale,
         }
     }
@@ -74,9 +88,6 @@ where
     /// # Returns
     /// SbomResponse containing enriched packages, optional dependency graph, and metadata
     pub async fn execute(&self, request: SbomRequest) -> Result<SbomResponse> {
-        // Acknowledge --check-abandoned flag; detection logic ships in a follow-up issue.
-        self.notify_abandoned_check_deferred_if_requested(&request);
-
         // Step 1: Read and parse lockfile
         let (packages, dependency_map) = self.read_and_report_lockfile(&request)?;
 
@@ -124,31 +135,108 @@ where
             )
             .await;
 
-        // Step 9: Build and return response
+        // Step 9: Abandoned package check if requested
+        let abandoned_packages_report = self
+            .check_abandoned_if_requested(&request, &filtered_packages, dependency_graph.as_ref())
+            .await?;
+
+        // Step 10: Build and return response
         Ok(self.build_response(
             enriched_packages,
             dependency_graph,
             vulnerability_check_result,
             license_compliance_result,
             upgrade_recommendations,
+            abandoned_packages_report,
         ))
     }
 
-    /// Emits a localised notice when `check_abandoned` is enabled.
-    /// Detection logic ships in a follow-up issue; this method is the current consumer of
-    /// `request.check_abandoned` and `request.abandoned_threshold_days`.
-    fn notify_abandoned_check_deferred_if_requested(&self, request: &SbomRequest) {
+    /// Checks for abandoned packages if `check_abandoned` is enabled.
+    ///
+    /// Returns `None` when the check is disabled or no maintenance repository is configured.
+    /// When `dependency_graph` is `None` (e.g. JSON output without dep analysis),
+    /// `is_direct` defaults to `false` for all packages — consistent with the existing
+    /// pattern for the resolution guide.
+    async fn check_abandoned_if_requested(
+        &self,
+        request: &SbomRequest,
+        packages: &[Package],
+        dependency_graph: Option<&DependencyGraph>,
+    ) -> Result<Option<AbandonedPackagesReport>> {
         if !request.check_abandoned {
-            return;
+            return Ok(None);
         }
+        let Some(repo) = &self.maintenance_repository else {
+            return Ok(None);
+        };
+
         let msgs = Messages::for_locale(self.locale);
-        eprintln!(
-            "{}",
-            Messages::format(
-                msgs.info_check_abandoned_deferred,
-                &[&request.abandoned_threshold_days.to_string()]
-            )
-        );
+        self.progress_reporter
+            .report(msgs.progress_fetching_abandoned);
+
+        let maint_use_case = CheckAbandonedPackagesUseCase::new(repo.clone());
+        let (results, errors) = maint_use_case
+            .fetch_with_progress(packages.to_vec())
+            .await?;
+
+        eprintln!(); // newline after progress bar
+
+        for (pkg_name, error_msg) in &errors {
+            self.progress_reporter.report_error(&Messages::format(
+                msgs.warn_abandoned_fetch_failed,
+                &[pkg_name, error_msg],
+            ));
+        }
+
+        let today = Utc::now().date_naive();
+        let direct_names: HashSet<&str> = dependency_graph
+            .map(|g| g.direct_dependencies().iter().map(|p| p.as_str()).collect())
+            .unwrap_or_default();
+
+        let threshold = request.abandoned_threshold_days as i64;
+        let mut abandoned_packages: Vec<AbandonedPackageView> = results
+            .into_iter()
+            .filter_map(|(pkg, info)| {
+                let release_date = info.last_release_date?;
+                let days_inactive = (today - release_date).num_days();
+                if days_inactive < threshold {
+                    return None;
+                }
+                Some(AbandonedPackageView {
+                    name: pkg.name().to_string(),
+                    version: pkg.version().to_string(),
+                    last_release_date: release_date,
+                    days_inactive,
+                    is_direct: direct_names.contains(pkg.name()),
+                })
+            })
+            .collect();
+
+        abandoned_packages.sort_by(|a, b| b.days_inactive.cmp(&a.days_inactive));
+
+        let report = AbandonedPackagesReport {
+            packages: abandoned_packages,
+            threshold_days: request.abandoned_threshold_days,
+        };
+
+        if report.is_empty() {
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_abandoned_none,
+                &[&report.threshold_days.to_string()],
+            ));
+        } else {
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_abandoned_found,
+                &[
+                    &report.total_count().to_string(),
+                    &report.direct_count().to_string(),
+                    &report.transitive_count().to_string(),
+                    &report.threshold_days.to_string(),
+                ],
+            ));
+        }
+
+        Ok(Some(report))
     }
 
     /// Reads and parses the lockfile, reporting progress
@@ -533,10 +621,11 @@ where
     fn build_response(
         &self,
         enriched_packages: Vec<EnrichedPackage>,
-        dependency_graph: Option<crate::sbom_generation::domain::DependencyGraph>,
+        dependency_graph: Option<DependencyGraph>,
         vulnerability_check_result: Option<VulnerabilityCheckResult>,
         license_compliance_result: Option<LicenseComplianceResult>,
         upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
+        abandoned_packages_report: Option<AbandonedPackagesReport>,
     ) -> SbomResponse {
         let metadata = SbomGenerator::generate_default_metadata();
 
@@ -568,6 +657,9 @@ where
         }
         if let Some(recommendations) = upgrade_recommendations {
             builder = builder.upgrade_recommendations(recommendations);
+        }
+        if let Some(report) = abandoned_packages_report {
+            builder = builder.abandoned_packages_report(report);
         }
 
         builder.build().expect("response build should not fail")

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -198,6 +198,9 @@ where
         let mut abandoned_packages: Vec<AbandonedPackageView> = results
             .into_iter()
             .filter_map(|(pkg, info)| {
+                // Packages with no recorded release date are excluded: their
+                // maintenance status cannot be determined, so we do not classify
+                // them as abandoned.
                 let release_date = info.last_release_date?;
                 let days_inactive = (today - release_date).num_days();
                 if days_inactive < threshold {

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::application::use_cases::test_doubles::MockVulnerabilityRepository;
+use crate::application::use_cases::test_doubles::{
+    MockMaintenanceRepository, MockVulnerabilityRepository,
+};
 use crate::ports::outbound::{LockfileParseResult, PyPiMetadata};
 use crate::sbom_generation::domain::Package;
 use std::collections::HashMap;
@@ -76,6 +78,7 @@ mod test_helpers {
         MockLicenseRepository,
         MockProgressReporter,
         MockVulnerabilityRepository,
+        MockMaintenanceRepository,
     >;
 
     pub(super) struct UseCaseBuilder {
@@ -83,6 +86,7 @@ mod test_helpers {
         deps: HashMap<String, Vec<String>>,
         project_name: String,
         vuln: Option<MockVulnerabilityRepository>,
+        maint: Option<MockMaintenanceRepository>,
     }
 
     impl Default for UseCaseBuilder {
@@ -92,6 +96,7 @@ mod test_helpers {
                 deps: HashMap::new(),
                 project_name: "test-project".to_string(),
                 vuln: None,
+                maint: None,
             }
         }
     }
@@ -122,6 +127,11 @@ mod test_helpers {
             self
         }
 
+        pub(super) fn with_maintenance_repo(mut self, repo: MockMaintenanceRepository) -> Self {
+            self.maint = Some(repo);
+            self
+        }
+
         pub(super) fn build(self) -> TestUseCase {
             GenerateSbomUseCase::new(
                 MockLockfileReader {
@@ -134,6 +144,7 @@ mod test_helpers {
                 MockLicenseRepository,
                 MockProgressReporter,
                 self.vuln,
+                self.maint,
                 Locale::default(),
             )
         }
@@ -388,7 +399,7 @@ mod tests_response {
             Some("Test description".to_string()),
         )];
 
-        let response = use_case.build_response(enriched_packages, None, None, None, None);
+        let response = use_case.build_response(enriched_packages, None, None, None, None, None);
 
         assert_eq!(response.enriched_packages.len(), 1);
         assert!(response.dependency_graph.is_none());
@@ -426,8 +437,14 @@ mod tests_response {
             threshold_exceeded: true,
         };
 
-        let response =
-            use_case.build_response(enriched_packages, None, Some(check_result), None, None);
+        let response = use_case.build_response(
+            enriched_packages,
+            None,
+            Some(check_result),
+            None,
+            None,
+            None,
+        );
 
         assert!(response.has_vulnerabilities_above_threshold);
         assert!(
@@ -467,8 +484,14 @@ mod tests_response {
             threshold_exceeded: false,
         };
 
-        let response =
-            use_case.build_response(enriched_packages, None, Some(check_result), None, None);
+        let response = use_case.build_response(
+            enriched_packages,
+            None,
+            Some(check_result),
+            None,
+            None,
+            None,
+        );
 
         assert!(!response.has_vulnerabilities_above_threshold);
         assert!(
@@ -568,6 +591,173 @@ mod tests_vulnerabilities {
         let config = TestUseCase::build_threshold_config(&request);
 
         assert_eq!(config, ThresholdConfig::Cvss(7.0));
+    }
+}
+
+mod tests_abandoned {
+    use super::test_helpers::*;
+    use super::*;
+    use crate::application::use_cases::test_doubles::MockMaintenanceRepository;
+    use crate::ports::outbound::MaintenanceInfo;
+    use chrono::NaiveDate;
+
+    #[tokio::test]
+    async fn test_check_abandoned_disabled_returns_none() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+
+        let result = use_case
+            .check_abandoned_if_requested(&default_request(), &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_no_repo_returns_none() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_with_old_package_returns_report() {
+        let old_date = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
+        let maint_repo = MockMaintenanceRepository::with_responses([Ok(MaintenanceInfo {
+            last_release_date: Some(old_date),
+        })]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        let report = result.unwrap();
+        assert_eq!(report.total_count(), 1);
+        assert_eq!(report.packages[0].name, "requests");
+        assert!(report.packages[0].days_inactive >= 365);
+        assert_eq!(report.threshold_days, 365);
+        assert_eq!(report.direct_count(), 0); // no graph supplied → all non-direct
+        assert_eq!(report.transitive_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_recent_package_produces_empty_report() {
+        use chrono::Utc;
+        let recent_date = Utc::now().date_naive();
+        let maint_repo = MockMaintenanceRepository::with_responses([Ok(MaintenanceInfo {
+            last_release_date: Some(recent_date),
+        })]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_unknown_release_date_excluded() {
+        let maint_repo = MockMaintenanceRepository::with_responses([Ok(MaintenanceInfo {
+            last_release_date: None,
+        })]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("old-pkg", "1.0.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("old-pkg", "1.0.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(1)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        // Package with unknown release date is excluded from the report
+        assert!(result.is_some());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_sorted_by_days_inactive_descending() {
+        let older_date = NaiveDate::from_ymd_opt(2018, 1, 1).unwrap();
+        let newer_date = NaiveDate::from_ymd_opt(2021, 1, 1).unwrap();
+        let maint_repo = MockMaintenanceRepository::with_responses([
+            Ok(MaintenanceInfo {
+                last_release_date: Some(newer_date),
+            }),
+            Ok(MaintenanceInfo {
+                last_release_date: Some(older_date),
+            }),
+        ]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("newer-pkg", "1.0.0"), pkg("older-pkg", "1.0.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("newer-pkg", "1.0.0"), pkg("older-pkg", "1.0.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        let report = result.unwrap();
+        assert_eq!(report.total_count(), 2);
+        // Sorted descending: older-pkg (more days inactive) should be first
+        assert!(report.packages[0].days_inactive >= report.packages[1].days_inactive);
     }
 }
 

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -1,4 +1,5 @@
 /// Use cases module containing application business logic orchestration
+mod check_abandoned_packages;
 mod check_vulnerabilities;
 mod fetch_licenses;
 mod generate_sbom;
@@ -6,7 +7,7 @@ mod generate_sbom;
 #[cfg(test)]
 pub(crate) mod test_doubles;
 
-#[allow(unused_imports)]
+pub use check_abandoned_packages::CheckAbandonedPackagesUseCase;
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
 pub use fetch_licenses::FetchLicensesUseCase;
 pub use generate_sbom::GenerateSbomUseCase;

--- a/src/application/use_cases/test_doubles.rs
+++ b/src/application/use_cases/test_doubles.rs
@@ -1,7 +1,61 @@
-use crate::ports::outbound::{ProgressCallback, VulnerabilityRepository};
+use crate::ports::outbound::{
+    MaintenanceInfo, MaintenanceRepository, ProgressCallback, VulnerabilityRepository,
+};
 use crate::sbom_generation::domain::{Package, PackageVulnerabilities};
 use crate::shared::Result;
 use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+/// Configurable in-memory mock implementing `MaintenanceRepository`.
+///
+/// Each call to `fetch_maintenance_info` pops the next response from the queue.
+/// When the queue is exhausted, returns `Ok(MaintenanceInfo { last_release_date: None })`.
+///
+/// `Clone` clones the `Arc`, so both copies share the same queue — consistent with
+/// how the production code clones the repository into sub-use-cases.
+#[derive(Clone)]
+pub(crate) struct MockMaintenanceRepository {
+    queue: Arc<Mutex<VecDeque<std::result::Result<MaintenanceInfo, String>>>>,
+}
+
+impl MockMaintenanceRepository {
+    /// Creates an empty mock (all calls return `last_release_date: None`).
+    pub fn new() -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Creates a mock with pre-loaded ordered responses.
+    pub fn with_responses(
+        responses: impl IntoIterator<Item = std::result::Result<MaintenanceInfo, String>>,
+    ) -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(responses.into_iter().collect())),
+        }
+    }
+}
+
+impl Default for MockMaintenanceRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MaintenanceRepository for MockMaintenanceRepository {
+    async fn fetch_maintenance_info(&self, _package_name: &str) -> Result<MaintenanceInfo> {
+        let next = self.queue.lock().unwrap().pop_front();
+        match next {
+            Some(Ok(info)) => Ok(info),
+            Some(Err(msg)) => Err(anyhow::anyhow!("{}", msg)),
+            None => Ok(MaintenanceInfo {
+                last_release_date: None,
+            }),
+        }
+    }
+}
 
 /// Configurable in-memory mock implementing `VulnerabilityRepository`.
 ///

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -89,7 +89,10 @@ pub struct Messages {
     pub warn_check_cve_no_effect: &'static str,
     pub warn_check_license_no_effect: &'static str,
     pub warn_verify_links_no_effect: &'static str,
-    pub info_check_abandoned_deferred: &'static str,
+    pub warn_abandoned_fetch_failed: &'static str,
+    pub progress_fetching_abandoned: &'static str,
+    pub progress_abandoned_found: &'static str,
+    pub progress_abandoned_none: &'static str,
 
     // Section description paragraphs
     pub desc_sbom_report: &'static str,
@@ -260,7 +263,10 @@ static EN_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  Warning: --check-cve has no effect with JSON format.",
     warn_check_license_no_effect: "⚠️  Warning: --check-license has no effect with JSON format.",
     warn_verify_links_no_effect: "⚠️  Warning: --verify-links has no effect with JSON format.",
-    info_check_abandoned_deferred: "ℹ️  --check-abandoned acknowledged (threshold: {} days). Detection arrives in a future release.",
+    warn_abandoned_fetch_failed: "⚠️  Warning: Failed to fetch maintenance info for {}: {}",
+    progress_fetching_abandoned: "🔍 Fetching package maintenance information...",
+    progress_abandoned_found: "✅ Abandoned check complete: {} package(s) abandoned ({} direct, {} transitive), threshold: {} days",
+    progress_abandoned_none: "✅ Abandoned check complete: No packages exceed {} day threshold",
 
     // Section description paragraphs
     desc_sbom_report: "A comprehensive list of all software components and libraries included in this project.",
@@ -399,7 +405,10 @@ static JA_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  警告: JSON形式では --check-cve は効果がありません。",
     warn_check_license_no_effect: "⚠️  警告: JSON形式では --check-license は効果がありません。",
     warn_verify_links_no_effect: "⚠️  警告: JSON形式では --verify-links は効果がありません。",
-    info_check_abandoned_deferred: "ℹ️  --check-abandoned を確認しました（閾値: {} 日）。検出機能は今後のリリースで追加されます。",
+    warn_abandoned_fetch_failed: "⚠️  警告: {}のメンテナンス情報の取得に失敗: {}",
+    progress_fetching_abandoned: "🔍 パッケージのメンテナンス情報を取得中...",
+    progress_abandoned_found: "✅ 廃止パッケージチェック完了: {}件廃止（直接: {}件、間接: {}件）、閾値: {}日",
+    progress_abandoned_none: "✅ 廃止パッケージチェック完了: {}日以上更新のないパッケージはありません",
 
     // Section description paragraphs
     desc_sbom_report: "このプロジェクトに含まれるすべてのソフトウェアコンポーネントとライブラリの一覧です。",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,13 @@
 //! let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::default());
 //!
 //! // Create use case
-//! let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+//! let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
 //!     lockfile_reader,
 //!     project_config_reader,
 //!     license_repository,
 //!     progress_reporter,
 //!     None, // No vulnerability checking in this example
+//!     None, // No abandoned-package checking in this example
 //!     uv_sbom::i18n::Locale::default(),
 //! );
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ mod shared;
 
 use adapters::outbound::console::StderrProgressReporter;
 use adapters::outbound::filesystem::FileSystemReader;
-use adapters::outbound::network::{CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository};
+use adapters::outbound::network::{
+    CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository, PyPiMaintenanceRepository,
+};
 use adapters::outbound::uv::UvWorkspaceReader;
 use application::dto::{OutputFormat, SbomRequest};
 use application::factories::{FormatterFactory, PresenterFactory, PresenterType};
@@ -217,6 +219,13 @@ async fn run(args: Args) -> Result<bool> {
         None
     };
 
+    // Create maintenance repository if abandoned check is requested
+    let maintenance_repository = if merged.check_abandoned {
+        Some(PyPiMaintenanceRepository::new()?)
+    } else {
+        None
+    };
+
     // Create use case with injected dependencies
     let use_case = GenerateSbomUseCase::new(
         lockfile_reader,
@@ -224,6 +233,7 @@ async fn run(args: Args) -> Result<bool> {
         license_repository,
         progress_reporter,
         vulnerability_repository,
+        maintenance_repository,
         locale,
     );
 
@@ -321,9 +331,15 @@ async fn run(args: Args) -> Result<bool> {
     let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted_output)?;
 
-    // Determine if vulnerabilities or license violations were detected
-    let has_issues =
-        response.has_vulnerabilities_above_threshold || response.has_license_violations;
+    // Determine if vulnerabilities, license violations, or abandoned packages were detected
+    let has_abandoned = response
+        .abandoned_packages_report
+        .as_ref()
+        .map(|r| !r.is_empty())
+        .unwrap_or(false);
+    let has_issues = response.has_vulnerabilities_above_threshold
+        || response.has_license_violations
+        || has_abandoned;
 
     Ok(has_issues)
 }
@@ -384,12 +400,19 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             None
         };
 
+        let maintenance_repository = if merged.check_abandoned {
+            Some(PyPiMaintenanceRepository::new()?)
+        } else {
+            None
+        };
+
         let use_case = GenerateSbomUseCase::new(
             lockfile_reader,
             project_config_reader,
             license_repository,
             progress_reporter,
             vulnerability_repository,
+            maintenance_repository,
             locale,
         );
 

--- a/src/ports/outbound/maintenance_repository.rs
+++ b/src/ports/outbound/maintenance_repository.rs
@@ -11,9 +11,6 @@ use chrono::NaiveDate;
 /// - `last_release_date` is `None` when the package has no published releases
 ///   on the upstream registry (extremely rare for installed packages, but
 ///   possible for yanked-only or pre-release-only packages).
-// Consumed by the PyPI maintenance adapter (#553) and use case integration (#555).
-// Suppressed here because this is a foundational subtask with no binary consumer yet.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaintenanceInfo {
     /// Date of the most recent release on the upstream registry (UTC).
@@ -60,8 +57,6 @@ pub struct MaintenanceInfo {
 /// # Ok(())
 /// # }
 /// ```
-// Implemented by PyPiMaintenanceRepository in #553; used in GenerateSbomUseCase in #555.
-#[allow(dead_code)]
 #[async_trait]
 pub trait MaintenanceRepository: Send + Sync {
     /// Fetches maintenance information for a single package

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -76,11 +76,12 @@ async fn test_e2e_json_format() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -126,11 +127,12 @@ async fn test_e2e_markdown_format() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -178,11 +180,12 @@ async fn test_e2e_nonexistent_project() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -205,11 +208,12 @@ async fn test_e2e_package_count() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -244,11 +248,12 @@ async fn test_e2e_exclude_single_package() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -283,11 +288,12 @@ async fn test_e2e_exclude_multiple_packages() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -326,11 +332,12 @@ async fn test_e2e_exclude_with_wildcard() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -365,11 +372,12 @@ async fn test_e2e_exclude_all_packages_error() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -410,11 +418,12 @@ async fn test_e2e_exclude_root_project_preserves_dependency_classification() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -463,11 +472,12 @@ async fn test_e2e_exclude_root_project_markdown_output() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -32,11 +32,12 @@ source = { registry = "https://pypi.org/simple" }
         .with_license("urllib3", "1.26.0", "MIT", "HTTP library");
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -85,11 +86,12 @@ source = { registry = "https://pypi.org/simple" }
         .with_license("urllib3", "1.26.0", "MIT", "HTTP library");
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -119,11 +121,12 @@ async fn test_generate_sbom_lockfile_read_failure() {
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -152,11 +155,12 @@ source = { registry = "https://pypi.org/simple" }
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -189,11 +193,12 @@ source = { registry = "https://pypi.org/simple" }
     let license_repository = MockLicenseRepository::with_failure();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter.clone(),
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -224,11 +229,12 @@ async fn test_generate_sbom_invalid_toml() {
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -261,11 +267,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter.clone(),
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -310,11 +317,12 @@ source = { registry = "https://pypi.org/simple" }
         .with_license("certifi", "2023.11.17", "MPL-2.0", "CA Bundle");
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -382,11 +390,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -439,11 +448,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -481,11 +491,12 @@ source = { registry = "https://pypi.org/simple" }
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -543,11 +554,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );


### PR DESCRIPTION
## Summary

- Wire the existing `MaintenanceRepository` port and `PyPiMaintenanceRepository` adapter into `GenerateSbomUseCase` as a new optional 6th type parameter
- Batch-fetch PyPI maintenance metadata for all packages when `--check-abandoned` is set, classify by threshold, report direct/transitive breakdown, and propagate a non-zero exit code when abandoned packages are found
- Add `CheckAbandonedPackagesUseCase` (indicatif progress bar, 100ms rate-limiting, soft-fail per package) and `MockMaintenanceRepository` test double

## Related Issue

Closes #555

## Changes Made

- Add `MREPO: MaintenanceRepository + Clone` as 6th type parameter to `GenerateSbomUseCase`; update all callers in `main.rs`, `lib.rs`, `e2e_test.rs`, `integration_test.rs`
- Add `check_abandoned_if_requested()` async method: fetches via `CheckAbandonedPackagesUseCase`, filters by `abandoned_threshold_days`, classifies direct/transitive via `DependencyGraph`, sorts descending by `days_inactive`, reports progress via i18n
- Add `CheckAbandonedPackagesUseCase` in new `src/application/use_cases/check_abandoned_packages.rs` with progress bar in a spawned thread and sequential per-package fetching with soft-fail error collection
- Add `MockMaintenanceRepository` test double (`Arc<Mutex<VecDeque>>`) in `test_doubles.rs`
- Add `abandoned_packages_report: Option<AbandonedPackagesReport>` to `SbomResponse`; non-empty report contributes to non-zero exit code in `main.rs`
- Replace `info_check_abandoned_deferred` i18n key with 4 new keys: `warn_abandoned_fetch_failed`, `progress_fetching_abandoned`, `progress_abandoned_found` (4 placeholders: total, direct, transitive, threshold), `progress_abandoned_none`
- Remove all speculative `#[allow(dead_code)]` stubs from `abandoned_package.rs`, `maintenance_repository.rs`, `pypi_maintenance_client.rs`
- Defer `SbomReadModel.abandoned_packages` field and Markdown formatter section to #556; remove 8th parameter from `SbomReadModelBuilder::build_with_project`
- Add 5 unit tests in `tests_abandoned` module covering: disabled/no-repo early returns, old package flagged, recent package excluded, unknown release date excluded, sort order

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo test --all` passes (all tests green)
- [x] Code review PASS via `/code-review` skill

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)