### PR TITLE
feat(application): add DiffRequest DTO and GenerateDiffUseCase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -204,6 +204,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
 | `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555 |
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
+| `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, format, check_cve) |
+| `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; CLI integration pending |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -187,7 +187,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `src/ports/outbound/` | Outbound port traits (e.g. repository, network interfaces) |
 | `src/adapters/inbound/` | Inbound adapter implementations |
 | `src/adapters/outbound/network/` | PyPI and OSV HTTP clients |
-| `src/adapters/outbound/formatters/` | CycloneDX and Markdown output formatters |
+| `src/adapters/outbound/formatters/` | CycloneDX, Markdown, and Diff (Markdown/JSON) output formatters |
 | `src/adapters/outbound/filesystem/` | File read/write adapters |
 | `src/adapters/outbound/uv/` | uv.lock file parsing |
 | `src/adapters/outbound/console/` | Console/progress reporter adapter |

--- a/src/application/dto/diff_request.rs
+++ b/src/application/dto/diff_request.rs
@@ -1,0 +1,55 @@
+use crate::application::dto::OutputFormat;
+use crate::ports::outbound::DiffSource;
+use std::path::PathBuf;
+
+/// DiffRequest - Internal request DTO for dependency diff generation use case.
+///
+/// Carries everything `GenerateDiffUseCase::execute` needs: where to read the
+/// "base" lockfile from, the project root holding the "current" `uv.lock`,
+/// the desired output format, and whether to enrich with CVE data.
+// Wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DiffRequest {
+    pub source: DiffSource,
+    pub project_path: PathBuf,
+    pub format: OutputFormat,
+    /// Whether to enrich results with CVE data. Currently a no-op; enrichment
+    /// will be implemented in a follow-up issue.
+    pub check_cve: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diff_request_with_git_ref() {
+        let req = DiffRequest {
+            source: DiffSource::GitRef("main".to_string()),
+            project_path: PathBuf::from("/project"),
+            format: OutputFormat::Json,
+            check_cve: false,
+        };
+        assert_eq!(req.source, DiffSource::GitRef("main".to_string()));
+        assert_eq!(req.project_path, PathBuf::from("/project"));
+        assert_eq!(req.format, OutputFormat::Json);
+        assert!(!req.check_cve);
+    }
+
+    #[test]
+    fn test_diff_request_with_file_path() {
+        let req = DiffRequest {
+            source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
+            project_path: PathBuf::from("/project"),
+            format: OutputFormat::Markdown,
+            check_cve: true,
+        };
+        assert_eq!(
+            req.source,
+            DiffSource::FilePath(PathBuf::from("/tmp/uv.lock"))
+        );
+        assert_eq!(req.format, OutputFormat::Markdown);
+        assert!(req.check_cve);
+    }
+}

--- a/src/application/dto/mod.rs
+++ b/src/application/dto/mod.rs
@@ -2,10 +2,14 @@
 ///
 /// DTOs are used to transfer data between the application layer
 /// and adapters, keeping the domain layer isolated.
+mod diff_request;
 mod output_format;
 mod sbom_request;
 mod sbom_response;
 
+// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(unused_imports)]
+pub use diff_request::DiffRequest;
 pub use output_format::OutputFormat;
 #[allow(unused_imports)]
 pub use sbom_request::{SbomRequest, SbomRequestBuilder};

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -1,0 +1,209 @@
+use crate::application::dto::DiffRequest;
+use crate::ports::outbound::{DiffLockfileReader, DiffSource, LockfileReader};
+use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
+use crate::sbom_generation::domain::services::DependencyDiffAnalyzer;
+use crate::shared::Result;
+
+// Wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(dead_code)]
+pub struct GenerateDiffUseCase<LR, DLR>
+where
+    LR: LockfileReader,
+    DLR: DiffLockfileReader,
+{
+    lockfile_reader: LR,
+    diff_reader: DLR,
+}
+
+#[allow(dead_code)]
+impl<LR, DLR> GenerateDiffUseCase<LR, DLR>
+where
+    LR: LockfileReader,
+    DLR: DiffLockfileReader,
+{
+    pub fn new(lockfile_reader: LR, diff_reader: DLR) -> Self {
+        Self {
+            lockfile_reader,
+            diff_reader,
+        }
+    }
+
+    /// Execute the diff use case.
+    ///
+    /// Reads the current `uv.lock` via `lockfile_reader`, reads the base packages
+    /// via `diff_reader`, and returns a `DependencyDiff` with `base_ref` set to
+    /// the string representation of the source. Non-UTF-8 path bytes are replaced
+    /// with U+FFFD (display use only — the string is never round-tripped to the FS).
+    ///
+    /// CVE enrichment (`check_cve`) is accepted but currently a no-op; it will be
+    /// wired in a follow-up issue.
+    pub fn execute(&self, request: DiffRequest) -> Result<DependencyDiff> {
+        let (current, _deps) = self
+            .lockfile_reader
+            .read_and_parse_lockfile(&request.project_path)?;
+
+        let base = self
+            .diff_reader
+            .read_base_packages(&request.source, &request.project_path)?;
+
+        let mut diff = DependencyDiffAnalyzer::analyze(&base, &current);
+
+        diff.base_ref = match &request.source {
+            DiffSource::GitRef(r) => r.clone(),
+            DiffSource::FilePath(p) => p.to_string_lossy().into_owned(),
+        };
+
+        // CVE enrichment deferred to a follow-up issue.
+        let _ = request.check_cve;
+
+        Ok(diff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::outbound::lockfile_reader::LockfileParseResult;
+    use crate::sbom_generation::domain::dependency_diff::ChangeType;
+    use crate::sbom_generation::domain::Package;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    fn pkg(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    struct StubLockfileReader {
+        packages: Vec<Package>,
+    }
+
+    impl LockfileReader for StubLockfileReader {
+        fn read_lockfile(&self, _project_path: &Path) -> Result<String> {
+            Ok(String::new())
+        }
+
+        fn read_and_parse_lockfile(&self, _project_path: &Path) -> Result<LockfileParseResult> {
+            Ok((self.packages.clone(), HashMap::new()))
+        }
+
+        fn read_and_parse_lockfile_for_member(
+            &self,
+            _project_path: &Path,
+            _member_name: &str,
+        ) -> Result<LockfileParseResult> {
+            Ok((self.packages.clone(), HashMap::new()))
+        }
+    }
+
+    struct StubDiffLockfileReader {
+        packages: Vec<Package>,
+    }
+
+    impl DiffLockfileReader for StubDiffLockfileReader {
+        fn read_base_packages(
+            &self,
+            _source: &DiffSource,
+            _project_path: &Path,
+        ) -> Result<Vec<Package>> {
+            Ok(self.packages.clone())
+        }
+    }
+
+    fn make_use_case(
+        current: Vec<Package>,
+        base: Vec<Package>,
+    ) -> GenerateDiffUseCase<StubLockfileReader, StubDiffLockfileReader> {
+        GenerateDiffUseCase::new(
+            StubLockfileReader { packages: current },
+            StubDiffLockfileReader { packages: base },
+        )
+    }
+
+    fn git_ref_request(ref_name: &str) -> DiffRequest {
+        DiffRequest {
+            source: DiffSource::GitRef(ref_name.to_string()),
+            project_path: PathBuf::from("/project"),
+            format: crate::application::dto::OutputFormat::Json,
+            check_cve: false,
+        }
+    }
+
+    #[test]
+    fn test_execute_detects_added_package() {
+        let uc = make_use_case(vec![pkg("requests", "2.31.0")], vec![]);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
+        assert_eq!(diff.changes[0].package_name, "requests");
+        assert_eq!(diff.summary.added, 1);
+    }
+
+    #[test]
+    fn test_execute_detects_removed_package() {
+        let uc = make_use_case(vec![], vec![pkg("requests", "2.31.0")]);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Removed);
+        assert_eq!(diff.summary.removed, 1);
+    }
+
+    #[test]
+    fn test_execute_detects_updated_package() {
+        let uc = make_use_case(
+            vec![pkg("urllib3", "2.0.7")],
+            vec![pkg("urllib3", "1.26.5")],
+        );
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
+        assert_eq!(diff.changes[0].old_version, Some("1.26.5".to_string()));
+        assert_eq!(diff.changes[0].new_version, Some("2.0.7".to_string()));
+        assert_eq!(diff.summary.updated, 1);
+    }
+
+    #[test]
+    fn test_execute_mixed_changes() {
+        let base = vec![pkg("a", "1.0"), pkg("b", "1.0"), pkg("c", "1.0")];
+        let current = vec![pkg("a", "1.0"), pkg("b", "2.0"), pkg("d", "1.0")];
+        let uc = make_use_case(current, base);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.summary.added, 1);
+        assert_eq!(diff.summary.updated, 1);
+        assert_eq!(diff.summary.removed, 1);
+        assert_eq!(diff.summary.unchanged, 1);
+    }
+
+    #[test]
+    fn test_execute_base_ref_uses_git_ref_string() {
+        let uc = make_use_case(vec![], vec![]);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.base_ref, "main");
+    }
+
+    #[test]
+    fn test_execute_base_ref_uses_file_path_string() {
+        let uc = make_use_case(vec![], vec![]);
+        let req = DiffRequest {
+            source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
+            project_path: PathBuf::from("/project"),
+            format: crate::application::dto::OutputFormat::Json,
+            check_cve: false,
+        };
+        let diff = uc.execute(req).unwrap();
+        assert_eq!(diff.base_ref, "/tmp/uv.lock");
+    }
+
+    #[test]
+    fn test_execute_check_cve_flag_is_currently_a_noop() {
+        let base = vec![pkg("a", "1.0")];
+        let current = vec![pkg("a", "2.0")];
+        let uc_false = make_use_case(current.clone(), base.clone());
+        let uc_true = make_use_case(current, base);
+        let diff_false = uc_false.execute(git_ref_request("main")).unwrap();
+        let mut req_cve = git_ref_request("main");
+        req_cve.check_cve = true;
+        let diff_true = uc_true.execute(req_cve).unwrap();
+        assert_eq!(diff_false.changes, diff_true.changes);
+        assert_eq!(diff_false.summary, diff_true.summary);
+    }
+}

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -2,6 +2,7 @@
 mod check_abandoned_packages;
 mod check_vulnerabilities;
 mod fetch_licenses;
+mod generate_diff;
 mod generate_sbom;
 
 #[cfg(test)]
@@ -10,4 +11,7 @@ pub(crate) mod test_doubles;
 pub use check_abandoned_packages::CheckAbandonedPackagesUseCase;
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
 pub use fetch_licenses::FetchLicensesUseCase;
+// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(unused_imports)]
+pub use generate_diff::GenerateDiffUseCase;
 pub use generate_sbom::GenerateSbomUseCase;

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -3,6 +3,7 @@ use crate::shared::Result;
 use std::path::{Path, PathBuf};
 
 /// Identifies where a base `uv.lock` should be read from for diff comparison.
+// Wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffSource {
@@ -19,6 +20,7 @@ pub enum DiffSource {
 /// Implementations:
 /// - `GitLockfileReader` (future, Issue #224) for `DiffSource::GitRef`
 /// - A filesystem-backed reader (future) for `DiffSource::FilePath`
+// Wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(dead_code)]
 pub trait DiffLockfileReader {
     /// Read the lockfile identified by `source` (interpreted relative to

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -15,7 +15,7 @@ pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
 
-// Note: Will be used in a subsequent subtask of the dependency-diff feature (#224)
+// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(unused_imports)]
 pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
 pub use enriched_package::EnrichedPackage;

--- a/src/sbom_generation/domain/dependency_diff.rs
+++ b/src/sbom_generation/domain/dependency_diff.rs
@@ -1,4 +1,4 @@
-// Foundation types for the dependency-diff feature; used by subsequent subtasks of #224.
+// Types for the dependency-diff feature; wired to the binary in a subsequent CLI integration subtask of #224.
 #![allow(dead_code)]
 
 /// Classification of how a package changed between two dependency snapshots.

--- a/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
+++ b/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
@@ -10,10 +10,10 @@ use crate::sbom_generation::domain::package::Package;
 ///
 /// All inputs and outputs are pure value objects — no I/O is performed.
 ///
-/// Note: `base_ref` is set to `"base"` in this implementation. Subsequent
-/// subtasks of the dependency-diff feature (#224) will introduce an entry
-/// point that accepts the actual git ref.
-// Foundation service for the dependency-diff feature; used by subsequent subtasks of #224.
+/// Note: `base_ref` is set to `"base"` in this implementation. Callers
+/// (e.g., `GenerateDiffUseCase`) override `base_ref` after calling `analyze`
+/// to reflect the actual `DiffSource` label.
+// Wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(dead_code)]
 pub struct DependencyDiffAnalyzer;
 


### PR DESCRIPTION
## Summary

- Add `DiffRequest` DTO that captures `source`, `project_path`, `format`, and `check_cve` for the diff use case
- Add `GenerateDiffUseCase<LR, DLR>` that reads current packages via `LockfileReader`, reads base packages via `DiffLockfileReader`, runs `DependencyDiffAnalyzer`, and sets `base_ref` from the `DiffSource` label
- CVE enrichment field is wired but deferred as a no-op pending a follow-up issue in the #224 epic

## Related Issue

Closes #580
Part of #224

## Changes Made

- `src/application/dto/diff_request.rs` — new `DiffRequest` DTO
- `src/application/use_cases/generate_diff.rs` — new `GenerateDiffUseCase` with 7 unit tests covering added/removed/updated/unchanged scenarios, GitRef and FilePath `base_ref` labeling, and `check_cve` no-op invariant
- `src/application/dto/mod.rs` — register and re-export `DiffRequest`
- `src/application/use_cases/mod.rs` — register and re-export `GenerateDiffUseCase`
- `src/ports/outbound/diff_lockfile_reader.rs` — refreshed `#[allow(dead_code)]` comments
- `src/sbom_generation/domain/dependency_diff.rs` — refreshed `#![allow(dead_code)]` comment
- `src/sbom_generation/domain/services/dependency_diff_analyzer.rs` — updated doc comment to describe `base_ref` override pattern

## Notes

- `CHANGELOG.md` not updated: this PR is internal-only. `GenerateDiffUseCase` is not yet wired to the binary (CLI integration is a subsequent subtask of #224). No user-visible behavior changes.
- Tests use inline `StubLockfileReader` and `StubDiffLockfileReader` in `#[cfg(test)] mod tests` — not added to `test_doubles.rs` (out of scope, avoids speculative stubs).
- `execute` is synchronous; will require async migration when CVE enrichment is wired in (VulnerabilityRepository is async).

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo test --all` passes

---
Generated with [Claude Code](https://claude.com/claude-code)