### PR TITLE
docs(examples): add abandoned-packages-project for --check-abandoned demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
 - **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
 - **Abandoned Packages Markdown section**: When `--check-abandoned` is active, a new `## Abandoned Packages` section is rendered in Markdown output after License Compliance and before Resolution Guide, showing a table of Package, Version, Last Release, Days Inactive, and Type (Direct/Transitive). The Summary table includes an Abandoned packages row with ⚠️/✅ status, or a skipped notice when the check is not enabled. All strings are fully localized for EN and JA (#556).
+- **Abandoned packages example**: Added `examples/abandoned-packages-project/` demonstrating `--check-abandoned` with genuinely unmaintained PyPI packages (docopt, nose, pep8, Paver) whose latest releases are more than 2 years old (#567).
 
 ## [2.3.0] - 2026-05-02
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -439,6 +439,14 @@ abandoned_threshold_days: 365  # オプション、デフォルト: 730
 
 > **注:** 廃止パッケージデータは現在Markdownのみで利用可能です。CycloneDX JSON出力は影響を受けません。
 
+確実に出力が得られるデモを実行するには：
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+詳細は [`examples/abandoned-packages-project/README-JP.md`](examples/abandoned-packages-project/README-JP.md) を参照してください。
+
 ### 脆弱性しきい値オプション
 
 しきい値オプションを使用して、どの脆弱性が終了コード1をトリガーするかを制御できます：

--- a/README.md
+++ b/README.md
@@ -443,6 +443,14 @@ abandoned_threshold_days: 365  # optional, default: 730
 
 > **Note:** Abandoned package data is currently Markdown-only. CycloneDX JSON output is not affected.
 
+For a demo with guaranteed output, run:
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+See [`examples/abandoned-packages-project/README.md`](examples/abandoned-packages-project/README.md) for a full walkthrough.
+
 ### Vulnerability Threshold Options
 
 You can control which vulnerabilities trigger a non-zero exit code using threshold options:

--- a/examples/abandoned-packages-project/README-JP.md
+++ b/examples/abandoned-packages-project/README-JP.md
@@ -1,0 +1,82 @@
+# abandoned-packages-project
+
+PyPI上の**最新リリースが2年以上前**のPythonパッケージを使用して、`uv-sbom` の `--check-abandoned` 機能を実演するサンプルプロジェクトです。
+
+## 目的
+
+`--check-abandoned` は、ロックされたバージョンの日付ではなく、**パッケージの最新リリース日**をPyPIに問い合わせます。ほとんどのデモプロジェクトは、活発にメンテナンスされているパッケージの古いバージョンをピン留めしています。しかしそれらは最新リリースが最近であるため、放棄されたパッケージとして**フラグが立ちません**。
+
+このプロジェクトは、PyPIレベルで本当にメンテナンスされていないパッケージを使用しています。各パッケージの最新バージョンでさえ何年も前のものです。そのため、`--check-abandoned` を実行すると、閾値に関わらず常に空でない「放棄されたパッケージ」セクションが表示されます。
+
+> ⚠️ これらのパッケージを本番環境で使用しないでください。
+
+## このサンプルに含まれる放棄されたパッケージ
+
+| パッケージ | ロックバージョン | 最新PyPIリリース | 非活動日数（目安） | 備考 |
+|-----------|--------------|----------------|-----------------|------|
+| docopt  | 0.6.2         | 2014-06-16     | 4400日以上        | `docopt-ng` に引き継がれた |
+| nose    | 1.3.7         | 2015-06-02     | 3990日以上        | 公式に非推奨。pytestを使用 |
+| pep8    | 1.7.1         | 2017-10-24     | 3100日以上        | `pycodestyle` に改名 |
+| Paver   | 1.3.4         | 2017-12-31     | 3050日以上        | アクティブなメンテナなし |
+
+`six`（Paverのtransitive dependency）は活発にメンテナンスされており、放棄されたパッケージセクションには**表示されません**。
+
+## 前提条件
+
+- `uv-sbom` をソースからビルド済み（`cargo build --release`）またはインストール済み
+- ネットワークアクセス（パッケージごとに1回PyPI APIを呼び出します）
+
+## 使用方法
+
+### Step 1: 放棄されたパッケージのチェック（デフォルト閾値: 730日）
+
+```bash
+# リポジトリルートから実行
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+**期待される放棄されたパッケージセクション:**
+
+```markdown
+## Abandoned Packages
+
+Packages whose most recent upstream release exceeds the configured inactivity threshold.
+Inactive projects may carry unpatched vulnerabilities and pose long-term maintenance risk.
+
+| Package | Version | Last Release | Days Inactive | Type                |
+|---------|---------|--------------|---------------|---------------------|
+| docopt  | 0.6.2   | 2014-06-16   | 4346          | Direct dependencies |
+| nose    | 1.3.7   | 2015-06-02   | 3995          | Direct dependencies |
+| pep8    | 1.7.1   | 2017-10-24   | 3120          | Direct dependencies |
+| paver   | 1.3.4   | 2017-12-31   | 3052          | Direct dependencies |
+```
+
+### Step 2: カスタム非活動閾値
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned \
+  --abandoned-threshold-days 365 -f markdown
+```
+
+4つのパッケージすべてが引き続き表示されます（最終リリースは3000日以上前）。
+
+### Step 3: CVEチェックとの組み合わせ
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-cve --check-abandoned -f markdown
+```
+
+## なぜ `sample-project` を使わないのか？
+
+`examples/sample-project/` は活発にメンテナンスされているパッケージの古いバージョン（chardet 3.0.4、idna 2.10 など）をピン留めしています。これらのパッケージは最新リリースが最近であるため、`--check-abandoned` を `sample-project` に対して実行すると、放棄されたパッケージは0件になります。
+
+このプロジェクトは**最新**リリースが古いパッケージを使用しているため、放棄チェックで常にフラグが立ちます。
+
+## 他のサンプルとの比較
+
+| | `examples/abandoned-packages-project` | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|---|
+| 主な機能 | `--check-abandoned`（特化） | CVE＋ライセンス＋放棄チェック | `--suggest-fix` アップグレードアドバイザー | `--workspace` モード |
+| 放棄デモ | ✅ あり（4パッケージ、常にフラグ） | 一部（PyPIの状態に依存） | ❌ 対象外 | ❌ 対象外 |
+| 脆弱なパッケージ | なし | 直接依存関係 | 間接依存関係 | N/A |
+| 設定ファイル | ❌ なし | ✅ あり（`config/`） | ❌ なし | ❌ なし |

--- a/examples/abandoned-packages-project/README.md
+++ b/examples/abandoned-packages-project/README.md
@@ -1,0 +1,92 @@
+# abandoned-packages-project
+
+An example project demonstrating the `--check-abandoned` feature of `uv-sbom` using Python
+packages whose **latest release on PyPI** is more than 2 years old.
+
+## Purpose
+
+This project exists because `--check-abandoned` queries PyPI for the **latest release date
+of each package** (not the locked version's date). Most demonstration projects pin *old
+versions* of actively maintained packages — but those packages have recent latest releases
+and are therefore **not** flagged as abandoned.
+
+This project uses packages that are genuinely unmaintained at the PyPI level: even the
+most recent version of each package is years old. Running `--check-abandoned` here always
+produces a non-empty Abandoned Packages section regardless of the threshold.
+
+> ⚠️ Do not use these packages in production.
+
+## Abandoned Packages in This Example
+
+| Package | Locked Version | Latest PyPI Release | Days Inactive (approx.) | Notes |
+|---------|---------------|--------------------|-----------------------|-------|
+| docopt  | 0.6.2         | 2014-06-16         | 4400+                 | Succeeded by `docopt-ng` |
+| nose    | 1.3.7         | 2015-06-02         | 3990+                 | Officially deprecated; use pytest |
+| pep8    | 1.7.1         | 2017-10-24         | 3100+                 | Renamed to `pycodestyle` |
+| Paver   | 1.3.4         | 2017-12-31         | 3050+                 | No active maintainer |
+
+`six` (a transitive dependency of Paver) is actively maintained and will **not** appear
+in the Abandoned Packages section.
+
+## Prerequisites
+
+- `uv-sbom` built from source (`cargo build --release`) or installed
+- Network access (one PyPI API call per package)
+
+## Usage
+
+### Step 1: Abandoned package check (default threshold: 730 days)
+
+```bash
+# From the repository root
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+**Expected Abandoned Packages section:**
+
+```markdown
+## Abandoned Packages
+
+Packages whose most recent upstream release exceeds the configured inactivity threshold.
+Inactive projects may carry unpatched vulnerabilities and pose long-term maintenance risk.
+
+| Package | Version | Last Release | Days Inactive | Type                |
+|---------|---------|--------------|---------------|---------------------|
+| docopt  | 0.6.2   | 2014-06-16   | 4346          | Direct dependencies |
+| nose    | 1.3.7   | 2015-06-02   | 3995          | Direct dependencies |
+| pep8    | 1.7.1   | 2017-10-24   | 3120          | Direct dependencies |
+| paver   | 1.3.4   | 2017-12-31   | 3052          | Direct dependencies |
+```
+
+### Step 2: Custom inactivity threshold
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned \
+  --abandoned-threshold-days 365 -f markdown
+```
+
+All 4 packages still appear (their last releases are 3000+ days ago).
+
+### Step 3: Combined with CVE check
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-cve --check-abandoned -f markdown
+```
+
+## Why Not Just Use `sample-project`?
+
+`examples/sample-project/` pins **old versions** of actively maintained packages
+(chardet 3.0.4, idna 2.10, etc.). Those packages have recent latest releases, so
+`--check-abandoned` returns 0 abandoned packages when run against `sample-project`.
+
+This project uses packages whose **latest** release is old, so the abandoned check
+always flags them.
+
+## Contrast with Other Examples
+
+| | `examples/abandoned-packages-project` | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|---|
+| Primary feature | `--check-abandoned` (focused) | CVE + license + abandoned | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
+| Abandoned demo | ✅ Yes (4 packages, always flagged) | Partial (depends on PyPI state) | ❌ Not focused | ❌ Not focused |
+| Vulnerable packages | None | Direct dependencies | Transitive dependencies | N/A |
+| Config file | ❌ No | ✅ Yes (`config/`) | ❌ No | ❌ No |

--- a/examples/abandoned-packages-project/pyproject.toml
+++ b/examples/abandoned-packages-project/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "abandoned-packages-project"
+version = "0.1.0"
+description = "Example project demonstrating --check-abandoned with genuinely unmaintained PyPI packages"
+requires-python = ">=3.11"
+dependencies = [
+    # Genuinely abandoned PyPI packages (latest release > 730 days ago).
+    # NOTE: These packages are intentionally unmaintained — DO NOT use in production.
+    "docopt==0.6.2",  # Last release: 2014-06-16 (~4400 days)
+    "nose==1.3.7",    # Last release: 2015-06-02 (~3990 days)
+    "pep8==1.7.1",    # Last release: 2017-10-24 (~3120 days)
+    "Paver==1.3.4",   # Last release: 2017-12-31 (~3050 days)
+]

--- a/examples/abandoned-packages-project/uv.lock
+++ b/examples/abandoned-packages-project/uv.lock
@@ -1,0 +1,67 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "abandoned-packages-project"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "docopt" },
+    { name = "nose" },
+    { name = "paver" },
+    { name = "pep8" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "docopt", specifier = "==0.6.2" },
+    { name = "nose", specifier = "==1.3.7" },
+    { name = "paver", specifier = "==1.3.4" },
+    { name = "pep8", specifier = "==1.7.1" },
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
+name = "nose"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz", hash = "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98", size = 280488, upload-time = "2015-06-02T09:12:32.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl", hash = "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac", size = 154731, upload-time = "2015-06-02T09:12:40.57Z" },
+]
+
+[[package]]
+name = "paver"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/df/c2aba0e68432471a252dc0d344f0a55f63104a1eeb83440e8e6b01cec47d/Paver-1.3.4.tar.gz", hash = "sha256:d3e6498881485ab750efe40c5278982a9343bc627e137b11adced627719308c7", size = 446425, upload-time = "2017-12-31T01:13:43.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1e/37ba8a75bd77ea56a75ef5ae66fe657b79205bbc36556c9456cd641782a4/Paver-1.3.4-py2.py3-none-any.whl", hash = "sha256:aeca608dc680abf58675e12b78d02817beb6d7ea5ae58ff2f917776d22d176fd", size = 428636, upload-time = "2017-12-31T01:13:41.452Z" },
+]
+
+[[package]]
+name = "pep8"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/a0/64ba19519db49e4094d82599412a9660dee8c26a7addbbb1bf17927ceefe/pep8-1.7.1.tar.gz", hash = "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374", size = 80334, upload-time = "2017-10-24T14:39:13.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/3f/669429ce58de2c22d8d2c542752e137ec4b9885fff398d3eceb1a7f5acb4/pep8-1.7.1-py2.py3-none-any.whl", hash = "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee", size = 41487, upload-time = "2017-10-24T14:39:11.465Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]

