### PR TITLE
refactor(ports,adapters): define DiffLockfileReader port and extract parse_lockfile_content as shared pub fn (#577)

### DIFF
--- a/src/adapters/outbound/filesystem/file_reader.rs
+++ b/src/adapters/outbound/filesystem/file_reader.rs
@@ -1,9 +1,8 @@
+use super::lockfile_parser::{parse_lockfile_content, parse_lockfile_content_for_member};
 use crate::ports::outbound::{LockfileParseResult, LockfileReader, ProjectConfigReader};
-use crate::sbom_generation::domain::Package;
 use crate::shared::error::SbomError;
 use crate::shared::security::{read_file_with_security, MAX_FILE_SIZE};
 use crate::shared::Result;
-use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 
 /// FileSystemReader adapter for reading files from the file system
@@ -45,7 +44,7 @@ impl LockfileReader for FileSystemReader {
         member_name: &str,
     ) -> Result<LockfileParseResult> {
         let lockfile_content = self.read_lockfile(project_path)?;
-        self.parse_lockfile_content_for_member(&lockfile_content, project_path, member_name)
+        parse_lockfile_content_for_member(&lockfile_content, project_path, member_name)
     }
 
     fn read_lockfile(&self, project_path: &Path) -> Result<String> {
@@ -75,210 +74,8 @@ impl LockfileReader for FileSystemReader {
     }
 
     fn read_and_parse_lockfile(&self, project_path: &Path) -> Result<LockfileParseResult> {
-        // Read the lockfile content
         let lockfile_content = self.read_lockfile(project_path)?;
-
-        // Parse TOML content
-        self.parse_lockfile_content(&lockfile_content, project_path)
-    }
-}
-
-impl FileSystemReader {
-    /// Parses lockfile content to extract packages and dependency map
-    ///
-    /// This method handles the TOML parsing logic which is an infrastructure concern.
-    /// It was moved from the application layer to properly separate concerns.
-    fn parse_lockfile_content(
-        &self,
-        content: &str,
-        project_path: &Path,
-    ) -> Result<LockfileParseResult> {
-        use serde::Deserialize;
-
-        #[derive(Debug, Deserialize)]
-        struct UvLock {
-            package: Vec<UvPackage>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvPackage {
-            name: String,
-            version: String,
-            #[serde(default)]
-            dependencies: Vec<UvDependency>,
-            #[serde(default, rename = "dev-dependencies")]
-            dev_dependencies: Option<DevDependencies>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvDependency {
-            name: String,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct DevDependencies {
-            #[serde(default)]
-            dev: Vec<UvDependency>,
-        }
-
-        let lockfile: UvLock =
-            toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-                path: project_path.join("uv.lock"),
-                details: e.to_string(),
-            })?;
-
-        let mut packages = Vec::new();
-        let mut dependency_map = HashMap::new();
-
-        for pkg in lockfile.package {
-            packages.push(Package::new(pkg.name.clone(), pkg.version.clone())?);
-
-            // Build dependency map
-            let mut deps = Vec::new();
-            for dep in &pkg.dependencies {
-                deps.push(dep.name.clone());
-            }
-            if let Some(dev_deps) = &pkg.dev_dependencies {
-                for dep in &dev_deps.dev {
-                    deps.push(dep.name.clone());
-                }
-            }
-            dependency_map.insert(pkg.name, deps);
-        }
-
-        Ok((packages, dependency_map))
-    }
-
-    /// Parse lockfile content and return only packages reachable from the given member.
-    ///
-    /// Identifies the member root package by matching `name == member_name` with either
-    /// `source.editable` or `source.virtual` set (uv < 0.5 uses `editable`; uv >= 0.5
-    /// uses `virtual` for packages without a build system), then performs BFS over the
-    /// dependency graph to collect all transitively reachable packages. The member root
-    /// itself is excluded.
-    fn parse_lockfile_content_for_member(
-        &self,
-        content: &str,
-        project_path: &Path,
-        member_name: &str,
-    ) -> Result<LockfileParseResult> {
-        use serde::Deserialize;
-
-        #[derive(Debug, Deserialize)]
-        struct PackageSource {
-            editable: Option<String>,
-            #[serde(rename = "virtual")]
-            virtual_path: Option<String>,
-        }
-
-        impl PackageSource {
-            fn is_local(&self) -> bool {
-                self.editable.is_some() || self.virtual_path.is_some()
-            }
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvPackage {
-            name: String,
-            version: String,
-            #[serde(default)]
-            dependencies: Vec<UvDependency>,
-            #[serde(default, rename = "dev-dependencies")]
-            dev_dependencies: Option<DevDependencies>,
-            source: Option<PackageSource>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvDependency {
-            name: String,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct DevDependencies {
-            #[serde(default)]
-            dev: Vec<UvDependency>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvLock {
-            package: Vec<UvPackage>,
-        }
-
-        let lockfile: UvLock =
-            toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-                path: project_path.join("uv.lock"),
-                details: e.to_string(),
-            })?;
-
-        // Build dependency map (name -> list of dependency names) and package lookup
-        let mut full_dep_map: HashMap<String, Vec<String>> = HashMap::new();
-        let mut pkg_lookup: HashMap<String, (String, String)> = HashMap::new(); // name -> (name, version)
-        let mut member_direct_deps: Option<Vec<String>> = None;
-
-        for pkg in &lockfile.package {
-            let mut deps: Vec<String> = pkg.dependencies.iter().map(|d| d.name.clone()).collect();
-            if let Some(dev_deps) = &pkg.dev_dependencies {
-                for dep in &dev_deps.dev {
-                    deps.push(dep.name.clone());
-                }
-            }
-
-            // Detect member root: name matches AND source is a local path
-            // (editable for uv < 0.5, virtual for uv >= 0.5)
-            let is_member_root = pkg.name == member_name
-                && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
-
-            if is_member_root {
-                member_direct_deps = Some(deps.clone());
-            }
-
-            full_dep_map.insert(pkg.name.clone(), deps);
-            pkg_lookup.insert(pkg.name.clone(), (pkg.name.clone(), pkg.version.clone()));
-        }
-
-        let direct_deps = member_direct_deps.ok_or_else(|| {
-            anyhow::anyhow!(
-                "Workspace member '{}' not found in uv.lock (no package with source.editable or source.virtual set)",
-                member_name
-            )
-        })?;
-
-        // BFS traversal from direct dependencies of the member root
-        let mut visited: HashSet<String> = HashSet::new();
-        let mut queue: VecDeque<String> = VecDeque::new();
-
-        for dep in direct_deps {
-            if !visited.contains(&dep) {
-                visited.insert(dep.clone());
-                queue.push_back(dep);
-            }
-        }
-
-        while let Some(current) = queue.pop_front() {
-            if let Some(deps) = full_dep_map.get(&current) {
-                for dep in deps {
-                    if !visited.contains(dep) {
-                        visited.insert(dep.clone());
-                        queue.push_back(dep.clone());
-                    }
-                }
-            }
-        }
-
-        // Build result from visited set (excluding member root itself)
-        let mut packages = Vec::new();
-        let mut dependency_map = HashMap::new();
-
-        for name in &visited {
-            if let Some((pkg_name, pkg_version)) = pkg_lookup.get(name) {
-                packages.push(Package::new(pkg_name.clone(), pkg_version.clone())?);
-                if let Some(deps) = full_dep_map.get(name) {
-                    dependency_map.insert(pkg_name.clone(), deps.clone());
-                }
-            }
-        }
-
-        Ok((packages, dependency_map))
+        parse_lockfile_content(&lockfile_content, project_path)
     }
 }
 
@@ -311,7 +108,6 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
     use std::fs;
-    use std::path::Path;
     use tempfile::TempDir;
 
     #[test]
@@ -405,15 +201,8 @@ version = "1.0.0"
         assert!(err_string.contains("Project name not found"));
     }
 
-    // Workspace lock fixture used by member-scoped filtering tests.
-    //
-    // Dependency graph:
-    //   alpha (editable) -> requests, certifi
-    //   beta  (editable) -> urllib3
-    //   requests         -> urllib3
-    //   urllib3          -> (none)
-    //   certifi          -> (none)
-    //   shared-lib       -> certifi
+    // Integration test: verifies FileSystemReader reads from disk and delegates
+    // parsing correctly to the lockfile_parser module.
     const WORKSPACE_LOCK_FOR_MEMBER: &str = r#"
 version = 1
 requires-python = ">=3.11"
@@ -469,97 +258,6 @@ source = { registry = "https://pypi.org/simple" }
 "#;
 
     #[test]
-    fn test_parse_lockfile_for_member_returns_correct_subtree_for_alpha() {
-        let reader = FileSystemReader::new();
-        let (packages, dep_map) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_FOR_MEMBER,
-                Path::new("/workspace"),
-                "alpha",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        // alpha itself must NOT appear
-        assert!(!names.contains("alpha"), "member root must be excluded");
-        // beta is not reachable from alpha
-        assert!(!names.contains("beta"), "sibling member must be excluded");
-        // shared-lib is not reachable from alpha
-        assert!(
-            !names.contains("shared-lib"),
-            "unreachable package must be excluded"
-        );
-
-        // alpha -> requests -> urllib3, alpha -> certifi
-        assert!(names.contains("requests"));
-        assert!(names.contains("urllib3"));
-        assert!(names.contains("certifi"));
-
-        // dependency_map must contain entries for all returned packages
-        assert!(dep_map.contains_key("requests"));
-        assert!(dep_map.contains_key("urllib3"));
-        assert!(dep_map.contains_key("certifi"));
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_returns_correct_subtree_for_beta() {
-        let reader = FileSystemReader::new();
-        let (packages, _dep_map) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_FOR_MEMBER,
-                Path::new("/workspace"),
-                "beta",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        assert!(!names.contains("beta"), "member root must be excluded");
-        assert!(!names.contains("alpha"), "sibling member must be excluded");
-        assert!(!names.contains("requests"), "unreachable from beta");
-        assert!(!names.contains("certifi"), "unreachable from beta");
-        assert!(!names.contains("shared-lib"), "unreachable from beta");
-
-        assert!(names.contains("urllib3"));
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_member_root_excluded() {
-        let reader = FileSystemReader::new();
-        let (packages, _) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_FOR_MEMBER,
-                Path::new("/workspace"),
-                "alpha",
-            )
-            .unwrap();
-
-        let names: Vec<String> = packages.iter().map(|p| p.name().to_string()).collect();
-        assert!(
-            !names.contains(&"alpha".to_string()),
-            "member root must not appear in result"
-        );
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_nonexistent_member_returns_error() {
-        let reader = FileSystemReader::new();
-        let result = reader.parse_lockfile_content_for_member(
-            WORKSPACE_LOCK_FOR_MEMBER,
-            Path::new("/workspace"),
-            "nonexistent-member",
-        );
-
-        assert!(result.is_err());
-        let err_string = result.unwrap_err().to_string();
-        assert!(
-            err_string.contains("nonexistent-member"),
-            "error must mention the missing member name"
-        );
-    }
-
-    #[test]
     fn test_read_and_parse_lockfile_for_member_reads_from_file() {
         let temp_dir = TempDir::new().unwrap();
         fs::write(temp_dir.path().join("uv.lock"), WORKSPACE_LOCK_FOR_MEMBER).unwrap();
@@ -574,94 +272,5 @@ source = { registry = "https://pypi.org/simple" }
         assert!(names.contains("urllib3"));
         assert!(names.contains("certifi"));
         assert!(!names.contains("alpha"));
-    }
-
-    // uv >= 0.5 workspace lock fixture using `source.virtual` instead of `source.editable`.
-    //
-    // Dependency graph:
-    //   api    (virtual at packages/api)    -> requests, fastapi
-    //   worker (virtual at packages/worker) -> celery
-    const WORKSPACE_LOCK_VIRTUAL_FORMAT: &str = r#"
-version = 1
-revision = 3
-requires-python = ">=3.11"
-
-[manifest]
-members = [
-    "api",
-    "worker",
-]
-
-[[package]]
-name = "api"
-version = "0.1.0"
-source = { virtual = "packages/api" }
-dependencies = [
-  { name = "fastapi" },
-  { name = "requests" },
-]
-
-[[package]]
-name = "celery"
-version = "5.4.0"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "fastapi"
-version = "0.115.0"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "requests"
-version = "2.32.3"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "worker"
-version = "0.1.0"
-source = { virtual = "packages/worker" }
-dependencies = [
-  { name = "celery" },
-]
-"#;
-
-    #[test]
-    fn test_parse_lockfile_for_member_handles_virtual_source_for_api() {
-        let reader = FileSystemReader::new();
-        let (packages, _) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_VIRTUAL_FORMAT,
-                Path::new("/workspace"),
-                "api",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        assert!(!names.contains("api"), "member root must be excluded");
-        assert!(!names.contains("worker"), "sibling member must be excluded");
-        assert!(names.contains("requests"));
-        assert!(names.contains("fastapi"));
-        assert!(!names.contains("celery"), "unreachable from api");
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_handles_virtual_source_for_worker() {
-        let reader = FileSystemReader::new();
-        let (packages, _) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_VIRTUAL_FORMAT,
-                Path::new("/workspace"),
-                "worker",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        assert!(!names.contains("worker"), "member root must be excluded");
-        assert!(!names.contains("api"), "sibling member must be excluded");
-        assert!(names.contains("celery"));
-        assert!(!names.contains("requests"), "unreachable from worker");
-        assert!(!names.contains("fastapi"), "unreachable from worker");
     }
 }

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -1,0 +1,478 @@
+use crate::ports::outbound::LockfileParseResult;
+use crate::sbom_generation::domain::Package;
+use crate::shared::error::SbomError;
+use crate::shared::Result;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+
+// Shared TOML deserialization structs.
+// Module-scoped so both parse functions share the same definitions.
+
+#[derive(Debug, Deserialize)]
+struct UvDependency {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevDependencies {
+    #[serde(default)]
+    dev: Vec<UvDependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageSource {
+    editable: Option<String>,
+    #[serde(rename = "virtual")]
+    virtual_path: Option<String>,
+}
+
+impl PackageSource {
+    fn is_local(&self) -> bool {
+        self.editable.is_some() || self.virtual_path.is_some()
+    }
+}
+
+/// Parse uv.lock TOML content into (packages, dependency_map).
+///
+/// Pure function: no I/O, no `&self`. Suitable for reuse by any adapter
+/// that has the raw lockfile bytes (filesystem, git blob, in-memory, etc.).
+pub fn parse_lockfile_content(content: &str, project_path: &Path) -> Result<LockfileParseResult> {
+    #[derive(Debug, Deserialize)]
+    struct UvPackage {
+        name: String,
+        version: String,
+        #[serde(default)]
+        dependencies: Vec<UvDependency>,
+        #[serde(default, rename = "dev-dependencies")]
+        dev_dependencies: Option<DevDependencies>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct UvLock {
+        package: Vec<UvPackage>,
+    }
+
+    let lockfile: UvLock =
+        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+            path: project_path.join("uv.lock"),
+            details: e.to_string(),
+        })?;
+
+    let mut packages = Vec::new();
+    let mut dependency_map = HashMap::new();
+
+    for pkg in lockfile.package {
+        packages.push(Package::new(pkg.name.clone(), pkg.version.clone())?);
+
+        let mut deps = Vec::new();
+        for dep in &pkg.dependencies {
+            deps.push(dep.name.clone());
+        }
+        if let Some(dev_deps) = &pkg.dev_dependencies {
+            for dep in &dev_deps.dev {
+                deps.push(dep.name.clone());
+            }
+        }
+        dependency_map.insert(pkg.name, deps);
+    }
+
+    Ok((packages, dependency_map))
+}
+
+/// Parse uv.lock TOML content and return only packages reachable from
+/// the workspace member named `member_name` (root excluded).
+///
+/// Identifies the member root package by matching `name == member_name` with either
+/// `source.editable` or `source.virtual` set (uv < 0.5 uses `editable`; uv >= 0.5
+/// uses `virtual` for packages without a build system), then performs BFS over the
+/// dependency graph to collect all transitively reachable packages. The member root
+/// itself is excluded.
+pub fn parse_lockfile_content_for_member(
+    content: &str,
+    project_path: &Path,
+    member_name: &str,
+) -> Result<LockfileParseResult> {
+    #[derive(Debug, Deserialize)]
+    struct UvPackage {
+        name: String,
+        version: String,
+        #[serde(default)]
+        dependencies: Vec<UvDependency>,
+        #[serde(default, rename = "dev-dependencies")]
+        dev_dependencies: Option<DevDependencies>,
+        source: Option<PackageSource>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct UvLock {
+        package: Vec<UvPackage>,
+    }
+
+    let lockfile: UvLock =
+        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+            path: project_path.join("uv.lock"),
+            details: e.to_string(),
+        })?;
+
+    let mut full_dep_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut pkg_lookup: HashMap<String, (String, String)> = HashMap::new();
+    let mut member_direct_deps: Option<Vec<String>> = None;
+
+    for pkg in &lockfile.package {
+        let deps = collect_all_deps(
+            &pkg.dependencies,
+            pkg.dev_dependencies.as_ref(),
+        );
+
+        let is_member_root = pkg.name == member_name
+            && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
+
+        if is_member_root {
+            member_direct_deps = Some(deps.clone());
+        }
+
+        full_dep_map.insert(pkg.name.clone(), deps);
+        pkg_lookup.insert(pkg.name.clone(), (pkg.name.clone(), pkg.version.clone()));
+    }
+
+    let direct_deps = member_direct_deps.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Workspace member '{}' not found in uv.lock (no package with source.editable or source.virtual set)",
+            member_name
+        )
+    })?;
+
+    let visited = bfs_reachable(&full_dep_map, direct_deps);
+
+    let mut packages = Vec::new();
+    let mut dependency_map = HashMap::new();
+
+    for name in &visited {
+        if let Some((pkg_name, pkg_version)) = pkg_lookup.get(name) {
+            packages.push(Package::new(pkg_name.clone(), pkg_version.clone())?);
+            if let Some(deps) = full_dep_map.get(name) {
+                dependency_map.insert(pkg_name.clone(), deps.clone());
+            }
+        }
+    }
+
+    Ok((packages, dependency_map))
+}
+
+/// Collect all dependency names from a package (runtime + dev).
+fn collect_all_deps(
+    dependencies: &[UvDependency],
+    dev_dependencies: Option<&DevDependencies>,
+) -> Vec<String> {
+    let mut deps: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+    if let Some(dev_deps) = dev_dependencies {
+        for dep in &dev_deps.dev {
+            deps.push(dep.name.clone());
+        }
+    }
+    deps
+}
+
+/// BFS traversal starting from `seeds`, returning all transitively reachable package names.
+fn bfs_reachable(dep_map: &HashMap<String, Vec<String>>, seeds: Vec<String>) -> HashSet<String> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    for dep in seeds {
+        if !visited.contains(&dep) {
+            visited.insert(dep.clone());
+            queue.push_back(dep);
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if let Some(deps) = dep_map.get(&current) {
+            for dep in deps {
+                if !visited.contains(dep) {
+                    visited.insert(dep.clone());
+                    queue.push_back(dep.clone());
+                }
+            }
+        }
+    }
+
+    visited
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    const SIMPLE_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "urllib3" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    #[test]
+    fn test_parse_lockfile_content_basic_returns_packages_and_deps() {
+        let (packages, dep_map) =
+            parse_lockfile_content(SIMPLE_LOCK, Path::new("/project")).unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+        assert!(names.contains("requests"));
+        assert!(names.contains("urllib3"));
+        assert_eq!(dep_map["requests"], vec!["urllib3"]);
+        assert!(dep_map["urllib3"].is_empty());
+    }
+
+    #[test]
+    fn test_parse_lockfile_content_invalid_toml_returns_error() {
+        let result = parse_lockfile_content("not valid toml [[[", Path::new("/project"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_lockfile_content_empty_lockfile_returns_no_packages() {
+        let content = "version = 1\n";
+        let result = parse_lockfile_content(content, Path::new("/project"));
+        assert!(result.is_err());
+    }
+
+    // Workspace lock fixture used by member-scoped filtering tests.
+    //
+    // Dependency graph:
+    //   alpha (editable) -> requests, certifi
+    //   beta  (editable) -> urllib3
+    //   requests         -> urllib3
+    //   urllib3          -> (none)
+    //   certifi          -> (none)
+    //   shared-lib       -> certifi
+    const WORKSPACE_LOCK_FOR_MEMBER: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[manifest]
+members = [
+    "packages/alpha",
+    "packages/beta",
+]
+
+[[package]]
+name = "alpha"
+version = "0.1.0"
+source = { editable = "packages/alpha" }
+dependencies = [
+  { name = "certifi" },
+  { name = "requests" },
+]
+
+[[package]]
+name = "beta"
+version = "0.2.0"
+source = { editable = "packages/beta" }
+dependencies = [
+  { name = "urllib3" },
+]
+
+[[package]]
+name = "certifi"
+version = "2024.1.1"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "urllib3" },
+]
+
+[[package]]
+name = "shared-lib"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "certifi" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    #[test]
+    fn test_parse_lockfile_for_member_returns_correct_subtree_for_alpha() {
+        let (packages, dep_map) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "alpha",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("alpha"), "member root must be excluded");
+        assert!(!names.contains("beta"), "sibling member must be excluded");
+        assert!(
+            !names.contains("shared-lib"),
+            "unreachable package must be excluded"
+        );
+
+        assert!(names.contains("requests"));
+        assert!(names.contains("urllib3"));
+        assert!(names.contains("certifi"));
+
+        assert!(dep_map.contains_key("requests"));
+        assert!(dep_map.contains_key("urllib3"));
+        assert!(dep_map.contains_key("certifi"));
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_returns_correct_subtree_for_beta() {
+        let (packages, _dep_map) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "beta",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("beta"), "member root must be excluded");
+        assert!(!names.contains("alpha"), "sibling member must be excluded");
+        assert!(!names.contains("requests"), "unreachable from beta");
+        assert!(!names.contains("certifi"), "unreachable from beta");
+        assert!(!names.contains("shared-lib"), "unreachable from beta");
+
+        assert!(names.contains("urllib3"));
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_member_root_excluded() {
+        let (packages, _) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "alpha",
+        )
+        .unwrap();
+
+        let names: Vec<String> = packages.iter().map(|p| p.name().to_string()).collect();
+        assert!(
+            !names.contains(&"alpha".to_string()),
+            "member root must not appear in result"
+        );
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_nonexistent_member_returns_error() {
+        let result = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "nonexistent-member",
+        );
+
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("nonexistent-member"),
+            "error must mention the missing member name"
+        );
+    }
+
+    // uv >= 0.5 workspace lock fixture using `source.virtual` instead of `source.editable`.
+    //
+    // Dependency graph:
+    //   api    (virtual at packages/api)    -> requests, fastapi
+    //   worker (virtual at packages/worker) -> celery
+    const WORKSPACE_LOCK_VIRTUAL_FORMAT: &str = r#"
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[manifest]
+members = [
+    "api",
+    "worker",
+]
+
+[[package]]
+name = "api"
+version = "0.1.0"
+source = { virtual = "packages/api" }
+dependencies = [
+  { name = "fastapi" },
+  { name = "requests" },
+]
+
+[[package]]
+name = "celery"
+version = "5.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "worker"
+version = "0.1.0"
+source = { virtual = "packages/worker" }
+dependencies = [
+  { name = "celery" },
+]
+"#;
+
+    #[test]
+    fn test_parse_lockfile_for_member_handles_virtual_source_for_api() {
+        let (packages, _) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_VIRTUAL_FORMAT,
+            Path::new("/workspace"),
+            "api",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("api"), "member root must be excluded");
+        assert!(!names.contains("worker"), "sibling member must be excluded");
+        assert!(names.contains("requests"));
+        assert!(names.contains("fastapi"));
+        assert!(!names.contains("celery"), "unreachable from api");
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_handles_virtual_source_for_worker() {
+        let (packages, _) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_VIRTUAL_FORMAT,
+            Path::new("/workspace"),
+            "worker",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("worker"), "member root must be excluded");
+        assert!(!names.contains("api"), "sibling member must be excluded");
+        assert!(names.contains("celery"));
+        assert!(!names.contains("requests"), "unreachable from worker");
+        assert!(!names.contains("fastapi"), "unreachable from worker");
+    }
+}

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -53,11 +53,10 @@ pub fn parse_lockfile_content(content: &str, project_path: &Path) -> Result<Lock
         package: Vec<UvPackage>,
     }
 
