### PR TITLE
feat(adapters): add Abandoned Packages Markdown section and i18n messages (#556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
 - **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
+- **Abandoned Packages Markdown section**: When `--check-abandoned` is active, a new `## Abandoned Packages` section is rendered in Markdown output after License Compliance and before Resolution Guide, showing a table of Package, Version, Last Release, Days Inactive, and Type (Direct/Transitive). The Summary table includes an Abandoned packages row with ⚠️/✅ status, or a skipped notice when the check is not enabled. All strings are fully localized for EN and JA (#556).
 
 ## [2.3.0] - 2026-05-02
 

--- a/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
@@ -100,6 +100,7 @@ mod tests {
             license_compliance: None,
             resolution_guide: None,
             upgrade_recommendations: None,
+            abandoned_packages: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/links.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/links.rs
@@ -106,6 +106,7 @@ mod tests {
             license_compliance: None,
             resolution_guide: None,
             upgrade_recommendations: None,
+            abandoned_packages: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -54,6 +54,7 @@ impl MarkdownFormatter {
             &model.components,
             model.vulnerabilities.as_ref(),
             model.license_compliance.as_ref(),
+            model.abandoned_packages.as_ref(),
         );
         sections::header::render(self.messages, output);
         sections::components::render(
@@ -64,8 +65,8 @@ impl MarkdownFormatter {
         );
     }
 
-    /// Renders the four conditional sections when present: dependencies, vulnerabilities,
-    /// resolution guide, and license compliance.
+    /// Renders the five conditional sections when present: dependencies, vulnerabilities,
+    /// license compliance, abandoned packages, and resolution guide.
     fn render_optional_sections(&self, output: &mut String, model: &SbomReadModel) {
         if let Some(deps) = &model.dependencies {
             sections::dependencies::render(
@@ -84,6 +85,12 @@ impl MarkdownFormatter {
                 vulns,
             );
         }
+        if let Some(compliance) = &model.license_compliance {
+            sections::license_compliance::render(self.messages, output, compliance);
+        }
+        if let Some(report) = &model.abandoned_packages {
+            sections::abandoned_packages::render(self.messages, output, report);
+        }
         if let Some(guide) = &model.resolution_guide {
             if !guide.entries.is_empty() {
                 sections::resolution_guide::render(
@@ -93,9 +100,6 @@ impl MarkdownFormatter {
                     model.upgrade_recommendations.as_ref(),
                 );
             }
-        }
-        if let Some(compliance) = &model.license_compliance {
-            sections::license_compliance::render(self.messages, output, compliance);
         }
     }
 }
@@ -120,9 +124,11 @@ mod tests {
 
     mod test_fixtures {
         use crate::application::read_models::{
-            ComponentView, LicenseView, SbomMetadataView, SbomReadModel, SeverityView,
-            VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
+            AbandonedPackageView, AbandonedPackagesReport, ComponentView, LicenseView,
+            SbomMetadataView, SbomReadModel, SeverityView, VulnerabilityReportView,
+            VulnerabilitySummary, VulnerabilityView,
         };
+        use chrono::NaiveDate;
 
         pub(super) fn base_model() -> SbomReadModel {
             SbomReadModel {
@@ -166,6 +172,7 @@ mod tests {
                 license_compliance: None,
                 resolution_guide: None,
                 upgrade_recommendations: None,
+                abandoned_packages: None,
             }
         }
 
@@ -283,6 +290,24 @@ mod tests {
                     total_count: 2,
                     affected_package_count: 2,
                 },
+            });
+            model
+        }
+
+        pub(super) fn with_abandoned_packages(count: usize) -> SbomReadModel {
+            let mut model = base_model();
+            let packages = (0..count)
+                .map(|i| AbandonedPackageView {
+                    name: format!("old-pkg-{i}"),
+                    version: "0.1.0".to_string(),
+                    last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                    days_inactive: 800 + i as i64,
+                    is_direct: i % 2 == 0,
+                })
+                .collect();
+            model.abandoned_packages = Some(AbandonedPackagesReport {
+                packages,
+                threshold_days: 730,
             });
             model
         }
@@ -771,5 +796,113 @@ mod tests {
         let markdown = formatter.format(&model).unwrap();
 
         assert!(markdown.contains("Some Custom License"));
+    }
+
+    // ===== Abandoned packages section tests =====
+
+    #[test]
+    fn test_abandoned_section_present_when_report_provided() {
+        let model = test_fixtures::with_abandoned_packages(2);
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("## Abandoned Packages"));
+        assert!(markdown.contains("old-pkg-0"));
+        assert!(markdown.contains("old-pkg-1"));
+    }
+
+    #[test]
+    fn test_abandoned_section_absent_when_none() {
+        let model = test_fixtures::base_model(); // abandoned_packages: None
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(!markdown.contains("## Abandoned Packages"));
+    }
+
+    #[test]
+    fn test_abandoned_empty_report_renders_no_packages_message() {
+        let mut model = test_fixtures::base_model();
+        model.abandoned_packages = Some(crate::application::read_models::AbandonedPackagesReport {
+            packages: vec![],
+            threshold_days: 730,
+        });
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("## Abandoned Packages"));
+        assert!(markdown.contains("No abandoned packages detected."));
+        assert!(!markdown.contains("| Package | Version | Last Release |"));
+    }
+
+    #[test]
+    fn test_abandoned_section_order_after_license_before_resolution_guide() {
+        use crate::application::read_models::{
+            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView, LicenseComplianceView,
+            LicenseComplianceSummary, ResolutionEntryView, ResolutionGuideView,
+        };
+        use chrono::NaiveDate;
+
+        let mut model = test_fixtures::base_model();
+        model.license_compliance = Some(LicenseComplianceView {
+            has_violations: false,
+            violations: vec![],
+            warnings: vec![],
+            summary: LicenseComplianceSummary {
+                violation_count: 0,
+                warning_count: 0,
+            },
+        });
+        model.abandoned_packages = Some(AbandonedPackagesReport {
+            packages: vec![AbandonedPackageView {
+                name: "stale-lib".to_string(),
+                version: "1.0.0".to_string(),
+                last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                days_inactive: 900,
+                is_direct: true,
+            }],
+            threshold_days: 730,
+        });
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "requests".to_string(),
+                current_version: "2.31.0".to_string(),
+                fixed_version: Some("2.32.0".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-0001".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![],
+            }],
+        });
+
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert_section_order(
+            &markdown,
+            &[
+                "## License Compliance Report",
+                "## Abandoned Packages",
+                "## Vulnerability Resolution Guide",
+            ],
+        );
+    }
+
+    #[test]
+    fn test_abandoned_section_ja_locale() {
+        let model = test_fixtures::with_abandoned_packages(1);
+        let markdown = MarkdownFormatter::new(Locale::Ja).format(&model).unwrap();
+        assert!(markdown.contains("## 廃止パッケージ"));
+        assert!(markdown.contains("old-pkg-0"));
+    }
+
+    #[test]
+    fn test_summary_shows_abandoned_skipped_when_none() {
+        let model = test_fixtures::base_model();
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("_Abandoned package check skipped._"));
+    }
+
+    #[test]
+    fn test_summary_shows_abandoned_row_when_report_present() {
+        let model = test_fixtures::with_abandoned_packages(2);
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("| Abandoned packages | 2 | ⚠️ |"));
+        assert!(!markdown.contains("_Abandoned package check skipped._"));
     }
 }

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -832,8 +832,9 @@ mod tests {
     #[test]
     fn test_abandoned_section_order_after_license_before_resolution_guide() {
         use crate::application::read_models::{
-            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView, LicenseComplianceView,
-            LicenseComplianceSummary, ResolutionEntryView, ResolutionGuideView,
+            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView,
+            LicenseComplianceSummary, LicenseComplianceView, ResolutionEntryView,
+            ResolutionGuideView,
         };
         use chrono::NaiveDate;
 

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
@@ -120,8 +120,9 @@ mod tests {
         };
         let output = render_ja(&report);
         assert!(output.contains("## 廃止パッケージ"));
-        assert!(output
-            .contains("| パッケージ | バージョン | 最終リリース | 非アクティブ日数 | 種別 |"));
+        assert!(
+            output.contains("| パッケージ | バージョン | 最終リリース | 非アクティブ日数 | 種別 |")
+        );
         assert!(output.contains("| requests | 1.0.0 | 2022-06-15 | 800 | 直接依存パッケージ |"));
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
@@ -1,0 +1,154 @@
+use crate::application::read_models::AbandonedPackagesReport;
+use crate::i18n::Messages;
+
+/// Renders the abandoned packages section
+pub(in super::super) fn render(
+    messages: &'static Messages,
+    output: &mut String,
+    report: &AbandonedPackagesReport,
+) {
+    output.push('\n');
+    output.push_str(messages.section_abandoned_packages);
+    output.push_str("\n\n");
+    output.push_str(messages.desc_abandoned_packages);
+    output.push_str("\n\n");
+
+    if report.packages.is_empty() {
+        output.push_str(messages.label_no_abandoned_packages);
+        output.push('\n');
+        return;
+    }
+
+    output.push_str(&format!(
+        "| {} | {} | {} | {} | {} |\n",
+        messages.col_package,
+        messages.col_version,
+        messages.col_last_release,
+        messages.col_days_inactive,
+        messages.col_type,
+    ));
+    output.push_str(&super::super::table::make_separator(&[
+        messages.col_package,
+        messages.col_version,
+        messages.col_last_release,
+        messages.col_days_inactive,
+        messages.col_type,
+    ]));
+
+    for pkg in &report.packages {
+        let type_label = if pkg.is_direct {
+            messages.label_direct_deps
+        } else {
+            messages.label_transitive_deps
+        };
+        output.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            super::super::table::escape_markdown_table_cell(&pkg.name),
+            super::super::table::escape_markdown_table_cell(&pkg.version),
+            pkg.last_release_date,
+            pkg.days_inactive,
+            type_label,
+        ));
+    }
+    output.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::AbandonedPackageView;
+    use crate::i18n::{Locale, Messages};
+    use chrono::NaiveDate;
+
+    fn make_view(name: &str, days: i64, is_direct: bool) -> AbandonedPackageView {
+        AbandonedPackageView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            last_release_date: NaiveDate::from_ymd_opt(2022, 6, 15).unwrap(),
+            days_inactive: days,
+            is_direct,
+        }
+    }
+
+    fn render_en(report: &AbandonedPackagesReport) -> String {
+        let mut output = String::new();
+        render(Messages::for_locale(Locale::En), &mut output, report);
+        output
+    }
+
+    fn render_ja(report: &AbandonedPackagesReport) -> String {
+        let mut output = String::new();
+        render(Messages::for_locale(Locale::Ja), &mut output, report);
+        output
+    }
+
+    #[test]
+    fn test_empty_report_renders_no_packages_message_en() {
+        let report = AbandonedPackagesReport::default();
+        let output = render_en(&report);
+        assert!(output.contains("## Abandoned Packages"));
+        assert!(output.contains("No abandoned packages detected."));
+        assert!(!output.contains("| Package |"));
+    }
+
+    #[test]
+    fn test_empty_report_renders_no_packages_message_ja() {
+        let report = AbandonedPackagesReport::default();
+        let output = render_ja(&report);
+        assert!(output.contains("## 廃止パッケージ"));
+        assert!(output.contains("廃止パッケージは検出されませんでした。"));
+        assert!(!output.contains("| パッケージ |"));
+    }
+
+    #[test]
+    fn test_table_rendered_with_packages_en() {
+        let report = AbandonedPackagesReport {
+            packages: vec![make_view("requests", 800, true)],
+            threshold_days: 730,
+        };
+        let output = render_en(&report);
+        assert!(output.contains("## Abandoned Packages"));
+        assert!(output.contains("| Package | Version | Last Release | Days Inactive | Type |"));
+        assert!(output.contains("| requests | 1.0.0 | 2022-06-15 | 800 | Direct dependencies |"));
+    }
+
+    #[test]
+    fn test_table_rendered_with_packages_ja() {
+        let report = AbandonedPackagesReport {
+            packages: vec![make_view("requests", 800, true)],
+            threshold_days: 730,
+        };
+        let output = render_ja(&report);
+        assert!(output.contains("## 廃止パッケージ"));
+        assert!(output
+            .contains("| パッケージ | バージョン | 最終リリース | 非アクティブ日数 | 種別 |"));
+        assert!(output.contains("| requests | 1.0.0 | 2022-06-15 | 800 | 直接依存パッケージ |"));
+    }
+
+    #[test]
+    fn test_direct_vs_transitive_type_label_en() {
+        let report = AbandonedPackagesReport {
+            packages: vec![
+                make_view("pkg-direct", 900, true),
+                make_view("pkg-transitive", 1000, false),
+            ],
+            threshold_days: 730,
+        };
+        let output = render_en(&report);
+        assert!(output.contains("| pkg-direct | 1.0.0 | 2022-06-15 | 900 | Direct dependencies |"));
+        assert!(output
+            .contains("| pkg-transitive | 1.0.0 | 2022-06-15 | 1000 | Transitive dependencies |"));
+    }
+
+    #[test]
+    fn test_package_name_with_pipe_is_escaped() {
+        let mut pkg = make_view("pkg|evil", 800, true);
+        pkg.name = "pkg|evil".to_string();
+        let report = AbandonedPackagesReport {
+            packages: vec![pkg],
+            threshold_days: 730,
+        };
+        let output = render_en(&report);
+        assert!(output.contains("pkg\\|evil"));
+    }
+}

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
@@ -1,3 +1,4 @@
+pub(super) mod abandoned_packages;
 pub(super) mod components;
 pub(super) mod dependencies;
 pub(super) mod header;

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -189,6 +189,7 @@ mod tests {
             license_compliance: None,
             resolution_guide: None,
             upgrade_recommendations: None,
+            abandoned_packages: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
@@ -1,5 +1,5 @@
 use crate::application::read_models::{
-    ComponentView, LicenseComplianceView, VulnerabilityReportView,
+    AbandonedPackagesReport, ComponentView, LicenseComplianceView, VulnerabilityReportView,
 };
 use crate::i18n::Messages;
 
@@ -10,6 +10,7 @@ pub(in super::super) fn render(
     components: &[ComponentView],
     vulnerabilities: Option<&VulnerabilityReportView>,
     license_compliance: Option<&LicenseComplianceView>,
+    abandoned_packages: Option<&AbandonedPackagesReport>,
 ) {
     output.push_str(messages.section_summary);
     output.push_str("\n\n");
@@ -104,6 +105,28 @@ pub(in super::super) fn render(
         messages.label_license_violations, violation_count, license_status
     ));
 
+    // Abandoned packages row
+    match abandoned_packages {
+        Some(report) => {
+            let n = report.total_count();
+            let abandoned_status = if n > 0 {
+                has_warning = true;
+                "⚠️"
+            } else {
+                "✅"
+            };
+            output.push_str(&format!(
+                "| {} | {} | {} |\n",
+                messages.label_abandoned_packages, n, abandoned_status
+            ));
+        }
+        None => {
+            output.push('\n');
+            output.push_str(messages.label_abandoned_check_skipped);
+            output.push('\n');
+        }
+    }
+
     // Overall line
     output.push('\n');
     let overall = if has_critical {
@@ -121,10 +144,11 @@ pub(in super::super) fn render(
 mod tests {
     use super::*;
     use crate::application::read_models::{
-        LicenseComplianceSummary, LicenseComplianceView, SeverityView, VulnerabilityReportView,
-        VulnerabilityView,
+        AbandonedPackageView, AbandonedPackagesReport, LicenseComplianceSummary,
+        LicenseComplianceView, SeverityView, VulnerabilityReportView, VulnerabilityView,
     };
     use crate::i18n::{Locale, Messages};
+    use chrono::NaiveDate;
 
     fn make_component(is_direct: bool) -> ComponentView {
         ComponentView {
@@ -173,6 +197,16 @@ mod tests {
         vulnerabilities: Option<&VulnerabilityReportView>,
         license_compliance: Option<&LicenseComplianceView>,
     ) -> String {
+        render_summary_with_abandoned(locale, components, vulnerabilities, license_compliance, None)
+    }
+
+    fn render_summary_with_abandoned(
+        locale: Locale,
+        components: &[ComponentView],
+        vulnerabilities: Option<&VulnerabilityReportView>,
+        license_compliance: Option<&LicenseComplianceView>,
+        abandoned_packages: Option<&AbandonedPackagesReport>,
+    ) -> String {
         let messages = Messages::for_locale(locale);
         let mut output = String::new();
         render(
@@ -181,6 +215,7 @@ mod tests {
             components,
             vulnerabilities,
             license_compliance,
+            abandoned_packages,
         );
         output
     }
@@ -357,6 +392,80 @@ mod tests {
             ..Default::default()
         };
         let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("**Overall: Action required**"));
+        assert!(!output.contains("**Overall: Attention recommended**"));
+    }
+
+    fn make_abandoned_report(count: usize) -> AbandonedPackagesReport {
+        let packages = (0..count)
+            .map(|i| AbandonedPackageView {
+                name: format!("pkg-{i}"),
+                version: "1.0.0".to_string(),
+                last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                days_inactive: 800,
+                is_direct: true,
+            })
+            .collect();
+        AbandonedPackagesReport {
+            packages,
+            threshold_days: 730,
+        }
+    }
+
+    #[test]
+    fn test_abandoned_check_skipped_en() {
+        let output = render_summary(Locale::En, &[], None, None);
+        assert!(output.contains("_Abandoned package check skipped._"));
+        assert!(!output.contains("Abandoned packages"));
+    }
+
+    #[test]
+    fn test_abandoned_check_skipped_ja() {
+        let output = render_summary(Locale::Ja, &[], None, None);
+        assert!(output.contains("_廃止パッケージチェックはスキップされました。_"));
+    }
+
+    #[test]
+    fn test_abandoned_zero_shows_ok_en() {
+        let report = make_abandoned_report(0);
+        let output =
+            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        assert!(output.contains("| Abandoned packages | 0 | ✅ |"));
+        assert!(!output.contains("_Abandoned package check skipped._"));
+    }
+
+    #[test]
+    fn test_abandoned_nonzero_shows_warning_en() {
+        let report = make_abandoned_report(3);
+        let output =
+            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        assert!(output.contains("| Abandoned packages | 3 | ⚠️ |"));
+        assert!(output.contains("**Overall: Attention recommended**"));
+    }
+
+    #[test]
+    fn test_abandoned_nonzero_shows_warning_ja() {
+        let report = make_abandoned_report(2);
+        let output =
+            render_summary_with_abandoned(Locale::Ja, &[], None, None, Some(&report));
+        assert!(output.contains("| 廃止パッケージ | 2 | ⚠️ |"));
+        assert!(output.contains("**総合判定: 注意が必要です**"));
+    }
+
+    #[test]
+    fn test_abandoned_warning_does_not_override_critical() {
+        let vuln_report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::Critical)],
+            ..Default::default()
+        };
+        let abandoned = make_abandoned_report(1);
+        let output = render_summary_with_abandoned(
+            Locale::En,
+            &[],
+            Some(&vuln_report),
+            None,
+            Some(&abandoned),
+        );
         assert!(output.contains("**Overall: Action required**"));
         assert!(!output.contains("**Overall: Attention recommended**"));
     }

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
@@ -197,7 +197,13 @@ mod tests {
         vulnerabilities: Option<&VulnerabilityReportView>,
         license_compliance: Option<&LicenseComplianceView>,
     ) -> String {
-        render_summary_with_abandoned(locale, components, vulnerabilities, license_compliance, None)
+        render_summary_with_abandoned(
+            locale,
+            components,
+            vulnerabilities,
+            license_compliance,
+            None,
+        )
     }
 
     fn render_summary_with_abandoned(
@@ -428,8 +434,7 @@ mod tests {
     #[test]
     fn test_abandoned_zero_shows_ok_en() {
         let report = make_abandoned_report(0);
-        let output =
-            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        let output = render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
         assert!(output.contains("| Abandoned packages | 0 | ✅ |"));
         assert!(!output.contains("_Abandoned package check skipped._"));
     }
@@ -437,8 +442,7 @@ mod tests {
     #[test]
     fn test_abandoned_nonzero_shows_warning_en() {
         let report = make_abandoned_report(3);
-        let output =
-            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        let output = render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
         assert!(output.contains("| Abandoned packages | 3 | ⚠️ |"));
         assert!(output.contains("**Overall: Attention recommended**"));
     }
@@ -446,8 +450,7 @@ mod tests {
     #[test]
     fn test_abandoned_nonzero_shows_warning_ja() {
         let report = make_abandoned_report(2);
-        let output =
-            render_summary_with_abandoned(Locale::Ja, &[], None, None, Some(&report));
+        let output = render_summary_with_abandoned(Locale::Ja, &[], None, None, Some(&report));
         assert!(output.contains("| 廃止パッケージ | 2 | ⚠️ |"));
         assert!(output.contains("**総合判定: 注意が必要です**"));
     }

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -3,6 +3,7 @@
 //! This module provides the main read model struct that aggregates
 //! all SBOM data in a query-optimized format.
 
+use super::abandoned_package::AbandonedPackagesReport;
 use super::component_view::ComponentView;
 use super::dependency_view::DependencyView;
 use super::license_compliance_view::LicenseComplianceView;
@@ -31,6 +32,9 @@ pub struct SbomReadModel {
     /// Upgrade recommendations for vulnerable transitive dependencies.
     /// Populated only when `suggest_fix` was true in the request.
     pub upgrade_recommendations: Option<UpgradeRecommendationView>,
+    /// Abandoned packages report.
+    /// Populated only when `check_abandoned` was true in the request.
+    pub abandoned_packages: Option<AbandonedPackagesReport>,
 }
 
 /// View representation of SBOM metadata

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -11,6 +11,7 @@ mod resolution_guide_builder;
 mod upgrade_recommendation_builder;
 mod vulnerability_builder;
 
+use super::abandoned_package::AbandonedPackagesReport;
 use super::resolution_guide_view::ResolutionGuideView;
 use super::sbom_read_model::SbomReadModel;
 use crate::ports::outbound::EnrichedPackage;
@@ -28,6 +29,7 @@ pub struct SbomReadModelBuilder;
 
 impl SbomReadModelBuilder {
     /// Builds a SbomReadModel from domain objects with optional project metadata component
+    #[allow(clippy::too_many_arguments)]
     pub fn build_with_project(
         packages: Vec<EnrichedPackage>,
         metadata: &SbomMetadata,
@@ -36,6 +38,7 @@ impl SbomReadModelBuilder {
         license_compliance_result: Option<&LicenseComplianceResult>,
         project_component: Option<(&str, &str)>,
         upgrade_recommendations: Option<&[UpgradeRecommendation]>,
+        abandoned_packages_report: Option<&AbandonedPackagesReport>,
     ) -> SbomReadModel {
         let metadata_view = metadata_builder::build_metadata(metadata, project_component);
         let components = component_builder::build_components(&packages, dependency_graph);
@@ -56,6 +59,8 @@ impl SbomReadModelBuilder {
         let upgrade_recommendations = upgrade_recommendations
             .map(upgrade_recommendation_builder::build_upgrade_recommendations);
 
+        let abandoned_packages = abandoned_packages_report.cloned();
+
         SbomReadModel {
             metadata: metadata_view,
             components,
@@ -64,6 +69,7 @@ impl SbomReadModelBuilder {
             license_compliance,
             resolution_guide,
             upgrade_recommendations,
+            abandoned_packages,
         }
     }
 
@@ -200,6 +206,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(read_model.metadata.tool_name, "uv-sbom");
@@ -217,7 +224,7 @@ mod tests {
         let metadata = th::metadata();
 
         let read_model = SbomReadModelBuilder::build_with_project(
-            packages, &metadata, None, None, None, None, None,
+            packages, &metadata, None, None, None, None, None, None,
         );
 
         assert!(read_model.components.is_empty());
@@ -242,6 +249,7 @@ mod tests {
             &metadata,
             None,
             Some(&vuln_result),
+            None,
             None,
             None,
             None,
@@ -288,6 +296,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(read_model.resolution_guide.is_some());
@@ -318,6 +327,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(read_model.resolution_guide.is_none());
@@ -333,6 +343,7 @@ mod tests {
             packages,
             &metadata,
             Some(&graph),
+            None,
             None,
             None,
             None,
@@ -364,6 +375,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         // requests is a direct dep, so ResolutionAnalyzer skips it → empty → None
@@ -382,6 +394,7 @@ mod tests {
             None,
             None,
             Some(("my-project", "1.0.0")),
+            None,
             None,
         );
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -170,6 +170,16 @@ pub struct Messages {
     pub overall_action_required: &'static str,
     pub overall_attention_recommended: &'static str,
     pub overall_no_issues: &'static str,
+
+    // Abandoned packages section
+    pub section_abandoned_packages: &'static str,
+    pub desc_abandoned_packages: &'static str,
+    pub label_abandoned_packages: &'static str,
+    pub label_abandoned_check_skipped: &'static str,
+    pub label_no_abandoned_packages: &'static str,
+    pub col_last_release: &'static str,
+    pub col_days_inactive: &'static str,
+    pub col_type: &'static str,
 }
 
 impl Messages {
@@ -343,6 +353,16 @@ static EN_MESSAGES: Messages = Messages {
     overall_action_required: "**Overall: Action required**",
     overall_attention_recommended: "**Overall: Attention recommended**",
     overall_no_issues: "**Overall: No issues found** ✅",
+
+    // Abandoned packages section
+    section_abandoned_packages: "## Abandoned Packages",
+    desc_abandoned_packages: "Packages whose most recent upstream release exceeds the configured inactivity threshold. Inactive projects may carry unpatched vulnerabilities and pose long-term maintenance risk.",
+    label_abandoned_packages: "Abandoned packages",
+    label_abandoned_check_skipped: "_Abandoned package check skipped._",
+    label_no_abandoned_packages: "No abandoned packages detected.",
+    col_last_release: "Last Release",
+    col_days_inactive: "Days Inactive",
+    col_type: "Type",
 };
 
 static JA_MESSAGES: Messages = Messages {
@@ -487,6 +507,16 @@ static JA_MESSAGES: Messages = Messages {
     overall_action_required: "**総合判定: 対応が必要です**",
     overall_attention_recommended: "**総合判定: 注意が必要です**",
     overall_no_issues: "**総合判定: 問題なし** ✅",
+
+    // Abandoned packages section
+    section_abandoned_packages: "## 廃止パッケージ",
+    desc_abandoned_packages: "設定された非アクティブ閾値を超えて更新されていないパッケージです。メンテナンスが停止しているプロジェクトは未修正の脆弱性を含む可能性があり、長期的な保守リスクとなります。",
+    label_abandoned_packages: "廃止パッケージ",
+    label_abandoned_check_skipped: "_廃止パッケージチェックはスキップされました。_",
+    label_no_abandoned_packages: "廃止パッケージは検出されませんでした。",
+    col_last_release: "最終リリース",
+    col_days_inactive: "非アクティブ日数",
+    col_type: "種別",
 };
 
 #[cfg(test)]
@@ -926,5 +956,41 @@ mod tests {
             result,
             "### ⚠️警告 2件の脆弱性が1個のパッケージで見つかりました。"
         );
+    }
+
+    #[test]
+    fn test_messages_abandoned_section_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(msgs.section_abandoned_packages, "## Abandoned Packages");
+        assert_eq!(msgs.label_abandoned_packages, "Abandoned packages");
+        assert_eq!(
+            msgs.label_abandoned_check_skipped,
+            "_Abandoned package check skipped._"
+        );
+        assert_eq!(
+            msgs.label_no_abandoned_packages,
+            "No abandoned packages detected."
+        );
+        assert_eq!(msgs.col_last_release, "Last Release");
+        assert_eq!(msgs.col_days_inactive, "Days Inactive");
+        assert_eq!(msgs.col_type, "Type");
+    }
+
+    #[test]
+    fn test_messages_abandoned_section_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(msgs.section_abandoned_packages, "## 廃止パッケージ");
+        assert_eq!(msgs.label_abandoned_packages, "廃止パッケージ");
+        assert_eq!(
+            msgs.label_abandoned_check_skipped,
+            "_廃止パッケージチェックはスキップされました。_"
+        );
+        assert_eq!(
+            msgs.label_no_abandoned_packages,
+            "廃止パッケージは検出されませんでした。"
+        );
+        assert_eq!(msgs.col_last_release, "最終リリース");
+        assert_eq!(msgs.col_days_inactive, "非アクティブ日数");
+        assert_eq!(msgs.col_type, "種別");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 //!     None,
 //!     None,
 //!     None,
+//!     None, // No abandoned-package report in this example
 //! );
 //! let formatter = CycloneDxFormatter::new();
 //! let output = formatter.format(&read_model)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,7 @@ async fn run(args: Args) -> Result<bool> {
             .as_ref()
             .map(|(n, v)| (n.as_str(), v.as_str())),
         response.upgrade_recommendations.as_deref(),
+        response.abandoned_packages_report.as_ref(),
     );
 
     // Verify PyPI links if requested
@@ -443,6 +444,7 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             response.license_compliance_result.as_ref(),
             None,
             response.upgrade_recommendations.as_deref(),
+            response.abandoned_packages_report.as_ref(),
         );
 
         let formatter = FormatterFactory::create(merged.format, None, locale);

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -104,6 +104,7 @@ async fn test_e2e_json_format() {
         response.license_compliance_result.as_ref(),
         None,
         None,
+        None,
     );
     let formatter = CycloneDxFormatter::new();
     let json_output = formatter.format(&read_model);
@@ -154,6 +155,7 @@ async fn test_e2e_markdown_format() {
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
         None,
         None,
     );
@@ -501,6 +503,7 @@ async fn test_e2e_exclude_root_project_markdown_output() {
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
         None,
         None,
     );


### PR DESCRIPTION
## Summary
- Add `## Abandoned Packages` section to Markdown output (rendered after License Compliance, before Resolution Guide) with a 5-column table: Package, Version, Last Release, Days Inactive, Type
- Update Summary table to include an Abandoned packages row with ⚠️/✅ status, or a skipped notice when `--check-abandoned` is not enabled
- Add 8 i18n keys to `Messages` struct in `src/i18n/mod.rs` for full EN/JA localization

## Related Issue
Closes #556

## Changes Made
- `src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs` — new section renderer with 5 unit tests
- `src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs` — added abandoned packages row to summary table
- `src/adapters/outbound/formatters/markdown_formatter/mod.rs` — wired abandoned packages into section rendering pipeline; reordered sections (license → abandoned → resolution)
- `src/application/read_models/sbom_read_model.rs` — added `abandoned_packages` field
- `src/application/read_models/sbom_read_model_builder/mod.rs` — added 8th param for abandoned packages
- `src/i18n/mod.rs` — added 8 new message keys (section header, description, labels, column headers)
- `src/main.rs` — pass `abandoned_packages_report` to builder (single-project and workspace paths)
- `CHANGELOG.md` — added `[Unreleased]` entry

## Test Plan
- [x] `cargo test --all` passes (641 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New section renderer has unit tests for EN/JA, empty report, table rows, direct/transitive labels, pipe escaping
- [x] Summary section tests cover abandoned check skipped, zero count, non-zero count, warning/critical precedence

---
Generated with [Claude Code](https://claude.com/claude-code)