### PR TITLE
docs(examples): add sample-project README with --check-abandoned usage guide

### DIFF
--- a/examples/sample-project/README.md
+++ b/examples/sample-project/README.md
@@ -1,0 +1,80 @@
+# sample-project
+
+An example project demonstrating CVE detection, license compliance checking,
+and abandoned package detection with `uv-sbom`.
+
+## Purpose
+
+This project contains **intentionally outdated package versions** to produce
+realistic uv-sbom output for all three major opt-in analysis features:
+
+| Feature | CLI flag | What this example shows |
+|---------|----------|------------------------|
+| CVE detection | `--check-cve` (default on) | Multiple known vulnerabilities in locked packages |
+| License compliance | `--check-license` | `chardet 3.0.4` uses LGPL-2.1-only (denied) |
+| Abandoned package detection | `--check-abandoned` | Several packages with no upstream release ≥ 730 days |
+
+> ⚠️ **Do not use these package versions in production.** They are intentionally
+> outdated for demonstration purposes.
+
+## Prerequisites
+
+- `uv-sbom` installed or built from source (`cargo build --release`)
+- Internet access (CVE, license, and abandoned checks all require network)
+
+## Usage
+
+### Step 1: CVE check (default)
+
+```bash
+# From the repository root
+uv-sbom -p examples/sample-project -f markdown
+```
+
+**What you will see:** A vulnerability report listing CVEs for `pillow`, `urllib3`,
+`requests`, `jinja2`, and `werkzeug`.
+
+### Step 2: License compliance check
+
+```bash
+uv-sbom -p examples/sample-project --check-license -f markdown \
+  -c examples/sample-project/config/uv-sbom.config.yml
+```
+
+**What you will see:** A License Compliance section flagging `chardet 3.0.4`
+(LGPL-2.1-only, denied by the config policy).
+
+### Step 3: Abandoned package detection
+
+```bash
+uv-sbom -p examples/sample-project --check-abandoned -f markdown
+```
+
+**What you will see:** An Abandoned Packages section listing packages whose
+**latest PyPI release** is more than 730 days old (the default threshold).
+
+To lower the threshold and see more results:
+
+```bash
+uv-sbom -p examples/sample-project --check-abandoned \
+  --abandoned-threshold-days 365 -f markdown
+```
+
+### Step 4: All checks via config file
+
+```bash
+uv-sbom -p examples/sample-project -f markdown \
+  -c examples/sample-project/config/uv-sbom.config.yml
+```
+
+This exercises CVE, license, and abandoned detection in a single run
+(once Issue #565 adds `check_abandoned: true` to the config file).
+
+## Contrast with other examples
+
+| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|
+| Primary feature | CVE + license + abandoned | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
+| Vulnerable packages | Direct dependencies | Transitive dependencies | N/A |
+| Abandoned demo | ✅ Yes | ❌ Not focused | ❌ Not focused |
+| Config file | ✅ Yes (`config/`) | ❌ No | ❌ No |

--- a/examples/suggest-fix-project/README.md
+++ b/examples/suggest-fix-project/README.md
@@ -119,6 +119,7 @@ uv-sbom -p examples/suggest-fix-project --check-cve --suggest-fix \
 | Vulnerable packages | All **direct** dependencies | All **transitive** dependencies |
 | Resolution Guide | Not shown (no transitive CVEs) | Shown with Recommended Action |
 | `--suggest-fix` output | No upgrade advice | Upgradable + Unresolvable cases |
+| `--check-abandoned` demo | ✅ See sample-project README | ❌ Not focused |
 
-Use `sample-project` to explore the basic CVE check and `--check-license` features.
+Use `sample-project` to explore the basic CVE check, `--check-license`, and `--check-abandoned` features.
 Use this project to explore the `--suggest-fix` Upgrade Advisor feature.


### PR DESCRIPTION
## Summary
- Add `examples/sample-project/README.md` with step-by-step guides for CVE, license compliance, and abandoned package detection demos
- Include a 3-way contrast table comparing `sample-project`, `suggest-fix-project`, and `workspace` examples
- Update `examples/suggest-fix-project/README.md` contrast table to reference the `--check-abandoned` demo in sample-project

## Related Issue
Closes #566

## Changes Made
- **Create** `examples/sample-project/README.md`: covers Steps 1–4 (CVE, license, abandoned, all-in-one via config); Step 4 notes dependency on Issue #565 for `check_abandoned: true` in config
- **Update** `examples/suggest-fix-project/README.md`: append `--check-abandoned` row to contrast table; update trailing prose to mention `--check-abandoned`

## Notes
- `examples/workspace/README.md` has a 2-column contrast table that could be harmonized in a follow-up issue
- No `README-JP.md` is added for `sample-project` in this PR (asymmetry with `suggest-fix-project`); a follow-up issue can address the JP translation
- After Issue #565 lands, remove the `(once Issue #565 adds check_abandoned: true ...)` disclaimer from Step 4

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (7 passed, 0 failed)
- [x] No Rust source files modified — documentation only

---
Generated with [Claude Code](https://claude.com/claude-code)