### PR TITLE
process(pr): add Step 4.6 CLI flag documentation backstop gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,7 +62,7 @@ Skills contain mandatory pre-flight checks and language requirements that preven
 - **PR #121**: Created in Japanese, `cargo fmt --all -- --check` failed in CI
 - **Issue #59**: `cargo clippy` was run without `-D warnings`, causing CI failure after push
 - **2026-04-18**: v2.2.0 release promoted an empty `[Unreleased]` section. Features added in PRs #441–#483 were never recorded in CHANGELOG. Fixed by Issue #491 (added gate in `/release` Step 3.6 and `/pr` Step 4.5).
-- **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Fixed by Issue #568 (added CLI Flag Documentation Gate in `/implement` Step 4.3 and expanded README Update Checklist trigger).
+- **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Root cause: `/implement` Step 4 said "update docs as needed" without a concrete gate; `/pr` had no documentation backstop. Fixed by Issue #568 (`/implement` Step 4.3 CLI Flag Documentation Gate) and Issue #569 (`/pr` Step 4.6 CLI Flag Documentation Backstop).
 
 ### Enforcement
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -173,6 +173,65 @@ If user-facing changes are detected and CHANGELOG.md was **not** updated, output
 > **Note**: This gate complements `/release` Step 3.6 — catching missing entries at PR
 > time prevents the empty `[Unreleased]` scenario that caused the v2.2.0 incident (Issue #491).
 
+### Step 4.6: CLI Flag Documentation Backstop (conditional)
+
+**Trigger**: Run this gate if the current branch added, removed, or renamed
+any CLI flag (i.e., any `#[arg(` or `#[clap(` annotation was added/changed in `src/cli/`).
+
+Detect via:
+```bash
+git diff origin/develop...HEAD -G'#\[arg\(|#\[clap\(' -- 'src/cli/'
+```
+
+If the diff is **non-empty**, verify ALL of the following before proceeding to Step 5:
+
+#### A. README.md usage section
+
+- [ ] A new `###` subsection exists for the feature (or an existing section is updated)
+- [ ] At least one ` ```bash ` command example demonstrates the new flag
+- [ ] The Config File Schema Reference table includes the corresponding config key(s)
+- [ ] The Priority and Merge Rules section is updated if the resolution order changed
+
+#### B. README-JP.md
+
+- [ ] All changes from A are translated into Japanese and applied
+
+#### C. Example project config file
+
+- [ ] `examples/sample-project/config/uv-sbom.config.yml` includes the new config key
+  (commented out with the default value, matching the style of existing entries)
+
+#### D. Example project documentation
+
+- [ ] At least one example project README demonstrates the new flag
+
+**If any checkbox is unchecked**, output:
+
+> ⚠️ CLI documentation gap detected. The following items are missing for the new
+> flag `--<flag-name>`:
+>
+> - [ ] README.md usage section
+> - [ ] README-JP.md (Japanese translation)
+> - [ ] Example config file entry
+> - [ ] Example project README
+>
+> Please update the missing documentation and commit the changes before creating the PR.
+> Type **yes** to proceed anyway (only if all gaps are intentionally deferred with a
+> tracking Issue linked in the PR body), or **no** to abort.
+
+- **yes** (with tracking Issues linked): Proceed, add a note to PR body listing the deferred Issues.
+- **no** (or no response): **STOP**. Do not push or create the PR.
+
+**Do NOT skip this gate** even if the implementation plan did not list documentation files.
+
+### Relationship to /implement Step 4.3
+
+| | `/implement` Step 4.3 | `/pr` Step 4.6 |
+|---|---|---|
+| When it runs | During implementation, before code review | Before PR creation |
+| Purpose | Catch gaps early, prompt immediate fix | Backstop if Step 4.3 was skipped or incomplete |
+| On failure | Fix now, continue | Block or defer with linked Issue |
+
 ### Step 5: Push to Remote
 
 ```bash


### PR DESCRIPTION
## Summary

- Add **Step 4.6: CLI Flag Documentation Backstop** to the `/pr` skill, positioned between the CHANGELOG gate (Step 4.5) and Push to Remote (Step 5)
- The gate reuses the same detection logic and four checkboxes (A–D) as `/implement` Step 4.3 (Issue #568), creating a companion backstop at PR creation time
- Update the 2026-05-09 incident record in `CLAUDE.md` to cite both Issue #568 and Issue #569 as the complete fix

## Related Issue

Closes #569

## Changes Made

- `.claude/skills/pr/SKILL.md`: Added Step 4.6 with CLI flag detection, four documentation checkboxes (A–D), failure message with yes/no escape hatch, and a relationship table comparing it to `/implement` Step 4.3
- `.claude/CLAUDE.md`: Updated 2026-05-09 incident note to include root cause analysis and reference both Issue #568 and Issue #569

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Code review (Reviewer Agent) passed with no findings

---
Generated with [Claude Code](https://claude.com/claude-code)