### PR TITLE
chore(release): prepare v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-05-21
+
 ### Added
 - **Dependency Diff (`--diff`)**: New `--diff <REF_OR_PATH>` flag compares the current `uv.lock` against a base version. Accepts a git ref (branch, tag, or commit SHA) or a path to a `uv.lock` file. Outputs a diff report in Markdown or JSON format. Mutually exclusive with `--workspace` and `--init` (#581).
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.3.0"
+version = "2.4.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.3.0"
+UV_SBOM_VERSION = "2.4.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v2.4.0
- Update version numbers in all required files
- Update CHANGELOG with release date

## Version Files Updated
- `Cargo.toml`: version = "2.4.0"
- `Cargo.lock`: regenerated via `cargo check`
- `python-wrapper/pyproject.toml`: version = "2.4.0"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "2.4.0"

## CHANGELOG
- Converted `[Unreleased]` to `[2.4.0] - 2026-05-21`
- Added empty `[Unreleased]` section above

## Changes in This Release

### Added
- **Dependency Diff (`--diff`)**: New `--diff <REF_OR_PATH>` flag compares the current `uv.lock` against a base version (#581)
- `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554)
- **Abandoned package detection**: Fetches maintenance metadata from PyPI, classifies inactive packages by threshold (#555)
- **Abandoned Packages Markdown section**: New `## Abandoned Packages` section in Markdown output, fully localized for EN and JA (#556)
- **Abandoned packages example**: `examples/abandoned-packages-project/` demonstrating `--check-abandoned` (#567)

## Test Plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] All version strings are consistent (2.4.0)

## Post-Merge Manual Steps
After merging this PR into `develop`:
1. Open a PR: `develop` → `main`
2. Merge the PR to main
3. Create tag: `git tag v2.4.0`
4. Push tag: `git push origin v2.4.0`
5. Verify CI release workflow completes successfully

Closes #591

---
Generated with [Claude Code](https://claude.com/claude-code)