### PR TITLE
process(implement): add CLI flag documentation gate as Step 4.3

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,7 @@ Skills contain mandatory pre-flight checks and language requirements that preven
 - **PR #121**: Created in Japanese, `cargo fmt --all -- --check` failed in CI
 - **Issue #59**: `cargo clippy` was run without `-D warnings`, causing CI failure after push
 - **2026-04-18**: v2.2.0 release promoted an empty `[Unreleased]` section. Features added in PRs #441–#483 were never recorded in CHANGELOG. Fixed by Issue #491 (added gate in `/release` Step 3.6 and `/pr` Step 4.5).
+- **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Fixed by Issue #568 (added CLI Flag Documentation Gate in `/implement` Step 4.3 and expanded README Update Checklist trigger).
 
 ### Enforcement
 
@@ -147,7 +148,12 @@ Agents complement skills: the Release Manager agent judges readiness; the `/rele
 
 ## README Update Checklist
 
-When updating README.md, check if the following files also need updates:
+Trigger this checklist when **any** of the following is true:
+- README.md content is being changed directly
+- A new CLI flag or config key was added (see also: /implement Step 4.3)
+- A new user-facing feature was implemented
+
+When triggered, check if the following files also need updates:
 
 | File | Action Required | Notes |
 |------|-----------------|-------|

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -107,6 +107,43 @@ Accepted responses:
   MUST be added as a named key in both `EN_MESSAGES` and `JA_MESSAGES` in
   `src/i18n/mod.rs`. Never hardcode English text in output paths.
 
+### Step 4.3: CLI Flag Documentation Gate (conditional)
+
+**Trigger**: Run this gate if the current implementation added, removed, or renamed
+any CLI flag (i.e., any `#[arg(` or `#[clap(` annotation was added/changed in `src/cli/`).
+
+Detect via:
+```bash
+git diff origin/develop...HEAD -G'#\[arg\(|#\[clap\(' -- 'src/cli/'
+```
+
+If the diff is **non-empty**, verify ALL of the following before proceeding to Step 4.5:
+
+#### A. README.md usage section
+
+- [ ] A new `###` subsection exists for the feature (or an existing section is updated)
+- [ ] At least one ` ```bash ` command example demonstrates the new flag
+- [ ] The Config File Schema Reference table includes the corresponding config key(s)
+- [ ] The Priority and Merge Rules section is updated if the resolution order changed
+
+#### B. README-JP.md
+
+- [ ] All changes from A are translated into Japanese and applied
+
+#### C. Example project config file
+
+- [ ] `examples/sample-project/config/uv-sbom.config.yml` includes the new config key
+  (commented out with the default value, matching the style of existing entries)
+
+#### D. Example project documentation
+
+- [ ] At least one example project README demonstrates the new flag
+  (use `examples/sample-project/README.md` if it exists, otherwise note this as a gap)
+
+**If any checkbox is unchecked**: implement the missing documentation now, before invoking `/code-review`.
+
+**Do NOT skip this gate** even if the implementation plan did not explicitly list documentation files. Every new CLI flag requires all four checks.
+
 ### Step 4.5: Code Review (MANDATORY)
 
 Invoke `/code-review` skill.


### PR DESCRIPTION
## Summary
- Add Step 4.3 (CLI Flag Documentation Gate) to `/implement` skill, positioned between Step 4 and Step 4.5, to prevent documentation gaps when new CLI flags are introduced
- Expand the README Update Checklist trigger in `CLAUDE.md` to fire not only when README.md is being edited directly, but also when CLI flags or config keys are added
- Record Issue #511 (`--check-abandoned` documentation gap) in the Recent Incidents log

## Related Issue
Closes #568

## Changes Made
- **`.claude/skills/implement/SKILL.md`**: Insert Step 4.3 that detects new `#[arg(` / `#[clap(` lines via `git diff` and verifies four documentation areas (README.md, README-JP.md, example config file, example project README) before allowing `/code-review` to proceed
- **`.claude/CLAUDE.md`**: Replace single-condition trigger ("When updating README.md") with a three-condition trigger list; add cross-reference to `/implement` Step 4.3; append Issue #511 incident record to the Recent Incidents section

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (7 passed, 0 failed)
- [x] No Rust source files modified — process documentation only
- [x] Cross-references verified: `CLAUDE.md` → `/implement Step 4.3` resolves to `### Step 4.3: CLI Flag Documentation Gate (conditional)` in SKILL.md

## Notes
- This is a companion to Issue #569 which adds a backstop gate to the `/pr` skill for the same class of oversight
- The gate is conditional (skips if no `#[arg(` / `#[clap(` changes) to avoid friction on unrelated PRs

---
Generated with [Claude Code](https://claude.com/claude-code)