### PR TITLE
docs(examples): add check_abandoned entries to sample-project config

### DIFF
--- a/examples/sample-project/config/uv-sbom.config.yml
+++ b/examples/sample-project/config/uv-sbom.config.yml
@@ -1,7 +1,7 @@
 # Sample configuration file for uv-sbom
-# Demonstrates ignore_cves (CVE suppression) and license compliance checking
-# using real vulnerability IDs and license violations from sample-project
-# dependencies (detected by OSV API and PyPI).
+# Demonstrates ignore_cves (CVE suppression), license compliance checking,
+# and abandoned package detection using real vulnerability IDs and license
+# violations from sample-project dependencies (detected by OSV API and PyPI).
 #
 # License violation demo:
 #   chardet 3.0.4 (transitive dep of requests 2.25.0) uses LGPL-2.1-only,
@@ -10,11 +10,19 @@
 # Usage (CVE + license check):
 #   cargo run -- -p examples/sample-project --check-cve --check-license \
 #     -f markdown -c examples/sample-project/config/uv-sbom.config.yml
+#
+# Usage (all checks via config — CVE + license + abandoned package detection):
+#   cargo run -- -p examples/sample-project -f markdown \
+#     -c examples/sample-project/config/uv-sbom.config.yml
 
 check_cve: true
 severity_threshold: medium
 
 check_license: true
+
+# Abandoned package detection: flag packages with no PyPI release in 730+ days
+check_abandoned: true
+abandoned_threshold_days: 730
 
 license_policy:
   allow:


### PR DESCRIPTION
## Summary

- Add `check_abandoned: true` and `abandoned_threshold_days: 730` to `examples/sample-project/config/uv-sbom.config.yml`
- Update the file header comment to mention abandoned package detection as a demonstrated feature
- Add a "Usage (all checks via config)" command example to the header

## Related Issue

Closes #565

## Changes Made

- `examples/sample-project/config/uv-sbom.config.yml`: expanded header comment (3 lines updated) and added `check_abandoned` block (3 lines added)

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual: `cargo run -- -p examples/sample-project -f markdown -c examples/sample-project/config/uv-sbom.config.yml` triggers abandoned package check without error

---
Generated with [Claude Code](https://claude.com/claude-code)