### PR TITLE
feat(adapters): add DiffMarkdownFormatter and DiffJsonFormatter

### DIFF
--- a/src/adapters/outbound/formatters/diff_json_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_json_formatter.rs
@@ -1,0 +1,327 @@
+// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
+// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
+// (pub items are reachable by library consumers), making the expectation unfulfilled there.
+#![allow(dead_code)]
+
+use serde::Serialize;
+
+use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff};
+use crate::shared::Result;
+
+/// Formats a `DependencyDiff` as machine-readable JSON.
+///
+/// Output shape:
+/// ```json
+/// { "diff": { "base": "<ref>", "summary": {...}, "changes": [...] } }
+/// ```
+/// Version fields are omitted when not applicable (e.g. `old_version` for Added packages).
+pub struct DiffJsonFormatter;
+
+impl DiffJsonFormatter {
+    /// Creates a new `DiffJsonFormatter`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Serializes `diff` to a pretty-printed JSON string.
+    ///
+    /// # Errors
+    /// Returns an error if JSON serialization fails (in practice this cannot happen
+    /// because all field types are serializable).
+    pub fn format(&self, diff: &DependencyDiff) -> Result<String> {
+        let changes: Vec<ChangeDto> = diff
+            .changes
+            .iter()
+            .map(|c| {
+                let (old_version, new_version) = match c.change_type {
+                    ChangeType::Added => (None, c.new_version.as_deref()),
+                    ChangeType::Removed => (c.old_version.as_deref(), None),
+                    ChangeType::Updated | ChangeType::Unchanged => {
+                        (c.old_version.as_deref(), c.new_version.as_deref())
+                    }
+                };
+                ChangeDto {
+                    package: &c.package_name,
+                    change: change_label(&c.change_type),
+                    old_version,
+                    new_version,
+                    license: c.license.as_deref(),
+                }
+            })
+            .collect();
+
+        let envelope = DiffEnvelope {
+            diff: DiffBody {
+                base: &diff.base_ref,
+                summary: SummaryDto {
+                    added: diff.summary.added,
+                    removed: diff.summary.removed,
+                    updated: diff.summary.updated,
+                    unchanged: diff.summary.unchanged,
+                },
+                changes,
+            },
+        };
+
+        serde_json::to_string_pretty(&envelope).map_err(Into::into)
+    }
+}
+
+impl Default for DiffJsonFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn change_label(change_type: &ChangeType) -> &'static str {
+    match change_type {
+        ChangeType::Added => "added",
+        ChangeType::Removed => "removed",
+        ChangeType::Updated => "updated",
+        ChangeType::Unchanged => "unchanged",
+    }
+}
+
+#[derive(Serialize)]
+struct DiffEnvelope<'a> {
+    diff: DiffBody<'a>,
+}
+
+#[derive(Serialize)]
+struct DiffBody<'a> {
+    base: &'a str,
+    summary: SummaryDto,
+    changes: Vec<ChangeDto<'a>>,
+}
+
+#[derive(Serialize)]
+struct SummaryDto {
+    added: usize,
+    removed: usize,
+    updated: usize,
+    unchanged: usize,
+}
+
+#[derive(Serialize)]
+struct ChangeDto<'a> {
+    package: &'a str,
+    change: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<&'a str>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::dependency_diff::{
+        ChangeType, DependencyDiff, DiffSummary, PackageChange,
+    };
+    use serde_json::Value;
+
+    fn make_diff(changes: Vec<PackageChange>) -> DependencyDiff {
+        let summary = DiffSummary {
+            added: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Added)
+                .count(),
+            removed: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Removed)
+                .count(),
+            updated: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Updated)
+                .count(),
+            unchanged: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Unchanged)
+                .count(),
+        };
+        DependencyDiff {
+            base_ref: "main".to_string(),
+            changes,
+            summary,
+        }
+    }
+
+    fn make_change(
+        name: &str,
+        change_type: ChangeType,
+        old: Option<&str>,
+        new: Option<&str>,
+        license: Option<&str>,
+        vuln_count: usize,
+    ) -> PackageChange {
+        PackageChange {
+            package_name: name.to_string(),
+            change_type,
+            old_version: old.map(str::to_string),
+            new_version: new.map(str::to_string),
+            license: license.map(str::to_string),
+            vulnerability_count: vuln_count,
+        }
+    }
+
+    #[test]
+    fn test_top_level_shape_and_base_ref() {
+        let diff = make_diff(vec![]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+
+        assert!(json["diff"].is_object());
+        assert_eq!(json["diff"]["base"], "main");
+        assert!(json["diff"]["summary"].is_object());
+        assert!(json["diff"]["changes"].is_array());
+    }
+
+    #[test]
+    fn test_empty_diff() {
+        let diff = make_diff(vec![]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+
+        assert_eq!(json["diff"]["summary"]["added"], 0);
+        assert_eq!(json["diff"]["summary"]["removed"], 0);
+        assert_eq!(json["diff"]["summary"]["updated"], 0);
+        assert_eq!(json["diff"]["summary"]["unchanged"], 0);
+        assert_eq!(json["diff"]["changes"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_added_omits_old_version() {
+        let diff = make_diff(vec![make_change(
+            "pydantic",
+            ChangeType::Added,
+            None,
+            Some("2.9.0"),
+            Some("MIT"),
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "added");
+        assert_eq!(change["new_version"], "2.9.0");
+        assert!(change["old_version"].is_null());
+        assert_eq!(change["license"], "MIT");
+    }
+
+    #[test]
+    fn test_removed_omits_new_version() {
+        let diff = make_diff(vec![make_change(
+            "flask",
+            ChangeType::Removed,
+            Some("3.0.0"),
+            None,
+            Some("BSD-3-Clause"),
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "removed");
+        assert_eq!(change["old_version"], "3.0.0");
+        assert!(change["new_version"].is_null());
+    }
+
+    #[test]
+    fn test_updated_keeps_both_versions() {
+        let diff = make_diff(vec![make_change(
+            "requests",
+            ChangeType::Updated,
+            Some("2.31.0"),
+            Some("2.32.0"),
+            Some("Apache-2.0"),
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "updated");
+        assert_eq!(change["old_version"], "2.31.0");
+        assert_eq!(change["new_version"], "2.32.0");
+    }
+
+    #[test]
+    fn test_unchanged_keeps_both_versions() {
+        let diff = make_diff(vec![make_change(
+            "urllib3",
+            ChangeType::Unchanged,
+            Some("1.26.0"),
+            Some("1.26.0"),
+            None,
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "unchanged");
+        assert_eq!(change["old_version"], "1.26.0");
+        assert_eq!(change["new_version"], "1.26.0");
+    }
+
+    #[test]
+    fn test_missing_license_omits_field() {
+        let diff = make_diff(vec![make_change(
+            "somelib",
+            ChangeType::Added,
+            None,
+            Some("1.0.0"),
+            None,
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json_str = formatter.format(&diff).unwrap();
+        let json: Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(json["diff"]["changes"][0]["license"].is_null());
+        assert!(!json_str.contains("\"license\""));
+    }
+
+    #[test]
+    fn test_all_change_types_in_one_diff() {
+        let diff = make_diff(vec![
+            make_change("a", ChangeType::Added, None, Some("1.0.0"), Some("MIT"), 0),
+            make_change(
+                "b",
+                ChangeType::Removed,
+                Some("0.5.0"),
+                None,
+                Some("Apache-2.0"),
+                0,
+            ),
+            make_change(
+                "c",
+                ChangeType::Updated,
+                Some("2.0.0"),
+                Some("2.1.0"),
+                None,
+                1,
+            ),
+            make_change(
+                "d",
+                ChangeType::Unchanged,
+                Some("3.0.0"),
+                Some("3.0.0"),
+                None,
+                0,
+            ),
+        ]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+
+        assert_eq!(json["diff"]["summary"]["added"], 1);
+        assert_eq!(json["diff"]["summary"]["removed"], 1);
+        assert_eq!(json["diff"]["summary"]["updated"], 1);
+        assert_eq!(json["diff"]["summary"]["unchanged"], 1);
+        assert_eq!(json["diff"]["changes"].as_array().unwrap().len(), 4);
+    }
+}

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -1,0 +1,322 @@
+// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
+// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
+// (pub items are reachable by library consumers), making the expectation unfulfilled there.
+#![allow(dead_code)]
+
+use std::fmt::Write;
+
+use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff, PackageChange};
+
+/// Formats a `DependencyDiff` as a human-readable Markdown report.
+///
+/// Produces a two-section report: a summary table with aggregate counts, and a
+/// changes table listing every package with its change type, versions, license,
+/// and vulnerability count.
+pub struct DiffMarkdownFormatter;
+
+impl DiffMarkdownFormatter {
+    /// Creates a new `DiffMarkdownFormatter`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Formats `diff` as a Markdown string. This operation is infallible.
+    pub fn format(&self, diff: &DependencyDiff) -> String {
+        let mut out = String::new();
+
+        writeln!(out, "## Dependency Diff Report").unwrap();
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "Compared: `{}` vs current `uv.lock`",
+            diff.base_ref
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "### Summary").unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "| Metric | Count |").unwrap();
+        writeln!(out, "|--------|-------|").unwrap();
+        writeln!(out, "| Added | {} |", diff.summary.added).unwrap();
+        writeln!(out, "| Removed | {} |", diff.summary.removed).unwrap();
+        writeln!(out, "| Updated | {} |", diff.summary.updated).unwrap();
+        writeln!(out, "| Unchanged | {} |", diff.summary.unchanged).unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "### Changes").unwrap();
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "|---------|--------|-------------|-------------|---------|-----------------|"
+        )
+        .unwrap();
+
+        for change in &diff.changes {
+            writeln!(out, "{}", format_change_row(change)).unwrap();
+        }
+
+        out
+    }
+}
+
+impl Default for DiffMarkdownFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn format_change_row(change: &PackageChange) -> String {
+    let change_label = match change.change_type {
+        ChangeType::Added => "Added",
+        ChangeType::Removed => "Removed",
+        ChangeType::Updated => "Updated",
+        ChangeType::Unchanged => "Unchanged",
+    };
+    let old = version_cell(&change.old_version);
+    let new = version_cell(&change.new_version);
+    let license = version_cell(&change.license);
+    let vulns = vuln_cell(&change.change_type, change.vulnerability_count);
+    format!(
+        "| {} | {} | {} | {} | {} | {} |",
+        change.package_name, change_label, old, new, license, vulns
+    )
+}
+
+fn version_cell(opt: &Option<String>) -> &str {
+    opt.as_deref().unwrap_or("-")
+}
+
+fn vuln_cell(change_type: &ChangeType, count: usize) -> String {
+    if matches!(change_type, ChangeType::Removed) {
+        return "-".to_string();
+    }
+    if count == 0 {
+        "None".to_string()
+    } else {
+        count.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::dependency_diff::{
+        ChangeType, DependencyDiff, DiffSummary, PackageChange,
+    };
+
+    fn make_diff(changes: Vec<PackageChange>) -> DependencyDiff {
+        let summary = DiffSummary {
+            added: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Added)
+                .count(),
+            removed: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Removed)
+                .count(),
+            updated: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Updated)
+                .count(),
+            unchanged: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Unchanged)
+                .count(),
+        };
+        DependencyDiff {
+            base_ref: "main".to_string(),
+            changes,
+            summary,
+        }
+    }
+
+    fn make_change(
+        name: &str,
+        change_type: ChangeType,
+        old: Option<&str>,
+        new: Option<&str>,
+        license: Option<&str>,
+        vuln_count: usize,
+    ) -> PackageChange {
+        PackageChange {
+            package_name: name.to_string(),
+            change_type,
+            old_version: old.map(str::to_string),
+            new_version: new.map(str::to_string),
+            license: license.map(str::to_string),
+            vulnerability_count: vuln_count,
+        }
+    }
+
+    #[test]
+    fn test_header_and_compared_line() {
+        let diff = make_diff(vec![]);
+        let formatter = DiffMarkdownFormatter::new();
+        let md = formatter.format(&diff);
+
+        assert!(md.contains("## Dependency Diff Report"));
+        assert!(md.contains("Compared: `main` vs current `uv.lock`"));
+    }
+
+    #[test]
+    fn test_summary_table_rows() {
+        let diff = DependencyDiff {
+            base_ref: "main".to_string(),
+            changes: vec![],
+            summary: DiffSummary {
+                added: 2,
+                removed: 1,
+                updated: 3,
+                unchanged: 45,
+            },
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| Added | 2 |"));
+        assert!(md.contains("| Removed | 1 |"));
+        assert!(md.contains("| Updated | 3 |"));
+        assert!(md.contains("| Unchanged | 45 |"));
+    }
+
+    #[test]
+    fn test_changes_table_header_always_present() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains(
+            "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
+        ));
+        assert!(md.contains(
+            "|---------|--------|-------------|-------------|---------|-----------------|"
+        ));
+    }
+
+    #[test]
+    fn test_added_package_row() {
+        let diff = make_diff(vec![make_change(
+            "pydantic",
+            ChangeType::Added,
+            None,
+            Some("2.9.0"),
+            Some("MIT"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| pydantic | Added | - | 2.9.0 | MIT | None |"));
+    }
+
+    #[test]
+    fn test_removed_package_row() {
+        let diff = make_diff(vec![make_change(
+            "flask",
+            ChangeType::Removed,
+            Some("3.0.0"),
+            None,
+            Some("BSD-3-Clause"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| flask | Removed | 3.0.0 | - | BSD-3-Clause | - |"));
+    }
+
+    #[test]
+    fn test_updated_package_row() {
+        let diff = make_diff(vec![make_change(
+            "requests",
+            ChangeType::Updated,
+            Some("2.31.0"),
+            Some("2.32.0"),
+            Some("Apache-2.0"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| requests | Updated | 2.31.0 | 2.32.0 | Apache-2.0 | None |"));
+    }
+
+    #[test]
+    fn test_unchanged_package_row() {
+        let diff = make_diff(vec![make_change(
+            "urllib3",
+            ChangeType::Unchanged,
+            Some("1.26.0"),
+            Some("1.26.0"),
+            Some("MIT"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| urllib3 | Unchanged | 1.26.0 | 1.26.0 | MIT | None |"));
+    }
+
+    #[test]
+    fn test_vuln_cell_shows_count_when_nonzero() {
+        let diff = make_diff(vec![make_change(
+            "vuln-pkg",
+            ChangeType::Updated,
+            Some("1.0.0"),
+            Some("1.1.0"),
+            None,
+            3,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| vuln-pkg | Updated | 1.0.0 | 1.1.0 | - | 3 |"));
+    }
+
+    #[test]
+    fn test_vuln_cell_dash_for_removed_regardless_of_count() {
+        let diff = make_diff(vec![make_change(
+            "gone",
+            ChangeType::Removed,
+            Some("1.0.0"),
+            None,
+            None,
+            5,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| gone | Removed | 1.0.0 | - | - | - |"));
+    }
+
+    #[test]
+    fn test_missing_license_shows_dash() {
+        let diff = make_diff(vec![make_change(
+            "nolic",
+            ChangeType::Added,
+            None,
+            Some("0.1.0"),
+            None,
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| nolic | Added | - | 0.1.0 | - | None |"));
+    }
+
+    #[test]
+    fn test_section_order() {
+        let diff = DependencyDiff {
+            base_ref: "main".to_string(),
+            changes: vec![],
+            summary: DiffSummary {
+                added: 0,
+                removed: 0,
+                updated: 0,
+                unchanged: 0,
+            },
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff);
+        let summary_pos = md.find("### Summary").unwrap();
+        let changes_pos = md.find("### Changes").unwrap();
+        assert!(summary_pos < changes_pos);
+    }
+}

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -26,12 +26,7 @@ impl DiffMarkdownFormatter {
 
         writeln!(out, "## Dependency Diff Report").unwrap();
         writeln!(out).unwrap();
-        writeln!(
-            out,
-            "Compared: `{}` vs current `uv.lock`",
-            diff.base_ref
-        )
-        .unwrap();
+        writeln!(out, "Compared: `{}` vs current `uv.lock`", diff.base_ref).unwrap();
         writeln!(out).unwrap();
 
         writeln!(out, "### Summary").unwrap();

--- a/src/adapters/outbound/formatters/mod.rs
+++ b/src/adapters/outbound/formatters/mod.rs
@@ -1,6 +1,12 @@
 /// Formatter adapters for different SBOM output formats
 mod cyclonedx_formatter;
+mod diff_json_formatter;
+mod diff_markdown_formatter;
 mod markdown_formatter;
 
 pub use cyclonedx_formatter::CycloneDxFormatter;
+#[allow(unused_imports)]
+pub use diff_json_formatter::DiffJsonFormatter;
+#[allow(unused_imports)]
+pub use diff_markdown_formatter::DiffMarkdownFormatter;
 pub use markdown_formatter::MarkdownFormatter;


### PR DESCRIPTION
## Summary

- Add `DiffMarkdownFormatter` that formats a `DependencyDiff` as a human-readable Markdown report (summary table + per-package changes table). Return type: `String` (infallible).
- Add `DiffJsonFormatter` that serializes `DependencyDiff` to pretty-printed JSON using `serde_json`. Version fields are omitted when not applicable (e.g. `old_version` for Added packages). Return type: `Result<String>`.
- Register both formatters in `src/adapters/outbound/formatters/mod.rs`.

## Related Issue

Closes #579
Part of #224

## Changes Made

- `src/adapters/outbound/formatters/diff_json_formatter.rs` (new): JSON formatter with serde wire-format DTOs using borrowed lifetimes for zero-copy serialization; 8 unit tests.
- `src/adapters/outbound/formatters/diff_markdown_formatter.rs` (new): Markdown formatter with pipe-table rendering; 11 unit tests.
- `src/adapters/outbound/formatters/mod.rs`: Added `mod` declarations and `#[allow(unused_imports)] pub use` re-exports following the established #224 foundation code pattern.

## CHANGELOG Note

⚠️ CHANGELOG not updated — author confirmed internal-only. Both formatters are foundation code for the #224 epic and are dead in the binary target until wired to the CLI in a subsequent subtask. They follow the same `#![allow(dead_code)]` / `#[allow(unused_imports)]` pattern established by `dependency_diff.rs`, `git_lockfile_reader.rs`, and `ports/outbound/mod.rs`.

## Test Plan

- [x] `cargo test --all` passes (19 new tests: 8 JSON + 11 Markdown)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)