--- a/examples/sample-project/README.md
+++ b/examples/sample-project/README.md
@@ -12,7 +12,7 @@ realistic uv-sbom output for all three major opt-in analysis features:
 |---------|----------|------------------------|
 | CVE detection | `--check-cve` (default on) | Multiple known vulnerabilities in locked packages |
 | License compliance | `--check-license` | `chardet 3.0.4` uses LGPL-2.1-only (denied) |
-| Abandoned package detection | `--check-abandoned` | Several packages with no upstream release ≥ 730 days |
+| Abandoned package detection | `--check-abandoned` | Some packages may be flagged depending on PyPI state; see `examples/abandoned-packages-project/` for a focused demo |
 
 > ⚠️ **Do not use these package versions in production.** They are intentionally
 > outdated for demonstration purposes.
@@ -67,14 +67,15 @@ uv-sbom -p examples/sample-project -f markdown \
   -c examples/sample-project/config/uv-sbom.config.yml
 ```
 
-This exercises CVE, license, and abandoned detection in a single run
-(once Issue #565 adds `check_abandoned: true` to the config file).
+This exercises CVE, license, and abandoned detection in a single run.
 
 ## Contrast with other examples
 
-| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
-|---|---|---|---|
-| Primary feature | CVE + license + abandoned | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
-| Vulnerable packages | Direct dependencies | Transitive dependencies | N/A |
-| Abandoned demo | ✅ Yes | ❌ Not focused | ❌ Not focused |
-| Config file | ✅ Yes (`config/`) | ❌ No | ❌ No |
+| | `examples/sample-project` | `examples/abandoned-packages-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|---|
+| Primary feature | CVE + license + abandoned | `--check-abandoned` (focused) | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
+| Vulnerable packages | Direct dependencies | None | Transitive dependencies | N/A |
+| Abandoned demo | Partial (depends on PyPI state) | ✅ Yes (4 packages, always flagged) | ❌ Not focused | ❌ Not focused |
+| Config file | ✅ Yes (`config/`) | ❌ No | ❌ No | ❌ No |
+
+Use `abandoned-packages-project` to explore `--check-abandoned` in isolation with guaranteed output.