-    let lockfile: UvLock =
-        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-            path: project_path.join("uv.lock"),
-            details: e.to_string(),
-        })?;
+    let lockfile: UvLock = toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+        path: project_path.join("uv.lock"),
+        details: e.to_string(),
+    })?;
 
     let mut packages = Vec::new();
     let mut dependency_map = HashMap::new();
@@ -109,24 +108,20 @@ pub fn parse_lockfile_content_for_member(
         package: Vec<UvPackage>,
     }
 
-    let lockfile: UvLock =
-        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-            path: project_path.join("uv.lock"),
-            details: e.to_string(),
-        })?;
+    let lockfile: UvLock = toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+        path: project_path.join("uv.lock"),
+        details: e.to_string(),
+    })?;
 
     let mut full_dep_map: HashMap<String, Vec<String>> = HashMap::new();
     let mut pkg_lookup: HashMap<String, (String, String)> = HashMap::new();
     let mut member_direct_deps: Option<Vec<String>> = None;
 
     for pkg in &lockfile.package {
-        let deps = collect_all_deps(
-            &pkg.dependencies,
-            pkg.dev_dependencies.as_ref(),
-        );
+        let deps = collect_all_deps(&pkg.dependencies, pkg.dev_dependencies.as_ref());
 
-        let is_member_root = pkg.name == member_name
-            && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
+        let is_member_root =
+            pkg.name == member_name && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
 
         if is_member_root {
             member_direct_deps = Some(deps.clone());

--- a/src/adapters/outbound/filesystem/mod.rs
+++ b/src/adapters/outbound/filesystem/mod.rs
@@ -1,6 +1,7 @@
 /// Filesystem adapters for file I/O operations
 mod file_reader;
 mod file_writer;
+mod lockfile_parser;
 
 pub use file_reader::FileSystemReader;
 pub use file_writer::{FileSystemWriter, StdoutPresenter};

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -1,0 +1,35 @@
+use crate::sbom_generation::domain::Package;
+use crate::shared::Result;
+use std::path::{Path, PathBuf};
+
+/// Identifies where a base `uv.lock` should be read from for diff comparison.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffSource {
+    /// A git ref (branch, tag, or commit SHA). The lockfile is read from
+    /// that revision of the repository.
+    GitRef(String),
+    /// A path on the local filesystem pointing directly to a `uv.lock` file.
+    FilePath(PathBuf),
+}
+
+/// Outbound port for retrieving a "base" set of packages to diff against
+/// the current project's `uv.lock`.
+///
+/// Implementations:
+/// - `GitLockfileReader` (future, Issue #224) for `DiffSource::GitRef`
+/// - A filesystem-backed reader (future) for `DiffSource::FilePath`
+#[allow(dead_code)]
+pub trait DiffLockfileReader {
+    /// Read the lockfile identified by `source` (interpreted relative to
+    /// `project_path` when applicable) and return its packages.
+    ///
+    /// # Errors
+    /// Returns an error if the source cannot be resolved, the lockfile cannot
+    /// be read, or TOML parsing fails.
+    fn read_base_packages(
+        &self,
+        source: &DiffSource,
+        project_path: &Path,
+    ) -> Result<Vec<Package>>;
+}

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -27,9 +27,5 @@ pub trait DiffLockfileReader {
     /// # Errors
     /// Returns an error if the source cannot be resolved, the lockfile cannot
     /// be read, or TOML parsing fails.
-    fn read_base_packages(
-        &self,
-        source: &DiffSource,
-        project_path: &Path,
-    ) -> Result<Vec<Package>>;
+    fn read_base_packages(&self, source: &DiffSource, project_path: &Path) -> Result<Vec<Package>>;
 }

--- a/src/ports/outbound/lockfile_reader.rs
+++ b/src/ports/outbound/lockfile_reader.rs
@@ -48,9 +48,9 @@ pub trait LockfileReader {
     /// Parse the lockfile and return only packages reachable from the given member.
     ///
     /// Performs a BFS traversal starting from the `[[package]]` entry whose
-    /// `name == member_name` and `source.editable` is set, collecting all
-    /// transitively reachable packages. The member package itself is excluded
-    /// from the result.
+    /// `name == member_name` and `source.editable` (uv < 0.5) or `source.virtual`
+    /// (uv >= 0.5) is set, collecting all transitively reachable packages. The member
+    /// package itself is excluded from the result.
     ///
     /// # Arguments
     /// * `project_path` - Path to the project directory containing uv.lock
@@ -64,7 +64,7 @@ pub trait LockfileReader {
     /// Returns an error if:
     /// - The uv.lock file does not exist or cannot be read
     /// - The TOML parsing fails
-    /// - No package with `name == member_name` and `source.editable` set is found
+    /// - No package with `name == member_name` and `source.editable` or `source.virtual` set is found
     fn read_and_parse_lockfile_for_member(
         &self,
         project_path: &Path,

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -2,6 +2,7 @@
 ///
 /// These ports define the interfaces that the application core uses
 /// to interact with external systems (file system, network, console, etc.).
+pub mod diff_lockfile_reader;
 pub mod enriched_package;
 pub mod formatter;
 pub mod license_repository;
@@ -14,6 +15,9 @@ pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
 
+// Note: Will be used in a subsequent subtask of the dependency-diff feature (#224)
+#[allow(unused_imports)]
+pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
 pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};


### PR DESCRIPTION
## Summary

- Define `DiffSource` enum and `DiffLockfileReader` trait in new outbound port `src/ports/outbound/diff_lockfile_reader.rs`, enabling future `GitLockfileReader` adapter (part of #224)
- Extract `parse_lockfile_content` and `parse_lockfile_content_for_member` from private `FileSystemReader` methods into public standalone functions in new `src/adapters/outbound/filesystem/lockfile_parser.rs`; `FileSystemReader` now delegates to these free functions
- Refactor `parse_lockfile_content_for_member` by hoisting shared structs (`UvDependency`, `DevDependencies`, `PackageSource`) to module scope and extracting `collect_all_deps()` / `bfs_reachable()` helpers

## Related Issue

Closes #577
Part of #224

## Changes Made

- **NEW** `src/adapters/outbound/filesystem/lockfile_parser.rs`: hosts two `pub fn` standalone parsers; module-scoped shared structs eliminate struct duplication; `bfs_reachable()` isolates graph traversal logic
- **NEW** `src/ports/outbound/diff_lockfile_reader.rs`: `DiffSource { GitRef(String), FilePath(PathBuf) }` and `DiffLockfileReader` trait with `read_base_packages()`
- **MODIFIED** `src/adapters/outbound/filesystem/file_reader.rs`: removed ~200 lines of private parsing methods; `LockfileReader` impl now calls free functions; unit tests for member-scoped parsing migrated to `lockfile_parser.rs`
- **MODIFIED** `src/ports/outbound/lockfile_reader.rs`: corrected doc comment on `read_and_parse_lockfile_for_member` to reflect both `source.editable` (uv < 0.5) and `source.virtual` (uv >= 0.5)
- **MODIFIED** `src/ports/outbound/mod.rs`: registered `diff_lockfile_reader` module with `#[allow(unused_imports)]` re-export (matches convention for not-yet-consumed ports)

## Notes on `#[allow(dead_code)]` in `diff_lockfile_reader.rs`

In this lib+bin crate, `pub` items that are unused in `main.rs` trigger the `dead_code` lint in the binary target when compiled with `--all-targets`. `#[expect(dead_code)]` (Rust 1.81+) cannot be used here because the lib target does not trigger `dead_code` for `pub` items, making the expectation "unfulfilled" — which itself errors under `-D warnings`. The `#[allow(dead_code)]` pattern matches the existing precedent in `src/sbom_generation/domain/dependency_diff.rs` (line 2) and `dependency_diff_analyzer.rs` for types waiting for their consumer in a follow-up PR.

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (653 lib + 7 doc tests)
- [x] 9 unit tests in `lockfile_parser` (3 new + 6 migrated from `file_reader`)
- [x] Existing `FileSystemReader` integration tests unchanged and passing

---
Generated with [Claude Code](https://claude.com/claude-code)