--- a/examples/suggest-fix-project/README-JP.md
+++ b/examples/suggest-fix-project/README-JP.md
@@ -104,13 +104,15 @@ uv-sbom -p examples/suggest-fix-project --check-cve --suggest-fix \
 | urllib3 | 2.0.4 | 2.6.0 | 🟠 HIGH | requests (2.31.0) | ⚠️ Cannot resolve: upgrading requests still resolves urllib3 to 2.0.4 which does not satisfy >= 2.6.0 | GHSA-2xpw-w6gg-jr37 |
 ```
 
-## `sample-project` との比較
+## 他のサンプルとの比較
 
-| | `examples/sample-project` | `examples/suggest-fix-project` |
-|---|---|---|
-| 脆弱なパッケージ | すべて**直接**依存関係 | すべて**推移的**依存関係 |
-| Resolution Guide | 非表示（推移的 CVE なし） | Recommended Action 付きで表示 |
-| `--suggest-fix` の出力 | アップグレード提案なし | Upgradable + Unresolvable のケース |
+| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/abandoned-packages-project` |
+|---|---|---|---|
+| 脆弱なパッケージ | すべて**直接**依存関係 | すべて**推移的**依存関係 | なし（放棄チェックに特化） |
+| Resolution Guide | 非表示（推移的 CVE なし） | Recommended Action 付きで表示 | 非表示 |
+| `--suggest-fix` の出力 | アップグレード提案なし | Upgradable + Unresolvable のケース | 対象外 |
+| `--check-abandoned` デモ | 一部 | ❌ 対象外 | ✅ あり（4パッケージ、常にフラグ） |
 
 基本的な CVE チェックや `--check-license` 機能を試す場合は `sample-project` を使用してください。
 `--suggest-fix` アップグレードアドバイザー機能を試す場合はこのプロジェクトを使用してください。
+`--check-abandoned` 機能を確実な出力で試す場合は `abandoned-packages-project` を使用してください。

--- a/examples/suggest-fix-project/README.md
+++ b/examples/suggest-fix-project/README.md
@@ -112,14 +112,15 @@ uv-sbom -p examples/suggest-fix-project --check-cve --suggest-fix \
 | urllib3 | 2.0.4 | 2.6.0 | 🟠 HIGH | requests (2.31.0) | ⚠️ Cannot resolve: upgrading requests still resolves urllib3 to 2.0.4 which does not satisfy >= 2.6.0 | GHSA-2xpw-w6gg-jr37 |
 ```
 
-## Contrast with `sample-project`
+## Contrast with other examples
 
-| | `examples/sample-project` | `examples/suggest-fix-project` |
-|---|---|---|
-| Vulnerable packages | All **direct** dependencies | All **transitive** dependencies |
-| Resolution Guide | Not shown (no transitive CVEs) | Shown with Recommended Action |
-| `--suggest-fix` output | No upgrade advice | Upgradable + Unresolvable cases |
-| `--check-abandoned` demo | ✅ See sample-project README | ❌ Not focused |
+| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/abandoned-packages-project` |
+|---|---|---|---|
+| Vulnerable packages | All **direct** dependencies | All **transitive** dependencies | None (focused on abandonment) |
+| Resolution Guide | Not shown (no transitive CVEs) | Shown with Recommended Action | Not shown |
+| `--suggest-fix` output | No upgrade advice | Upgradable + Unresolvable cases | Not focused |
+| `--check-abandoned` demo | Partial | ❌ Not focused | ✅ Yes (4 packages, always flagged) |
 
-Use `sample-project` to explore the basic CVE check, `--check-license`, and `--check-abandoned` features.
+Use `sample-project` to explore the basic CVE check and `--check-license` features.
 Use this project to explore the `--suggest-fix` Upgrade Advisor feature.
+Use `abandoned-packages-project` to explore `--check-abandoned` in isolation with guaranteed output.


### PR DESCRIPTION
## Summary

- Adds `examples/abandoned-packages-project/` containing four genuinely abandoned PyPI packages (docopt, nose, pep8, Paver) whose **latest** releases are more than 2 years old, ensuring `--check-abandoned` always produces non-empty output
- Updates contrast tables in `sample-project` and `suggest-fix-project` READMEs to include the new project
- Adds a "For a demo with guaranteed output" pointer in root `README.md` / `README-JP.md` under the Abandoned Package Detection section

## Related Issue

Closes #567

## Changes Made

- **New**: `examples/abandoned-packages-project/pyproject.toml` — declares docopt==0.6.2, nose==1.3.7, pep8==1.7.1, Paver==1.3.4 as direct dependencies
- **New**: `examples/abandoned-packages-project/uv.lock` — generated via `uv lock`; `six` appears as a transitive dep of Paver and is NOT flagged as abandoned
- **New**: `examples/abandoned-packages-project/README.md` — purpose, packages table with last-release dates, usage commands, expected output excerpt, contrast table
- **New**: `examples/abandoned-packages-project/README-JP.md` — Japanese translation of the above
- **Updated**: `examples/sample-project/README.md` — corrected the abandoned-demo claim from "Several packages with no upstream release ≥ 730 days" (inaccurate) to "Some packages may be flagged depending on PyPI state"; added new project to contrast table
- **Updated**: `examples/suggest-fix-project/README.md` + `README-JP.md` — added new project column to contrast table
- **Updated**: `README.md` + `README-JP.md` — added 4-line demo pointer after the `### Abandoned Package Detection` Note
- **Updated**: `CHANGELOG.md` — added entry under `[Unreleased] ### Added`

## Verification

Smoke test output (all 4 packages flagged):

```
| Package | Version | Last Release | Days Inactive | Type                |
|---------|---------|--------------|---------------|---------------------|
| docopt  | 0.6.2   | 2014-06-16   | 4346          | Direct dependencies |
| nose    | 1.3.7   | 2015-06-02   | 3995          | Direct dependencies |
| pep8    | 1.7.1   | 2017-10-24   | 3120          | Direct dependencies |
| paver   | 1.3.4   | 2017-12-31   | 3052          | Direct dependencies |
```

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (12 unit tests + 7 doc-tests)
- [x] `cargo run -- -p examples/abandoned-packages-project --check-abandoned -f markdown` produces Abandoned Packages section with 4 packages

---
Generated with [Claude Code](https://claude.com/claude-code)