### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -196,7 +196,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `MergedConfig` | `src/cli/config_resolver.rs` | Final resolved config (CLI > env > file > default) |
 | `ConfigFile` | `src/config.rs` | Raw deserialized config file struct |
 | `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
-| `GenerateSbomUseCase` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation |
+| `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555 |
+| `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,7 @@ Skills contain mandatory pre-flight checks and language requirements that preven
 - **PR #121**: Created in Japanese, `cargo fmt --all -- --check` failed in CI
 - **Issue #59**: `cargo clippy` was run without `-D warnings`, causing CI failure after push
 - **2026-04-18**: v2.2.0 release promoted an empty `[Unreleased]` section. Features added in PRs #441–#483 were never recorded in CHANGELOG. Fixed by Issue #491 (added gate in `/release` Step 3.6 and `/pr` Step 4.5).
+- **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Fixed by Issue #568 (added CLI Flag Documentation Gate in `/implement` Step 4.3 and expanded README Update Checklist trigger).
 
 ### Enforcement
 
@@ -147,7 +148,12 @@ Agents complement skills: the Release Manager agent judges readiness; the `/rele
 
 ## README Update Checklist
 
-When updating README.md, check if the following files also need updates:
+Trigger this checklist when **any** of the following is true:
+- README.md content is being changed directly
+- A new CLI flag or config key was added (see also: /implement Step 4.3)
+- A new user-facing feature was implemented
+
+When triggered, check if the following files also need updates:
 
 | File | Action Required | Notes |
 |------|-----------------|-------|

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -204,6 +204,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
 | `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555 |
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
+| `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, format, check_cve) |
+| `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; CLI integration pending |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,7 +62,7 @@ Skills contain mandatory pre-flight checks and language requirements that preven
 - **PR #121**: Created in Japanese, `cargo fmt --all -- --check` failed in CI
 - **Issue #59**: `cargo clippy` was run without `-D warnings`, causing CI failure after push
 - **2026-04-18**: v2.2.0 release promoted an empty `[Unreleased]` section. Features added in PRs #441–#483 were never recorded in CHANGELOG. Fixed by Issue #491 (added gate in `/release` Step 3.6 and `/pr` Step 4.5).
-- **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Fixed by Issue #568 (added CLI Flag Documentation Gate in `/implement` Step 4.3 and expanded README Update Checklist trigger).
+- **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Root cause: `/implement` Step 4 said "update docs as needed" without a concrete gate; `/pr` had no documentation backstop. Fixed by Issue #568 (`/implement` Step 4.3 CLI Flag Documentation Gate) and Issue #569 (`/pr` Step 4.6 CLI Flag Documentation Backstop).
 
 ### Enforcement
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -187,7 +187,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `src/ports/outbound/` | Outbound port traits (e.g. repository, network interfaces) |
 | `src/adapters/inbound/` | Inbound adapter implementations |
 | `src/adapters/outbound/network/` | PyPI and OSV HTTP clients |
-| `src/adapters/outbound/formatters/` | CycloneDX and Markdown output formatters |
+| `src/adapters/outbound/formatters/` | CycloneDX, Markdown, and Diff (Markdown/JSON) output formatters |
 | `src/adapters/outbound/filesystem/` | File read/write adapters |
 | `src/adapters/outbound/uv/` | uv.lock file parsing |
 | `src/adapters/outbound/console/` | Console/progress reporter adapter |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -204,8 +204,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
 | `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555 |
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
-| `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, format, check_cve) |
-| `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; CLI integration pending |
+| `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, check_cve) |
+| `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; wired to CLI via `--diff` flag (#581) |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -107,6 +107,43 @@ Accepted responses:
   MUST be added as a named key in both `EN_MESSAGES` and `JA_MESSAGES` in
   `src/i18n/mod.rs`. Never hardcode English text in output paths.
 
+### Step 4.3: CLI Flag Documentation Gate (conditional)
+
+**Trigger**: Run this gate if the current implementation added, removed, or renamed
+any CLI flag (i.e., any `#[arg(` or `#[clap(` annotation was added/changed in `src/cli/`).
+
+Detect via:
+```bash
+git diff origin/develop...HEAD -G'#\[arg\(|#\[clap\(' -- 'src/cli/'
+```
+
+If the diff is **non-empty**, verify ALL of the following before proceeding to Step 4.5:
+
+#### A. README.md usage section
+
+- [ ] A new `###` subsection exists for the feature (or an existing section is updated)
+- [ ] At least one ` ```bash ` command example demonstrates the new flag
+- [ ] The Config File Schema Reference table includes the corresponding config key(s)
+- [ ] The Priority and Merge Rules section is updated if the resolution order changed
+
+#### B. README-JP.md
+
+- [ ] All changes from A are translated into Japanese and applied
+
+#### C. Example project config file
+
+- [ ] `examples/sample-project/config/uv-sbom.config.yml` includes the new config key
+  (commented out with the default value, matching the style of existing entries)
+
+#### D. Example project documentation
+
+- [ ] At least one example project README demonstrates the new flag
+  (use `examples/sample-project/README.md` if it exists, otherwise note this as a gap)
+
+**If any checkbox is unchecked**: implement the missing documentation now, before invoking `/code-review`.
+
+**Do NOT skip this gate** even if the implementation plan did not explicitly list documentation files. Every new CLI flag requires all four checks.
+
 ### Step 4.5: Code Review (MANDATORY)
 
 Invoke `/code-review` skill.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -173,6 +173,65 @@ If user-facing changes are detected and CHANGELOG.md was **not** updated, output
 > **Note**: This gate complements `/release` Step 3.6 — catching missing entries at PR
 > time prevents the empty `[Unreleased]` scenario that caused the v2.2.0 incident (Issue #491).
 
+### Step 4.6: CLI Flag Documentation Backstop (conditional)
+
+**Trigger**: Run this gate if the current branch added, removed, or renamed
+any CLI flag (i.e., any `#[arg(` or `#[clap(` annotation was added/changed in `src/cli/`).
+
+Detect via:
+```bash
+git diff origin/develop...HEAD -G'#\[arg\(|#\[clap\(' -- 'src/cli/'
+```
+
+If the diff is **non-empty**, verify ALL of the following before proceeding to Step 5:
+
+#### A. README.md usage section
+
+- [ ] A new `###` subsection exists for the feature (or an existing section is updated)
+- [ ] At least one ` ```bash ` command example demonstrates the new flag
+- [ ] The Config File Schema Reference table includes the corresponding config key(s)
+- [ ] The Priority and Merge Rules section is updated if the resolution order changed
+
+#### B. README-JP.md
+
+- [ ] All changes from A are translated into Japanese and applied
+
+#### C. Example project config file
+
+- [ ] `examples/sample-project/config/uv-sbom.config.yml` includes the new config key
+  (commented out with the default value, matching the style of existing entries)
+
+#### D. Example project documentation
+
+- [ ] At least one example project README demonstrates the new flag
+
+**If any checkbox is unchecked**, output:
+
+> ⚠️ CLI documentation gap detected. The following items are missing for the new
+> flag `--<flag-name>`:
+>
+> - [ ] README.md usage section
+> - [ ] README-JP.md (Japanese translation)
+> - [ ] Example config file entry
+> - [ ] Example project README
+>
+> Please update the missing documentation and commit the changes before creating the PR.
+> Type **yes** to proceed anyway (only if all gaps are intentionally deferred with a
+> tracking Issue linked in the PR body), or **no** to abort.
+
+- **yes** (with tracking Issues linked): Proceed, add a note to PR body listing the deferred Issues.
+- **no** (or no response): **STOP**. Do not push or create the PR.
+
+**Do NOT skip this gate** even if the implementation plan did not list documentation files.
+
+### Relationship to /implement Step 4.3
+
+| | `/implement` Step 4.3 | `/pr` Step 4.6 |
+|---|---|---|
+| When it runs | During implementation, before code review | Before PR creation |
+| Purpose | Catch gaps early, prompt immediate fix | Backstop if Step 4.3 was skipped or incomplete |
+| On failure | Fix now, continue | Block or defer with linked Issue |
+
 ### Step 5: Push to Remote
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
+- **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
 
 ## [2.3.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
 - **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
+- **Abandoned Packages Markdown section**: When `--check-abandoned` is active, a new `## Abandoned Packages` section is rendered in Markdown output after License Compliance and before Resolution Guide, showing a table of Package, Version, Last Release, Days Inactive, and Type (Direct/Transitive). The Summary table includes an Abandoned packages row with ⚠️/✅ status, or a skipped notice when the check is not enabled. All strings are fully localized for EN and JA (#556).
 
 ## [2.3.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
+
 ## [2.3.0] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
 - **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
 - **Abandoned Packages Markdown section**: When `--check-abandoned` is active, a new `## Abandoned Packages` section is rendered in Markdown output after License Compliance and before Resolution Guide, showing a table of Package, Version, Last Release, Days Inactive, and Type (Direct/Transitive). The Summary table includes an Abandoned packages row with ⚠️/✅ status, or a skipped notice when the check is not enabled. All strings are fully localized for EN and JA (#556).
+- **Abandoned packages example**: Added `examples/abandoned-packages-project/` demonstrating `--check-abandoned` with genuinely unmaintained PyPI packages (docopt, nose, pep8, Paver) whose latest releases are more than 2 years old (#567).
 
 ## [2.3.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Dependency Diff (`--diff`)**: New `--diff <REF_OR_PATH>` flag compares the current `uv.lock` against a base version. Accepts a git ref (branch, tag, or commit SHA) or a path to a `uv.lock` file. Outputs a diff report in Markdown or JSON format. Mutually exclusive with `--workspace` and `--init` (#581).
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.
 - **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom now fetches maintenance metadata from PyPI for every package, classifies inactive packages by threshold, and reports a summary of abandoned direct and transitive dependencies. Non-empty results contribute to a non-zero exit code (#555).
 - **Abandoned Packages Markdown section**: When `--check-abandoned` is active, a new `## Abandoned Packages` section is rendered in Markdown output after License Compliance and before Resolution Guide, showing a table of Package, Version, Last Release, Days Inactive, and Type (Direct/Transitive). The Summary table includes an Abandoned packages row with ⚠️/✅ status, or a skipped notice when the check is not enabled. All strings are fully localized for EN and JA (#556).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-05-21
+
 ### Added
 - **Dependency Diff (`--diff`)**: New `--diff <REF_OR_PATH>` flag compares the current `uv.lock` against a base version. Accepts a git ref (branch, tag, or commit SHA) or a path to a `uv.lock` file. Outputs a diff report in Markdown or JSON format. Mutually exclusive with `--workspace` and `--init` (#581).
 - Added `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554). Accepts the flags and emits a localised notice; full detection logic ships in a follow-up issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,9 +1768,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -1768,9 +1768,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/README-JP.md
+++ b/README-JP.md
@@ -439,6 +439,14 @@ abandoned_threshold_days: 365  # オプション、デフォルト: 730
 
 > **注:** 廃止パッケージデータは現在Markdownのみで利用可能です。CycloneDX JSON出力は影響を受けません。
 
+確実に出力が得られるデモを実行するには：
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+詳細は [`examples/abandoned-packages-project/README-JP.md`](examples/abandoned-packages-project/README-JP.md) を参照してください。
+
 ### 脆弱性しきい値オプション
 
 しきい値オプションを使用して、どの脆弱性が終了コード1をトリガーするかを制御できます：

--- a/README-JP.md
+++ b/README-JP.md
@@ -20,6 +20,7 @@
 - 📊 複数のフォーマットに対応:
   - **CycloneDX 1.6** JSON形式（標準SBOM形式）
   - **Markdown**形式（直接依存と推移的依存を明確に分離）
+- 🔍 **廃止パッケージ検出** - 設定可能な日数（デフォルト: 730日）以内にPyPI上で新しいリリースがないパッケージを特定し、セキュリティパッチが行われていないメンテナンス停止の依存関係を把握できます
 - 🚀 高速でスタンドアロン - Rustで実装
 - 💾 標準出力またはファイルへ出力
 - 🛡️ 堅牢なエラーハンドリングと親切なエラーメッセージ・提案
@@ -315,6 +316,8 @@ license_policy:
 | `license_policy.allow` | string[] | No | 許可するライセンスパターン（ワイルドカード対応） |
 | `license_policy.deny` | string[] | No | 拒否するライセンスパターン（ワイルドカード対応） |
 | `license_policy.unknown` | string | No | 不明ライセンスの処理（`warn` / `deny` / `allow`） |
+| `check_abandoned` | bool | No | 廃止パッケージ検出を有効化（オプトイン、デフォルト: false） |
+| `abandoned_threshold_days` | integer | No | 廃止パッケージ検出の非アクティブ期間しきい値（日数、デフォルト: 730） |
 
 #### 優先度とマージルール
 
@@ -324,6 +327,7 @@ license_policy:
 - **`ignore_cves`** はCLI（`--ignore-cve`）と設定ファイルの両方から**マージ**され、IDで重複が除去されます（重複時はCLIの指定が優先）
 - **`check_license`** はCLIフラグまたは設定ファイルのいずれかで設定されていれば有効化（論理OR、`check_cve`と同様）
 - **`--license-allow`** と **`--license-deny`** CLIオプションは設定ファイルの `license_policy.allow` / `license_policy.deny` を**完全に上書き**します（マージされません）
+- **`check_abandoned`** はオプトイン（デフォルト: false）です。CLIフラグ `--check-abandoned` または設定ファイルの `check_abandoned: true` で有効化できます。`abandoned_threshold_days` の値はCLI > 設定ファイル > デフォルト（730）の順に解決されます。
 
 ### 特定のCVEを無視する
 
@@ -392,6 +396,48 @@ uv-sbom --check-license --severity-threshold high
   - `deny`: 不明ライセンスをポリシー違反として扱う
   - `allow`: 不明ライセンスを黙って許可
 - **終了コード**: ポリシー違反が検出された場合、終了コード1を返す
+
+### 廃止パッケージ検出
+
+`--check-abandoned` オプションを使用して、設定可能な日数以内にPyPI上で新しいリリースがないパッケージを特定できます。これにより、CVEが報告されていなくても長期的なリスクをもたらす可能性のあるメンテナンス停止の依存関係を把握できます。
+
+```bash
+# 廃止パッケージ検出を有効化（デフォルトしきい値: 730日 / 約2年）
+uv-sbom --check-abandoned --format markdown
+
+# カスタム非アクティブしきい値を使用（例: 365日 / 1年）
+uv-sbom --check-abandoned --abandoned-threshold-days 365
+
+# 脆弱性チェックとライセンスチェックと組み合わせ
+uv-sbom --check-abandoned --check-license --severity-threshold high
+```
+
+**動作の仕組み:**
+- パッケージごとにPyPIパッケージレベルエンドポイント（`https://pypi.org/pypi/{name}/json`）を照会します
+- 最新リリース日を設定されたしきい値を引いた今日の日付と比較します
+- しきい値を超えたパッケージはMarkdown出力の**Abandoned Packages**セクションに表示されます
+- パッケージのPyPIメタデータが取得できない場合、実行を中断せずにスキップします
+- ネットワークアクセスが必要で、パッケージごとに1回のAPIコールが追加されます
+
+**出力:**
+- **サマリーテーブル行**: カウント > 0 の場合 `| Abandoned packages | N | ⚠️ |`、0の場合 `✅`
+- **Abandoned Packagesセクション**: パッケージ名、バージョン、最終リリース日、非アクティブ日数、種別（Direct / Transitive）のテーブル
+- `--check-abandoned` を指定しない場合、セクションは完全に省略され、サマリー行には `_Abandoned package check skipped._` と表示されます
+
+**設定ファイル相当:**
+```yaml
+check_abandoned: true
+abandoned_threshold_days: 365  # オプション、デフォルト: 730
+```
+
+**CI統合例:**
+```yaml
+# GitHub Actions - 廃止パッケージ検出
+- name: Abandoned Package Detection
+  run: uv-sbom --check-abandoned --abandoned-threshold-days 730 --format markdown
+```
+
+> **注:** 廃止パッケージデータは現在Markdownのみで利用可能です。CycloneDX JSON出力は影響を受けません。
 
 ### 脆弱性しきい値オプション
 
@@ -465,6 +511,12 @@ CI/CDパイプライン統合には脆弱性しきい値を使用します：
 
 - name: Combined Security and License Check
   run: uv-sbom --check-license --severity-threshold high
+```
+
+```yaml
+# GitHub Actions - 廃止パッケージ検出
+- name: Abandoned Package Detection
+  run: uv-sbom --check-abandoned --format markdown
 ```
 
 ```yaml

--- a/README-JP.md
+++ b/README-JP.md
@@ -496,6 +496,40 @@ uv-sbom --format markdown --verify-links --output SBOM.md
 - ネットワークエラー時はプレーンテキストにフォールバック（クラッシュなし）
 - リクエストは並列実行（最大10同時接続）でパフォーマンスを確保
 
+### 依存関係Diff
+
+`--diff` オプションを使用して、現在の `uv.lock` を過去のバージョンと比較します。ブランチ、タグ、任意のロックファイルスナップショットとの差分をマージ前に確認するのに便利です。
+
+```bash
+# Gitブランチやタグと比較
+uv-sbom --diff main
+uv-sbom --diff v1.2.0
+uv-sbom --diff abc1234    # 短縮コミットSHA
+
+# ファイルパスとの比較（CWDからの絶対または相対パス）
+uv-sbom --diff /path/to/old/uv.lock
+
+# Markdownレポートとして出力
+uv-sbom --diff main --format markdown --output diff.md
+
+# JSONとして出力
+uv-sbom --diff main --format json
+```
+
+**自動判別:** 引数がディスク上の既存ファイルとして解決される場合はファイルパスとして扱い、そうでない場合はgit refとして扱います。相対パスはプロセスのワーキングディレクトリ（`--path` ではなく）から解決されます。
+
+**git ref検証:** git refに使用できる文字は `[a-zA-Z0-9._/-]` のみです。`-` で始まるrefも拒否されます。これによりコマンドインジェクションを防止します。
+
+**排他制約:** `--diff` は `--workspace` または `--init` と同時に使用できません。
+
+**CVEチェック:** デフォルトでは追加・更新されたパッケージのCVEチェックが有効です（`--no-check-cve` で無効化）。脆弱性が見つかった場合、プロセスはコード `1` で終了します。
+
+**CI例:**
+```bash
+# このPRで新規追加された依存関係に既知のCVEがある場合にビルドを失敗させる
+uv-sbom --diff origin/main --format markdown --output diff.md
+```
+
 ### CI統合
 
 CI/CDパイプライン統合には脆弱性しきい値を使用します：

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Generate SBOMs (Software Bill of Materials) for Python projects managed by [uv](
 - 📊 Outputs in multiple formats:
   - **CycloneDX 1.6** JSON format (standard SBOM format)
   - **Markdown** format with direct and transitive dependencies clearly separated
+- 🔍 **Abandoned Package Detection** - Identifies packages that have not received a new release on PyPI within a configurable number of days (default: 730), helping surface unmaintained dependencies with no active security patching
 - 🚀 Fast and standalone - written in Rust
 - 💾 Output to stdout or file
 - 🛡️ Robust error handling with helpful error messages and suggestions
@@ -316,6 +317,8 @@ license_policy:
 | `license_policy.allow` | string[] | No | Allowed license patterns (supports wildcards) |
 | `license_policy.deny` | string[] | No | Denied license patterns (supports wildcards) |
 | `license_policy.unknown` | string | No | Unknown license handling (`warn` / `deny` / `allow`) |
+| `check_abandoned` | bool | No | Enable abandoned package detection (opt-in, default: false) |
+| `abandoned_threshold_days` | integer | No | Inactivity threshold in days for abandoned package detection (default: 730) |
 
 #### Priority and Merge Rules
 
@@ -325,6 +328,7 @@ license_policy:
 - **`ignore_cves`** are **merged** from both CLI (`--ignore-cve`) and config file, deduplicated by ID (CLI entry takes precedence for duplicates)
 - **`check_license`** is enabled if set via CLI flag OR config file (logical OR, same as `check_cve`)
 - **`--license-allow`** and **`--license-deny`** CLI options **override** config file `license_policy.allow` / `license_policy.deny` entirely (not merged)
+- **`check_abandoned`** is opt-in (default: false). Enable via CLI flag `--check-abandoned` or config file `check_abandoned: true`. The `abandoned_threshold_days` value follows CLI > config file > default (730) resolution order.
 
 ### Ignoring specific CVEs
 
@@ -396,6 +400,48 @@ uv-sbom --check-license --severity-threshold high
   - `deny`: Treat unknown licenses as violations
   - `allow`: Silently allow unknown licenses
 - **Exit code**: Returns exit code 1 when policy violations are detected
+
+### Abandoned Package Detection
+
+Use the `--check-abandoned` option to identify packages that have not received a new release on PyPI within a configurable number of days. This surfaces unmaintained dependencies that may pose a long-term risk even when no CVE has been filed.
+
+```bash
+# Enable abandoned package detection (default threshold: 730 days / ~2 years)
+uv-sbom --check-abandoned --format markdown
+
+# Use a custom inactivity threshold (e.g., 365 days / 1 year)
+uv-sbom --check-abandoned --abandoned-threshold-days 365
+
+# Combined with vulnerability and license checks
+uv-sbom --check-abandoned --check-license --severity-threshold high
+```
+
+**How it works:**
+- Queries the PyPI package-level endpoint (`https://pypi.org/pypi/{name}/json`) for each package
+- Compares the latest release date against today minus the configured threshold
+- Packages exceeding the threshold appear in the **Abandoned Packages** section of the Markdown output
+- If a package's PyPI metadata cannot be fetched, it is skipped without aborting the run
+- Requires network access; adds one API call per package
+
+**Output:**
+- **Summary table row**: `| Abandoned packages | N | ⚠️ |` when count > 0, `✅` when count == 0
+- **Abandoned Packages section**: Table with Package, Version, Last Release date, Days Inactive, and Type (Direct / Transitive)
+- When `--check-abandoned` is not passed, the section is omitted entirely and the Summary row shows `_Abandoned package check skipped._`
+
+**Config file equivalent:**
+```yaml
+check_abandoned: true
+abandoned_threshold_days: 365  # optional, default: 730
+```
+
+**CI Integration example:**
+```yaml
+# GitHub Actions - Abandoned Package Check
+- name: Abandoned Package Detection
+  run: uv-sbom --check-abandoned --abandoned-threshold-days 730 --format markdown
+```
+
+> **Note:** Abandoned package data is currently Markdown-only. CycloneDX JSON output is not affected.
 
 ### Vulnerability Threshold Options
 
@@ -469,6 +515,12 @@ Use vulnerability thresholds for CI/CD pipeline integration:
 
 - name: Combined Security and License Check
   run: uv-sbom --check-license --severity-threshold high
+```
+
+```yaml
+# GitHub Actions - Abandoned Package Check
+- name: Abandoned Package Detection
+  run: uv-sbom --check-abandoned --format markdown
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -500,6 +500,40 @@ uv-sbom --format markdown --verify-links --output SBOM.md
 - Network errors gracefully fall back to plain text (no crash)
 - Requests are executed in parallel (max 10 concurrent) for performance
 
+### Dependency Diff
+
+Use the `--diff` option to compare the current `uv.lock` against a previous version. This is useful for reviewing what changed between branches, tags, or arbitrary lockfile snapshots before merging.
+
+```bash
+# Compare against a git branch or tag
+uv-sbom --diff main
+uv-sbom --diff v1.2.0
+uv-sbom --diff abc1234    # abbreviated commit SHA
+
+# Compare against a file path (absolute or relative to CWD)
+uv-sbom --diff /path/to/old/uv.lock
+
+# Output as Markdown report
+uv-sbom --diff main --format markdown --output diff.md
+
+# Output as JSON
+uv-sbom --diff main --format json
+```
+
+**Auto-detection:** If the argument resolves to an existing file on disk it is treated as a file path; otherwise it is treated as a git ref. Relative paths are resolved against the process working directory (not `--path`).
+
+**Git ref validation:** Only `[a-zA-Z0-9._/-]` characters are allowed in git refs. Refs starting with `-` are also rejected. This prevents command injection.
+
+**Mutual exclusion:** `--diff` cannot be combined with `--workspace` or `--init`.
+
+**CVE check:** By default CVE checking is enabled for added and updated packages (use `--no-check-cve` to disable). When a vulnerability is found, the process exits with code `1`.
+
+**CI example:**
+```bash
+# Fail the build if new dependencies introduced by this PR have known CVEs
+uv-sbom --diff origin/main --format markdown --output diff.md
+```
+
 ### CI Integration
 
 Use vulnerability thresholds for CI/CD pipeline integration:

--- a/README.md
+++ b/README.md
@@ -443,6 +443,14 @@ abandoned_threshold_days: 365  # optional, default: 730
 
 > **Note:** Abandoned package data is currently Markdown-only. CycloneDX JSON output is not affected.
 
+For a demo with guaranteed output, run:
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+See [`examples/abandoned-packages-project/README.md`](examples/abandoned-packages-project/README.md) for a full walkthrough.
+
 ### Vulnerability Threshold Options
 
 You can control which vulnerabilities trigger a non-zero exit code using threshold options:

--- a/examples/abandoned-packages-project/README-JP.md
+++ b/examples/abandoned-packages-project/README-JP.md
@@ -1,0 +1,82 @@
+# abandoned-packages-project
+
+PyPI上の**最新リリースが2年以上前**のPythonパッケージを使用して、`uv-sbom` の `--check-abandoned` 機能を実演するサンプルプロジェクトです。
+
+## 目的
+
+`--check-abandoned` は、ロックされたバージョンの日付ではなく、**パッケージの最新リリース日**をPyPIに問い合わせます。ほとんどのデモプロジェクトは、活発にメンテナンスされているパッケージの古いバージョンをピン留めしています。しかしそれらは最新リリースが最近であるため、放棄されたパッケージとして**フラグが立ちません**。
+
+このプロジェクトは、PyPIレベルで本当にメンテナンスされていないパッケージを使用しています。各パッケージの最新バージョンでさえ何年も前のものです。そのため、`--check-abandoned` を実行すると、閾値に関わらず常に空でない「放棄されたパッケージ」セクションが表示されます。
+
+> ⚠️ これらのパッケージを本番環境で使用しないでください。
+
+## このサンプルに含まれる放棄されたパッケージ
+
+| パッケージ | ロックバージョン | 最新PyPIリリース | 非活動日数（目安） | 備考 |
+|-----------|--------------|----------------|-----------------|------|
+| docopt  | 0.6.2         | 2014-06-16     | 4400日以上        | `docopt-ng` に引き継がれた |
+| nose    | 1.3.7         | 2015-06-02     | 3990日以上        | 公式に非推奨。pytestを使用 |
+| pep8    | 1.7.1         | 2017-10-24     | 3100日以上        | `pycodestyle` に改名 |
+| Paver   | 1.3.4         | 2017-12-31     | 3050日以上        | アクティブなメンテナなし |
+
+`six`（Paverのtransitive dependency）は活発にメンテナンスされており、放棄されたパッケージセクションには**表示されません**。
+
+## 前提条件
+
+- `uv-sbom` をソースからビルド済み（`cargo build --release`）またはインストール済み
+- ネットワークアクセス（パッケージごとに1回PyPI APIを呼び出します）
+
+## 使用方法
+
+### Step 1: 放棄されたパッケージのチェック（デフォルト閾値: 730日）
+
+```bash
+# リポジトリルートから実行
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+**期待される放棄されたパッケージセクション:**
+
+```markdown
+## Abandoned Packages
+
+Packages whose most recent upstream release exceeds the configured inactivity threshold.
+Inactive projects may carry unpatched vulnerabilities and pose long-term maintenance risk.
+
+| Package | Version | Last Release | Days Inactive | Type                |
+|---------|---------|--------------|---------------|---------------------|
+| docopt  | 0.6.2   | 2014-06-16   | 4346          | Direct dependencies |
+| nose    | 1.3.7   | 2015-06-02   | 3995          | Direct dependencies |
+| pep8    | 1.7.1   | 2017-10-24   | 3120          | Direct dependencies |
+| paver   | 1.3.4   | 2017-12-31   | 3052          | Direct dependencies |
+```
+
+### Step 2: カスタム非活動閾値
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned \
+  --abandoned-threshold-days 365 -f markdown
+```
+
+4つのパッケージすべてが引き続き表示されます（最終リリースは3000日以上前）。
+
+### Step 3: CVEチェックとの組み合わせ
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-cve --check-abandoned -f markdown
+```
+
+## なぜ `sample-project` を使わないのか？
+
+`examples/sample-project/` は活発にメンテナンスされているパッケージの古いバージョン（chardet 3.0.4、idna 2.10 など）をピン留めしています。これらのパッケージは最新リリースが最近であるため、`--check-abandoned` を `sample-project` に対して実行すると、放棄されたパッケージは0件になります。
+
+このプロジェクトは**最新**リリースが古いパッケージを使用しているため、放棄チェックで常にフラグが立ちます。
+
+## 他のサンプルとの比較
+
+| | `examples/abandoned-packages-project` | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|---|
+| 主な機能 | `--check-abandoned`（特化） | CVE＋ライセンス＋放棄チェック | `--suggest-fix` アップグレードアドバイザー | `--workspace` モード |
+| 放棄デモ | ✅ あり（4パッケージ、常にフラグ） | 一部（PyPIの状態に依存） | ❌ 対象外 | ❌ 対象外 |
+| 脆弱なパッケージ | なし | 直接依存関係 | 間接依存関係 | N/A |
+| 設定ファイル | ❌ なし | ✅ あり（`config/`） | ❌ なし | ❌ なし |

--- a/examples/abandoned-packages-project/README.md
+++ b/examples/abandoned-packages-project/README.md
@@ -1,0 +1,92 @@
+# abandoned-packages-project
+
+An example project demonstrating the `--check-abandoned` feature of `uv-sbom` using Python
+packages whose **latest release on PyPI** is more than 2 years old.
+
+## Purpose
+
+This project exists because `--check-abandoned` queries PyPI for the **latest release date
+of each package** (not the locked version's date). Most demonstration projects pin *old
+versions* of actively maintained packages — but those packages have recent latest releases
+and are therefore **not** flagged as abandoned.
+
+This project uses packages that are genuinely unmaintained at the PyPI level: even the
+most recent version of each package is years old. Running `--check-abandoned` here always
+produces a non-empty Abandoned Packages section regardless of the threshold.
+
+> ⚠️ Do not use these packages in production.
+
+## Abandoned Packages in This Example
+
+| Package | Locked Version | Latest PyPI Release | Days Inactive (approx.) | Notes |
+|---------|---------------|--------------------|-----------------------|-------|
+| docopt  | 0.6.2         | 2014-06-16         | 4400+                 | Succeeded by `docopt-ng` |
+| nose    | 1.3.7         | 2015-06-02         | 3990+                 | Officially deprecated; use pytest |
+| pep8    | 1.7.1         | 2017-10-24         | 3100+                 | Renamed to `pycodestyle` |
+| Paver   | 1.3.4         | 2017-12-31         | 3050+                 | No active maintainer |
+
+`six` (a transitive dependency of Paver) is actively maintained and will **not** appear
+in the Abandoned Packages section.
+
+## Prerequisites
+
+- `uv-sbom` built from source (`cargo build --release`) or installed
+- Network access (one PyPI API call per package)
+
+## Usage
+
+### Step 1: Abandoned package check (default threshold: 730 days)
+
+```bash
+# From the repository root
+uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
+```
+
+**Expected Abandoned Packages section:**
+
+```markdown
+## Abandoned Packages
+
+Packages whose most recent upstream release exceeds the configured inactivity threshold.
+Inactive projects may carry unpatched vulnerabilities and pose long-term maintenance risk.
+
+| Package | Version | Last Release | Days Inactive | Type                |
+|---------|---------|--------------|---------------|---------------------|
+| docopt  | 0.6.2   | 2014-06-16   | 4346          | Direct dependencies |
+| nose    | 1.3.7   | 2015-06-02   | 3995          | Direct dependencies |
+| pep8    | 1.7.1   | 2017-10-24   | 3120          | Direct dependencies |
+| paver   | 1.3.4   | 2017-12-31   | 3052          | Direct dependencies |
+```
+
+### Step 2: Custom inactivity threshold
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-abandoned \
+  --abandoned-threshold-days 365 -f markdown
+```
+
+All 4 packages still appear (their last releases are 3000+ days ago).
+
+### Step 3: Combined with CVE check
+
+```bash
+uv-sbom -p examples/abandoned-packages-project --check-cve --check-abandoned -f markdown
+```
+
+## Why Not Just Use `sample-project`?
+
+`examples/sample-project/` pins **old versions** of actively maintained packages
+(chardet 3.0.4, idna 2.10, etc.). Those packages have recent latest releases, so
+`--check-abandoned` returns 0 abandoned packages when run against `sample-project`.
+
+This project uses packages whose **latest** release is old, so the abandoned check
+always flags them.
+
+## Contrast with Other Examples
+
+| | `examples/abandoned-packages-project` | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|---|
+| Primary feature | `--check-abandoned` (focused) | CVE + license + abandoned | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
+| Abandoned demo | ✅ Yes (4 packages, always flagged) | Partial (depends on PyPI state) | ❌ Not focused | ❌ Not focused |
+| Vulnerable packages | None | Direct dependencies | Transitive dependencies | N/A |
+| Config file | ❌ No | ✅ Yes (`config/`) | ❌ No | ❌ No |

--- a/examples/abandoned-packages-project/pyproject.toml
+++ b/examples/abandoned-packages-project/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "abandoned-packages-project"
+version = "0.1.0"
+description = "Example project demonstrating --check-abandoned with genuinely unmaintained PyPI packages"
+requires-python = ">=3.11"
+dependencies = [
+    # Genuinely abandoned PyPI packages (latest release > 730 days ago).
+    # NOTE: These packages are intentionally unmaintained — DO NOT use in production.
+    "docopt==0.6.2",  # Last release: 2014-06-16 (~4400 days)
+    "nose==1.3.7",    # Last release: 2015-06-02 (~3990 days)
+    "pep8==1.7.1",    # Last release: 2017-10-24 (~3120 days)
+    "Paver==1.3.4",   # Last release: 2017-12-31 (~3050 days)
+]

--- a/examples/abandoned-packages-project/uv.lock
+++ b/examples/abandoned-packages-project/uv.lock
@@ -1,0 +1,67 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "abandoned-packages-project"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "docopt" },
+    { name = "nose" },
+    { name = "paver" },
+    { name = "pep8" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "docopt", specifier = "==0.6.2" },
+    { name = "nose", specifier = "==1.3.7" },
+    { name = "paver", specifier = "==1.3.4" },
+    { name = "pep8", specifier = "==1.7.1" },
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
+name = "nose"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz", hash = "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98", size = 280488, upload-time = "2015-06-02T09:12:32.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl", hash = "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac", size = 154731, upload-time = "2015-06-02T09:12:40.57Z" },
+]
+
+[[package]]
+name = "paver"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/df/c2aba0e68432471a252dc0d344f0a55f63104a1eeb83440e8e6b01cec47d/Paver-1.3.4.tar.gz", hash = "sha256:d3e6498881485ab750efe40c5278982a9343bc627e137b11adced627719308c7", size = 446425, upload-time = "2017-12-31T01:13:43.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1e/37ba8a75bd77ea56a75ef5ae66fe657b79205bbc36556c9456cd641782a4/Paver-1.3.4-py2.py3-none-any.whl", hash = "sha256:aeca608dc680abf58675e12b78d02817beb6d7ea5ae58ff2f917776d22d176fd", size = 428636, upload-time = "2017-12-31T01:13:41.452Z" },
+]
+
+[[package]]
+name = "pep8"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/a0/64ba19519db49e4094d82599412a9660dee8c26a7addbbb1bf17927ceefe/pep8-1.7.1.tar.gz", hash = "sha256:fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374", size = 80334, upload-time = "2017-10-24T14:39:13.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/3f/669429ce58de2c22d8d2c542752e137ec4b9885fff398d3eceb1a7f5acb4/pep8-1.7.1-py2.py3-none-any.whl", hash = "sha256:b22cfae5db09833bb9bd7c8463b53e1a9c9b39f12e304a8d0bba729c501827ee", size = 41487, upload-time = "2017-10-24T14:39:11.465Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]

--- a/examples/sample-project/README.md
+++ b/examples/sample-project/README.md
@@ -12,7 +12,7 @@ realistic uv-sbom output for all three major opt-in analysis features:
 |---------|----------|------------------------|
 | CVE detection | `--check-cve` (default on) | Multiple known vulnerabilities in locked packages |
 | License compliance | `--check-license` | `chardet 3.0.4` uses LGPL-2.1-only (denied) |
-| Abandoned package detection | `--check-abandoned` | Several packages with no upstream release ≥ 730 days |
+| Abandoned package detection | `--check-abandoned` | Some packages may be flagged depending on PyPI state; see `examples/abandoned-packages-project/` for a focused demo |
 
 > ⚠️ **Do not use these package versions in production.** They are intentionally
 > outdated for demonstration purposes.
@@ -67,14 +67,15 @@ uv-sbom -p examples/sample-project -f markdown \
   -c examples/sample-project/config/uv-sbom.config.yml
 ```
 
-This exercises CVE, license, and abandoned detection in a single run
-(once Issue #565 adds `check_abandoned: true` to the config file).
+This exercises CVE, license, and abandoned detection in a single run.
 
 ## Contrast with other examples
 
-| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
-|---|---|---|---|
-| Primary feature | CVE + license + abandoned | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
-| Vulnerable packages | Direct dependencies | Transitive dependencies | N/A |
-| Abandoned demo | ✅ Yes | ❌ Not focused | ❌ Not focused |
-| Config file | ✅ Yes (`config/`) | ❌ No | ❌ No |
+| | `examples/sample-project` | `examples/abandoned-packages-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|---|
+| Primary feature | CVE + license + abandoned | `--check-abandoned` (focused) | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
+| Vulnerable packages | Direct dependencies | None | Transitive dependencies | N/A |
+| Abandoned demo | Partial (depends on PyPI state) | ✅ Yes (4 packages, always flagged) | ❌ Not focused | ❌ Not focused |
+| Config file | ✅ Yes (`config/`) | ❌ No | ❌ No | ❌ No |
+
+Use `abandoned-packages-project` to explore `--check-abandoned` in isolation with guaranteed output.

--- a/examples/sample-project/README.md
+++ b/examples/sample-project/README.md
@@ -1,0 +1,80 @@
+# sample-project
+
+An example project demonstrating CVE detection, license compliance checking,
+and abandoned package detection with `uv-sbom`.
+
+## Purpose
+
+This project contains **intentionally outdated package versions** to produce
+realistic uv-sbom output for all three major opt-in analysis features:
+
+| Feature | CLI flag | What this example shows |
+|---------|----------|------------------------|
+| CVE detection | `--check-cve` (default on) | Multiple known vulnerabilities in locked packages |
+| License compliance | `--check-license` | `chardet 3.0.4` uses LGPL-2.1-only (denied) |
+| Abandoned package detection | `--check-abandoned` | Several packages with no upstream release ≥ 730 days |
+
+> ⚠️ **Do not use these package versions in production.** They are intentionally
+> outdated for demonstration purposes.
+
+## Prerequisites
+
+- `uv-sbom` installed or built from source (`cargo build --release`)
+- Internet access (CVE, license, and abandoned checks all require network)
+
+## Usage
+
+### Step 1: CVE check (default)
+
+```bash
+# From the repository root
+uv-sbom -p examples/sample-project -f markdown
+```
+
+**What you will see:** A vulnerability report listing CVEs for `pillow`, `urllib3`,
+`requests`, `jinja2`, and `werkzeug`.
+
+### Step 2: License compliance check
+
+```bash
+uv-sbom -p examples/sample-project --check-license -f markdown \
+  -c examples/sample-project/config/uv-sbom.config.yml
+```
+
+**What you will see:** A License Compliance section flagging `chardet 3.0.4`
+(LGPL-2.1-only, denied by the config policy).
+
+### Step 3: Abandoned package detection
+
+```bash
+uv-sbom -p examples/sample-project --check-abandoned -f markdown
+```
+
+**What you will see:** An Abandoned Packages section listing packages whose
+**latest PyPI release** is more than 730 days old (the default threshold).
+
+To lower the threshold and see more results:
+
+```bash
+uv-sbom -p examples/sample-project --check-abandoned \
+  --abandoned-threshold-days 365 -f markdown
+```
+
+### Step 4: All checks via config file
+
+```bash
+uv-sbom -p examples/sample-project -f markdown \
+  -c examples/sample-project/config/uv-sbom.config.yml
+```
+
+This exercises CVE, license, and abandoned detection in a single run
+(once Issue #565 adds `check_abandoned: true` to the config file).
+
+## Contrast with other examples
+
+| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/workspace` |
+|---|---|---|---|
+| Primary feature | CVE + license + abandoned | `--suggest-fix` Upgrade Advisor | `--workspace` mode |
+| Vulnerable packages | Direct dependencies | Transitive dependencies | N/A |
+| Abandoned demo | ✅ Yes | ❌ Not focused | ❌ Not focused |
+| Config file | ✅ Yes (`config/`) | ❌ No | ❌ No |

--- a/examples/sample-project/README.md
+++ b/examples/sample-project/README.md
@@ -60,7 +60,20 @@ uv-sbom -p examples/sample-project --check-abandoned \
   --abandoned-threshold-days 365 -f markdown
 ```
 
-### Step 4: All checks via config file
+### Step 4: Dependency diff against a git ref
+
+```bash
+# Compare the sample-project lockfile against the main branch
+uv-sbom --diff main -p examples/sample-project -f markdown
+
+# Compare against a file (e.g., a saved snapshot of uv.lock)
+uv-sbom --diff /path/to/old/uv.lock -p examples/sample-project -f json
+```
+
+**What you will see:** A diff report listing Added, Removed, Updated, and
+Unchanged packages between the base ref and the current lockfile.
+
+### Step 5: All checks via config file
 
 ```bash
 uv-sbom -p examples/sample-project -f markdown \

--- a/examples/sample-project/config/uv-sbom.config.yml
+++ b/examples/sample-project/config/uv-sbom.config.yml
@@ -1,7 +1,7 @@
 # Sample configuration file for uv-sbom
-# Demonstrates ignore_cves (CVE suppression) and license compliance checking
-# using real vulnerability IDs and license violations from sample-project
-# dependencies (detected by OSV API and PyPI).
+# Demonstrates ignore_cves (CVE suppression), license compliance checking,
+# and abandoned package detection using real vulnerability IDs and license
+# violations from sample-project dependencies (detected by OSV API and PyPI).
 #
 # License violation demo:
 #   chardet 3.0.4 (transitive dep of requests 2.25.0) uses LGPL-2.1-only,
@@ -10,11 +10,19 @@
 # Usage (CVE + license check):
 #   cargo run -- -p examples/sample-project --check-cve --check-license \
 #     -f markdown -c examples/sample-project/config/uv-sbom.config.yml
+#
+# Usage (all checks via config — CVE + license + abandoned package detection):
+#   cargo run -- -p examples/sample-project -f markdown \
+#     -c examples/sample-project/config/uv-sbom.config.yml
 
 check_cve: true
 severity_threshold: medium
 
 check_license: true
+
+# Abandoned package detection: flag packages with no PyPI release in 730+ days
+check_abandoned: true
+abandoned_threshold_days: 730
 
 license_policy:
   allow:

--- a/examples/suggest-fix-project/README-JP.md
+++ b/examples/suggest-fix-project/README-JP.md
@@ -104,13 +104,15 @@ uv-sbom -p examples/suggest-fix-project --check-cve --suggest-fix \
 | urllib3 | 2.0.4 | 2.6.0 | 🟠 HIGH | requests (2.31.0) | ⚠️ Cannot resolve: upgrading requests still resolves urllib3 to 2.0.4 which does not satisfy >= 2.6.0 | GHSA-2xpw-w6gg-jr37 |
 ```
 
-## `sample-project` との比較
+## 他のサンプルとの比較
 
-| | `examples/sample-project` | `examples/suggest-fix-project` |
-|---|---|---|
-| 脆弱なパッケージ | すべて**直接**依存関係 | すべて**推移的**依存関係 |
-| Resolution Guide | 非表示（推移的 CVE なし） | Recommended Action 付きで表示 |
-| `--suggest-fix` の出力 | アップグレード提案なし | Upgradable + Unresolvable のケース |
+| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/abandoned-packages-project` |
+|---|---|---|---|
+| 脆弱なパッケージ | すべて**直接**依存関係 | すべて**推移的**依存関係 | なし（放棄チェックに特化） |
+| Resolution Guide | 非表示（推移的 CVE なし） | Recommended Action 付きで表示 | 非表示 |
+| `--suggest-fix` の出力 | アップグレード提案なし | Upgradable + Unresolvable のケース | 対象外 |
+| `--check-abandoned` デモ | 一部 | ❌ 対象外 | ✅ あり（4パッケージ、常にフラグ） |
 
 基本的な CVE チェックや `--check-license` 機能を試す場合は `sample-project` を使用してください。
 `--suggest-fix` アップグレードアドバイザー機能を試す場合はこのプロジェクトを使用してください。
+`--check-abandoned` 機能を確実な出力で試す場合は `abandoned-packages-project` を使用してください。

--- a/examples/suggest-fix-project/README.md
+++ b/examples/suggest-fix-project/README.md
@@ -112,14 +112,15 @@ uv-sbom -p examples/suggest-fix-project --check-cve --suggest-fix \
 | urllib3 | 2.0.4 | 2.6.0 | 🟠 HIGH | requests (2.31.0) | ⚠️ Cannot resolve: upgrading requests still resolves urllib3 to 2.0.4 which does not satisfy >= 2.6.0 | GHSA-2xpw-w6gg-jr37 |
 ```
 
-## Contrast with `sample-project`
+## Contrast with other examples
 
-| | `examples/sample-project` | `examples/suggest-fix-project` |
-|---|---|---|
-| Vulnerable packages | All **direct** dependencies | All **transitive** dependencies |
-| Resolution Guide | Not shown (no transitive CVEs) | Shown with Recommended Action |
-| `--suggest-fix` output | No upgrade advice | Upgradable + Unresolvable cases |
-| `--check-abandoned` demo | ✅ See sample-project README | ❌ Not focused |
+| | `examples/sample-project` | `examples/suggest-fix-project` | `examples/abandoned-packages-project` |
+|---|---|---|---|
+| Vulnerable packages | All **direct** dependencies | All **transitive** dependencies | None (focused on abandonment) |
+| Resolution Guide | Not shown (no transitive CVEs) | Shown with Recommended Action | Not shown |
+| `--suggest-fix` output | No upgrade advice | Upgradable + Unresolvable cases | Not focused |
+| `--check-abandoned` demo | Partial | ❌ Not focused | ✅ Yes (4 packages, always flagged) |
 
-Use `sample-project` to explore the basic CVE check, `--check-license`, and `--check-abandoned` features.
+Use `sample-project` to explore the basic CVE check and `--check-license` features.
 Use this project to explore the `--suggest-fix` Upgrade Advisor feature.
+Use `abandoned-packages-project` to explore `--check-abandoned` in isolation with guaranteed output.

--- a/examples/suggest-fix-project/README.md
+++ b/examples/suggest-fix-project/README.md
@@ -119,6 +119,7 @@ uv-sbom -p examples/suggest-fix-project --check-cve --suggest-fix \
 | Vulnerable packages | All **direct** dependencies | All **transitive** dependencies |
 | Resolution Guide | Not shown (no transitive CVEs) | Shown with Recommended Action |
 | `--suggest-fix` output | No upgrade advice | Upgradable + Unresolvable cases |
+| `--check-abandoned` demo | ✅ See sample-project README | ❌ Not focused |
 
-Use `sample-project` to explore the basic CVE check and `--check-license` features.
+Use `sample-project` to explore the basic CVE check, `--check-license`, and `--check-abandoned` features.
 Use this project to explore the `--suggest-fix` Upgrade Advisor feature.

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.3.0"
+version = "2.4.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.3.0"
+UV_SBOM_VERSION = "2.4.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (

--- a/src/adapters/outbound/filesystem/file_reader.rs
+++ b/src/adapters/outbound/filesystem/file_reader.rs
@@ -1,9 +1,8 @@
+use super::lockfile_parser::{parse_lockfile_content, parse_lockfile_content_for_member};
 use crate::ports::outbound::{LockfileParseResult, LockfileReader, ProjectConfigReader};
-use crate::sbom_generation::domain::Package;
 use crate::shared::error::SbomError;
 use crate::shared::security::{read_file_with_security, MAX_FILE_SIZE};
 use crate::shared::Result;
-use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 
 /// FileSystemReader adapter for reading files from the file system
@@ -45,7 +44,7 @@ impl LockfileReader for FileSystemReader {
         member_name: &str,
     ) -> Result<LockfileParseResult> {
         let lockfile_content = self.read_lockfile(project_path)?;
-        self.parse_lockfile_content_for_member(&lockfile_content, project_path, member_name)
+        parse_lockfile_content_for_member(&lockfile_content, project_path, member_name)
     }
 
     fn read_lockfile(&self, project_path: &Path) -> Result<String> {
@@ -75,210 +74,8 @@ impl LockfileReader for FileSystemReader {
     }
 
     fn read_and_parse_lockfile(&self, project_path: &Path) -> Result<LockfileParseResult> {
-        // Read the lockfile content
         let lockfile_content = self.read_lockfile(project_path)?;
-
-        // Parse TOML content
-        self.parse_lockfile_content(&lockfile_content, project_path)
-    }
-}
-
-impl FileSystemReader {
-    /// Parses lockfile content to extract packages and dependency map
-    ///
-    /// This method handles the TOML parsing logic which is an infrastructure concern.
-    /// It was moved from the application layer to properly separate concerns.
-    fn parse_lockfile_content(
-        &self,
-        content: &str,
-        project_path: &Path,
-    ) -> Result<LockfileParseResult> {
-        use serde::Deserialize;
-
-        #[derive(Debug, Deserialize)]
-        struct UvLock {
-            package: Vec<UvPackage>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvPackage {
-            name: String,
-            version: String,
-            #[serde(default)]
-            dependencies: Vec<UvDependency>,
-            #[serde(default, rename = "dev-dependencies")]
-            dev_dependencies: Option<DevDependencies>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvDependency {
-            name: String,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct DevDependencies {
-            #[serde(default)]
-            dev: Vec<UvDependency>,
-        }
-
-        let lockfile: UvLock =
-            toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-                path: project_path.join("uv.lock"),
-                details: e.to_string(),
-            })?;
-
-        let mut packages = Vec::new();
-        let mut dependency_map = HashMap::new();
-
-        for pkg in lockfile.package {
-            packages.push(Package::new(pkg.name.clone(), pkg.version.clone())?);
-
-            // Build dependency map
-            let mut deps = Vec::new();
-            for dep in &pkg.dependencies {
-                deps.push(dep.name.clone());
-            }
-            if let Some(dev_deps) = &pkg.dev_dependencies {
-                for dep in &dev_deps.dev {
-                    deps.push(dep.name.clone());
-                }
-            }
-            dependency_map.insert(pkg.name, deps);
-        }
-
-        Ok((packages, dependency_map))
-    }
-
-    /// Parse lockfile content and return only packages reachable from the given member.
-    ///
-    /// Identifies the member root package by matching `name == member_name` with either
-    /// `source.editable` or `source.virtual` set (uv < 0.5 uses `editable`; uv >= 0.5
-    /// uses `virtual` for packages without a build system), then performs BFS over the
-    /// dependency graph to collect all transitively reachable packages. The member root
-    /// itself is excluded.
-    fn parse_lockfile_content_for_member(
-        &self,
-        content: &str,
-        project_path: &Path,
-        member_name: &str,
-    ) -> Result<LockfileParseResult> {
-        use serde::Deserialize;
-
-        #[derive(Debug, Deserialize)]
-        struct PackageSource {
-            editable: Option<String>,
-            #[serde(rename = "virtual")]
-            virtual_path: Option<String>,
-        }
-
-        impl PackageSource {
-            fn is_local(&self) -> bool {
-                self.editable.is_some() || self.virtual_path.is_some()
-            }
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvPackage {
-            name: String,
-            version: String,
-            #[serde(default)]
-            dependencies: Vec<UvDependency>,
-            #[serde(default, rename = "dev-dependencies")]
-            dev_dependencies: Option<DevDependencies>,
-            source: Option<PackageSource>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvDependency {
-            name: String,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct DevDependencies {
-            #[serde(default)]
-            dev: Vec<UvDependency>,
-        }
-
-        #[derive(Debug, Deserialize)]
-        struct UvLock {
-            package: Vec<UvPackage>,
-        }
-
-        let lockfile: UvLock =
-            toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-                path: project_path.join("uv.lock"),
-                details: e.to_string(),
-            })?;
-
-        // Build dependency map (name -> list of dependency names) and package lookup
-        let mut full_dep_map: HashMap<String, Vec<String>> = HashMap::new();
-        let mut pkg_lookup: HashMap<String, (String, String)> = HashMap::new(); // name -> (name, version)
-        let mut member_direct_deps: Option<Vec<String>> = None;
-
-        for pkg in &lockfile.package {
-            let mut deps: Vec<String> = pkg.dependencies.iter().map(|d| d.name.clone()).collect();
-            if let Some(dev_deps) = &pkg.dev_dependencies {
-                for dep in &dev_deps.dev {
-                    deps.push(dep.name.clone());
-                }
-            }
-
-            // Detect member root: name matches AND source is a local path
-            // (editable for uv < 0.5, virtual for uv >= 0.5)
-            let is_member_root = pkg.name == member_name
-                && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
-
-            if is_member_root {
-                member_direct_deps = Some(deps.clone());
-            }
-
-            full_dep_map.insert(pkg.name.clone(), deps);
-            pkg_lookup.insert(pkg.name.clone(), (pkg.name.clone(), pkg.version.clone()));
-        }
-
-        let direct_deps = member_direct_deps.ok_or_else(|| {
-            anyhow::anyhow!(
-                "Workspace member '{}' not found in uv.lock (no package with source.editable or source.virtual set)",
-                member_name
-            )
-        })?;
-
-        // BFS traversal from direct dependencies of the member root
-        let mut visited: HashSet<String> = HashSet::new();
-        let mut queue: VecDeque<String> = VecDeque::new();
-
-        for dep in direct_deps {
-            if !visited.contains(&dep) {
-                visited.insert(dep.clone());
-                queue.push_back(dep);
-            }
-        }
-
-        while let Some(current) = queue.pop_front() {
-            if let Some(deps) = full_dep_map.get(&current) {
-                for dep in deps {
-                    if !visited.contains(dep) {
-                        visited.insert(dep.clone());
-                        queue.push_back(dep.clone());
-                    }
-                }
-            }
-        }
-
-        // Build result from visited set (excluding member root itself)
-        let mut packages = Vec::new();
-        let mut dependency_map = HashMap::new();
-
-        for name in &visited {
-            if let Some((pkg_name, pkg_version)) = pkg_lookup.get(name) {
-                packages.push(Package::new(pkg_name.clone(), pkg_version.clone())?);
-                if let Some(deps) = full_dep_map.get(name) {
-                    dependency_map.insert(pkg_name.clone(), deps.clone());
-                }
-            }
-        }
-
-        Ok((packages, dependency_map))
+        parse_lockfile_content(&lockfile_content, project_path)
     }
 }
 
@@ -311,7 +108,6 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
     use std::fs;
-    use std::path::Path;
     use tempfile::TempDir;
 
     #[test]
@@ -405,15 +201,8 @@ version = "1.0.0"
         assert!(err_string.contains("Project name not found"));
     }
 
-    // Workspace lock fixture used by member-scoped filtering tests.
-    //
-    // Dependency graph:
-    //   alpha (editable) -> requests, certifi
-    //   beta  (editable) -> urllib3
-    //   requests         -> urllib3
-    //   urllib3          -> (none)
-    //   certifi          -> (none)
-    //   shared-lib       -> certifi
+    // Integration test: verifies FileSystemReader reads from disk and delegates
+    // parsing correctly to the lockfile_parser module.
     const WORKSPACE_LOCK_FOR_MEMBER: &str = r#"
 version = 1
 requires-python = ">=3.11"
@@ -469,97 +258,6 @@ source = { registry = "https://pypi.org/simple" }
 "#;
 
     #[test]
-    fn test_parse_lockfile_for_member_returns_correct_subtree_for_alpha() {
-        let reader = FileSystemReader::new();
-        let (packages, dep_map) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_FOR_MEMBER,
-                Path::new("/workspace"),
-                "alpha",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        // alpha itself must NOT appear
-        assert!(!names.contains("alpha"), "member root must be excluded");
-        // beta is not reachable from alpha
-        assert!(!names.contains("beta"), "sibling member must be excluded");
-        // shared-lib is not reachable from alpha
-        assert!(
-            !names.contains("shared-lib"),
-            "unreachable package must be excluded"
-        );
-
-        // alpha -> requests -> urllib3, alpha -> certifi
-        assert!(names.contains("requests"));
-        assert!(names.contains("urllib3"));
-        assert!(names.contains("certifi"));
-
-        // dependency_map must contain entries for all returned packages
-        assert!(dep_map.contains_key("requests"));
-        assert!(dep_map.contains_key("urllib3"));
-        assert!(dep_map.contains_key("certifi"));
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_returns_correct_subtree_for_beta() {
-        let reader = FileSystemReader::new();
-        let (packages, _dep_map) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_FOR_MEMBER,
-                Path::new("/workspace"),
-                "beta",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        assert!(!names.contains("beta"), "member root must be excluded");
-        assert!(!names.contains("alpha"), "sibling member must be excluded");
-        assert!(!names.contains("requests"), "unreachable from beta");
-        assert!(!names.contains("certifi"), "unreachable from beta");
-        assert!(!names.contains("shared-lib"), "unreachable from beta");
-
-        assert!(names.contains("urllib3"));
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_member_root_excluded() {
-        let reader = FileSystemReader::new();
-        let (packages, _) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_FOR_MEMBER,
-                Path::new("/workspace"),
-                "alpha",
-            )
-            .unwrap();
-
-        let names: Vec<String> = packages.iter().map(|p| p.name().to_string()).collect();
-        assert!(
-            !names.contains(&"alpha".to_string()),
-            "member root must not appear in result"
-        );
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_nonexistent_member_returns_error() {
-        let reader = FileSystemReader::new();
-        let result = reader.parse_lockfile_content_for_member(
-            WORKSPACE_LOCK_FOR_MEMBER,
-            Path::new("/workspace"),
-            "nonexistent-member",
-        );
-
-        assert!(result.is_err());
-        let err_string = result.unwrap_err().to_string();
-        assert!(
-            err_string.contains("nonexistent-member"),
-            "error must mention the missing member name"
-        );
-    }
-
-    #[test]
     fn test_read_and_parse_lockfile_for_member_reads_from_file() {
         let temp_dir = TempDir::new().unwrap();
         fs::write(temp_dir.path().join("uv.lock"), WORKSPACE_LOCK_FOR_MEMBER).unwrap();
@@ -574,94 +272,5 @@ source = { registry = "https://pypi.org/simple" }
         assert!(names.contains("urllib3"));
         assert!(names.contains("certifi"));
         assert!(!names.contains("alpha"));
-    }
-
-    // uv >= 0.5 workspace lock fixture using `source.virtual` instead of `source.editable`.
-    //
-    // Dependency graph:
-    //   api    (virtual at packages/api)    -> requests, fastapi
-    //   worker (virtual at packages/worker) -> celery
-    const WORKSPACE_LOCK_VIRTUAL_FORMAT: &str = r#"
-version = 1
-revision = 3
-requires-python = ">=3.11"
-
-[manifest]
-members = [
-    "api",
-    "worker",
-]
-
-[[package]]
-name = "api"
-version = "0.1.0"
-source = { virtual = "packages/api" }
-dependencies = [
-  { name = "fastapi" },
-  { name = "requests" },
-]
-
-[[package]]
-name = "celery"
-version = "5.4.0"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "fastapi"
-version = "0.115.0"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "requests"
-version = "2.32.3"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "worker"
-version = "0.1.0"
-source = { virtual = "packages/worker" }
-dependencies = [
-  { name = "celery" },
-]
-"#;
-
-    #[test]
-    fn test_parse_lockfile_for_member_handles_virtual_source_for_api() {
-        let reader = FileSystemReader::new();
-        let (packages, _) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_VIRTUAL_FORMAT,
-                Path::new("/workspace"),
-                "api",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        assert!(!names.contains("api"), "member root must be excluded");
-        assert!(!names.contains("worker"), "sibling member must be excluded");
-        assert!(names.contains("requests"));
-        assert!(names.contains("fastapi"));
-        assert!(!names.contains("celery"), "unreachable from api");
-    }
-
-    #[test]
-    fn test_parse_lockfile_for_member_handles_virtual_source_for_worker() {
-        let reader = FileSystemReader::new();
-        let (packages, _) = reader
-            .parse_lockfile_content_for_member(
-                WORKSPACE_LOCK_VIRTUAL_FORMAT,
-                Path::new("/workspace"),
-                "worker",
-            )
-            .unwrap();
-
-        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
-
-        assert!(!names.contains("worker"), "member root must be excluded");
-        assert!(!names.contains("api"), "sibling member must be excluded");
-        assert!(names.contains("celery"));
-        assert!(!names.contains("requests"), "unreachable from worker");
-        assert!(!names.contains("fastapi"), "unreachable from worker");
     }
 }

--- a/src/adapters/outbound/filesystem/git_lockfile_reader.rs
+++ b/src/adapters/outbound/filesystem/git_lockfile_reader.rs
@@ -1,0 +1,248 @@
+use super::lockfile_parser::parse_lockfile_content;
+use crate::ports::outbound::{DiffLockfileReader, DiffSource};
+use crate::sbom_generation::domain::Package;
+use crate::shared::error::SbomError;
+use crate::shared::security::{read_file_with_security, MAX_FILE_SIZE};
+use crate::shared::Result;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub struct GitLockfileReader;
+
+impl GitLockfileReader {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GitLockfileReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DiffLockfileReader for GitLockfileReader {
+    fn read_base_packages(&self, source: &DiffSource, project_path: &Path) -> Result<Vec<Package>> {
+        match source {
+            DiffSource::GitRef(ref_name) => {
+                validate_git_ref(ref_name)?;
+
+                let output = Command::new("git")
+                    .args(["show", &format!("{}:uv.lock", ref_name)])
+                    .current_dir(project_path)
+                    .output()
+                    .map_err(|e| SbomError::FileReadError {
+                        path: project_path.join("uv.lock"),
+                        details: format!(
+                            "Failed to invoke git: {}. Ensure `git` is installed and on PATH.",
+                            e
+                        ),
+                    })?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    return Err(SbomError::FileReadError {
+                        path: project_path.join("uv.lock"),
+                        details: format!(
+                            "git show {}:uv.lock failed: {}",
+                            ref_name,
+                            stderr.trim()
+                        ),
+                    }
+                    .into());
+                }
+
+                let content = String::from_utf8(output.stdout).map_err(|_| {
+                    SbomError::LockfileParseError {
+                        path: project_path.join("uv.lock"),
+                        details: "git show output is not valid UTF-8".to_string(),
+                    }
+                })?;
+
+                let (packages, _) = parse_lockfile_content(&content, project_path)?;
+                Ok(packages)
+            }
+            DiffSource::FilePath(path) => {
+                let content =
+                    read_file_with_security(path, "uv.lock (diff base)", MAX_FILE_SIZE)?;
+                let (packages, _) = parse_lockfile_content(&content, project_path)?;
+                Ok(packages)
+            }
+        }
+    }
+}
+
+/// Validates a git ref against a safe character allowlist to prevent command injection.
+///
+/// Allowed characters: `[a-zA-Z0-9._/-]`
+/// Rejected: empty strings, refs starting with `-` (option injection risk).
+fn validate_git_ref(ref_name: &str) -> Result<()> {
+    if ref_name.is_empty() {
+        return Err(SbomError::SecurityError {
+            path: PathBuf::from("<git-ref>"),
+            reason: "Git ref must not be empty".to_string(),
+            hint: "Provide a valid git ref such as a branch name, tag, or commit SHA.".to_string(),
+        }
+        .into());
+    }
+
+    if ref_name.starts_with('-') {
+        return Err(SbomError::SecurityError {
+            path: PathBuf::from(ref_name),
+            reason: format!("Git ref '{}' must not start with '-'", ref_name),
+            hint: "Git refs starting with '-' could be interpreted as command options. Use a valid ref name.".to_string(),
+        }
+        .into());
+    }
+
+    if let Some(c) = ref_name
+        .chars()
+        .find(|&c| !c.is_ascii_alphanumeric() && !matches!(c, '.' | '_' | '/' | '-'))
+    {
+        return Err(SbomError::SecurityError {
+            path: PathBuf::from(ref_name),
+            reason: format!(
+                "Git ref '{}' contains invalid character '{}'",
+                ref_name, c
+            ),
+            hint: "Only alphanumeric characters and '.', '_', '/', '-' are allowed in git refs."
+                .to_string(),
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Determines whether `arg` refers to an existing file or a git ref.
+///
+/// If `arg` resolves to an existing regular file, returns `DiffSource::FilePath`.
+/// Otherwise returns `DiffSource::GitRef`. Note: relative paths are resolved
+/// against the process working directory, not the project path.
+// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
+// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
+// (pub fn is reachable by library consumers), making the expectation unfulfilled there.
+#[allow(dead_code)]
+pub fn determine_diff_source(arg: &str) -> DiffSource {
+    let path = Path::new(arg);
+    if path.exists() && path.is_file() {
+        DiffSource::FilePath(path.to_path_buf())
+    } else {
+        DiffSource::GitRef(arg.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // --- validate_git_ref ---
+
+    #[test]
+    fn test_validate_git_ref_accepts_main() {
+        assert!(validate_git_ref("main").is_ok());
+    }
+
+    #[test]
+    fn test_validate_git_ref_accepts_version_tag() {
+        assert!(validate_git_ref("v1.0.0").is_ok());
+    }
+
+    #[test]
+    fn test_validate_git_ref_accepts_short_commit_sha() {
+        assert!(validate_git_ref("abc1234").is_ok());
+    }
+
+    #[test]
+    fn test_validate_git_ref_accepts_feature_branch_with_slash() {
+        assert!(validate_git_ref("feature/my-branch").is_ok());
+    }
+
+    #[test]
+    fn test_validate_git_ref_accepts_remote_tracking_ref() {
+        assert!(validate_git_ref("origin/main").is_ok());
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_empty_string() {
+        let result = validate_git_ref("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_leading_dash() {
+        let result = validate_git_ref("-rf");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must not start with '-'"));
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_option_injection() {
+        let result = validate_git_ref("--upload-pack=malicious");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_semicolon() {
+        let result = validate_git_ref("main;rm");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid character"));
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_space() {
+        let result = validate_git_ref("feature branch");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid character"));
+    }
+
+    // --- determine_diff_source ---
+
+    #[test]
+    fn test_determine_diff_source_returns_file_path_for_existing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let lock_path = temp_dir.path().join("uv.lock");
+        fs::write(&lock_path, "version = 1").unwrap();
+
+        let source = determine_diff_source(lock_path.to_str().unwrap());
+        assert_eq!(source, DiffSource::FilePath(lock_path));
+    }
+
+    #[test]
+    fn test_determine_diff_source_returns_git_ref_for_branch_name() {
+        let source = determine_diff_source("main");
+        assert_eq!(source, DiffSource::GitRef("main".to_string()));
+    }
+
+    #[test]
+    fn test_determine_diff_source_returns_git_ref_for_nonexistent_path() {
+        let source = determine_diff_source("/nonexistent/path/uv.lock");
+        assert_eq!(
+            source,
+            DiffSource::GitRef("/nonexistent/path/uv.lock".to_string())
+        );
+    }
+
+    #[test]
+    fn test_determine_diff_source_returns_git_ref_for_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        // A directory is not a file, so it should be treated as a git ref
+        let source = determine_diff_source(temp_dir.path().to_str().unwrap());
+        assert_eq!(
+            source,
+            DiffSource::GitRef(temp_dir.path().to_str().unwrap().to_string())
+        );
+    }
+}

--- a/src/adapters/outbound/filesystem/git_lockfile_reader.rs
+++ b/src/adapters/outbound/filesystem/git_lockfile_reader.rs
@@ -111,10 +111,6 @@ fn validate_git_ref(ref_name: &str) -> Result<()> {
 /// If `arg` resolves to an existing regular file, returns `DiffSource::FilePath`.
 /// Otherwise returns `DiffSource::GitRef`. Note: relative paths are resolved
 /// against the process working directory, not the project path.
-// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
-// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
-// (pub fn is reachable by library consumers), making the expectation unfulfilled there.
-#[allow(dead_code)]
 pub fn determine_diff_source(arg: &str) -> DiffSource {
     let path = Path::new(arg);
     if path.exists() && path.is_file() {

--- a/src/adapters/outbound/filesystem/git_lockfile_reader.rs
+++ b/src/adapters/outbound/filesystem/git_lockfile_reader.rs
@@ -43,11 +43,7 @@ impl DiffLockfileReader for GitLockfileReader {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     return Err(SbomError::FileReadError {
                         path: project_path.join("uv.lock"),
-                        details: format!(
-                            "git show {}:uv.lock failed: {}",
-                            ref_name,
-                            stderr.trim()
-                        ),
+                        details: format!("git show {}:uv.lock failed: {}", ref_name, stderr.trim()),
                     }
                     .into());
                 }
@@ -63,8 +59,7 @@ impl DiffLockfileReader for GitLockfileReader {
                 Ok(packages)
             }
             DiffSource::FilePath(path) => {
-                let content =
-                    read_file_with_security(path, "uv.lock (diff base)", MAX_FILE_SIZE)?;
+                let content = read_file_with_security(path, "uv.lock (diff base)", MAX_FILE_SIZE)?;
                 let (packages, _) = parse_lockfile_content(&content, project_path)?;
                 Ok(packages)
             }
@@ -101,10 +96,7 @@ fn validate_git_ref(ref_name: &str) -> Result<()> {
     {
         return Err(SbomError::SecurityError {
             path: PathBuf::from(ref_name),
-            reason: format!(
-                "Git ref '{}' contains invalid character '{}'",
-                ref_name, c
-            ),
+            reason: format!("Git ref '{}' contains invalid character '{}'", ref_name, c),
             hint: "Only alphanumeric characters and '.', '_', '/', '-' are allowed in git refs."
                 .to_string(),
         }
@@ -169,7 +161,10 @@ mod tests {
     fn test_validate_git_ref_rejects_empty_string() {
         let result = validate_git_ref("");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("must not be empty"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must not be empty"));
     }
 
     #[test]

--- a/src/adapters/outbound/filesystem/git_lockfile_reader.rs
+++ b/src/adapters/outbound/filesystem/git_lockfile_reader.rs
@@ -334,7 +334,8 @@ mod tests {
 
         assert_eq!(packages.len(), 1);
         assert_eq!(
-            packages[0].name(), "sub-pkg",
+            packages[0].name(),
+            "sub-pkg",
             "expected the subdirectory lockfile to be read, not the repo-root lockfile"
         );
     }
@@ -356,10 +357,7 @@ mod tests {
 
         let reader = GitLockfileReader::new();
         let packages = reader
-            .read_base_packages(
-                &DiffSource::GitRef("v-root".to_string()),
-                repo.path(),
-            )
+            .read_base_packages(&DiffSource::GitRef("v-root".to_string()), repo.path())
             .expect("repo-root project should still work");
         assert_eq!(packages[0].name(), "certifi");
     }

--- a/src/adapters/outbound/filesystem/git_lockfile_reader.rs
+++ b/src/adapters/outbound/filesystem/git_lockfile_reader.rs
@@ -28,7 +28,7 @@ impl DiffLockfileReader for GitLockfileReader {
                 validate_git_ref(ref_name)?;
 
                 let output = Command::new("git")
-                    .args(["show", &format!("{}:uv.lock", ref_name)])
+                    .args(["show", &format!("{}:./uv.lock", ref_name)])
                     .current_dir(project_path)
                     .output()
                     .map_err(|e| SbomError::FileReadError {
@@ -43,7 +43,11 @@ impl DiffLockfileReader for GitLockfileReader {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     return Err(SbomError::FileReadError {
                         path: project_path.join("uv.lock"),
-                        details: format!("git show {}:uv.lock failed: {}", ref_name, stderr.trim()),
+                        details: format!(
+                            "git show {}:./uv.lock failed: {}",
+                            ref_name,
+                            stderr.trim()
+                        ),
                     }
                     .into());
                 }
@@ -125,6 +129,56 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    fn git_available() -> bool {
+        Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn minimal_uv_lock() -> &'static str {
+        "version = 1\nrevision = 1\nrequires-python = \">=3.11\"\n\n\
+         [[package]]\nname = \"certifi\"\nversion = \"2024.8.30\"\n"
+    }
+
+    fn init_repo_with_lockfile_at(
+        repo_root: &Path,
+        relative_lock_path: &Path,
+        lock_content: &str,
+        tag: &str,
+    ) {
+        let abs_lock = repo_root.join(relative_lock_path);
+        if let Some(parent) = abs_lock.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&abs_lock, lock_content).unwrap();
+
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(repo_root)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .status()
+                .expect("git invocation failed");
+            assert!(status.success(), "git {:?} failed", args);
+        };
+
+        run(&["init", "-q", "-b", "main"]);
+        run(&["config", "commit.gpgsign", "false"]);
+        run(&["config", "tag.gpgsign", "false"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        run(&["add", relative_lock_path.to_str().unwrap()]);
+        run(&["commit", "-q", "-m", "add lockfile"]);
+        run(&["tag", tag]);
+    }
 
     // --- validate_git_ref ---
 
@@ -224,6 +278,90 @@ mod tests {
             source,
             DiffSource::GitRef("/nonexistent/path/uv.lock".to_string())
         );
+    }
+
+    // --- read_base_packages (git ref resolution) ---
+
+    #[test]
+    fn test_read_base_packages_reads_subdirectory_lockfile_not_repo_root() {
+        if !git_available() {
+            eprintln!("skipping: git binary not available on PATH");
+            return;
+        }
+
+        let repo = TempDir::new().unwrap();
+        let sub_rel = Path::new("examples/sample-project");
+
+        let root_lock = "version = 1\nrevision = 1\nrequires-python = \">=3.11\"\n\n\
+                         [[package]]\nname = \"root-pkg\"\nversion = \"0.0.0\"\n";
+        let sub_lock = "version = 1\nrevision = 1\nrequires-python = \">=3.11\"\n\n\
+                        [[package]]\nname = \"sub-pkg\"\nversion = \"9.9.9\"\n";
+
+        fs::create_dir_all(repo.path().join(sub_rel)).unwrap();
+        fs::write(repo.path().join("uv.lock"), root_lock).unwrap();
+        fs::write(repo.path().join(sub_rel).join("uv.lock"), sub_lock).unwrap();
+
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(repo.path())
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .status()
+                .expect("git failed");
+            assert!(status.success(), "git {:?} failed", args);
+        };
+        run(&["init", "-q", "-b", "main"]);
+        run(&["config", "commit.gpgsign", "false"]);
+        run(&["config", "tag.gpgsign", "false"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        run(&["add", "."]);
+        run(&["commit", "-q", "-m", "init"]);
+        run(&["tag", "v-test"]);
+
+        let reader = GitLockfileReader::new();
+        let packages = reader
+            .read_base_packages(
+                &DiffSource::GitRef("v-test".to_string()),
+                &repo.path().join(sub_rel),
+            )
+            .expect("read_base_packages should succeed for subdirectory project");
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(
+            packages[0].name(), "sub-pkg",
+            "expected the subdirectory lockfile to be read, not the repo-root lockfile"
+        );
+    }
+
+    #[test]
+    fn test_read_base_packages_still_works_at_repo_root() {
+        if !git_available() {
+            eprintln!("skipping: git binary not available on PATH");
+            return;
+        }
+
+        let repo = TempDir::new().unwrap();
+        init_repo_with_lockfile_at(
+            repo.path(),
+            Path::new("uv.lock"),
+            minimal_uv_lock(),
+            "v-root",
+        );
+
+        let reader = GitLockfileReader::new();
+        let packages = reader
+            .read_base_packages(
+                &DiffSource::GitRef("v-root".to_string()),
+                repo.path(),
+            )
+            .expect("repo-root project should still work");
+        assert_eq!(packages[0].name(), "certifi");
     }
 
     #[test]

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -1,0 +1,478 @@
+use crate::ports::outbound::LockfileParseResult;
+use crate::sbom_generation::domain::Package;
+use crate::shared::error::SbomError;
+use crate::shared::Result;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+
+// Shared TOML deserialization structs.
+// Module-scoped so both parse functions share the same definitions.
+
+#[derive(Debug, Deserialize)]
+struct UvDependency {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevDependencies {
+    #[serde(default)]
+    dev: Vec<UvDependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageSource {
+    editable: Option<String>,
+    #[serde(rename = "virtual")]
+    virtual_path: Option<String>,
+}
+
+impl PackageSource {
+    fn is_local(&self) -> bool {
+        self.editable.is_some() || self.virtual_path.is_some()
+    }
+}
+
+/// Parse uv.lock TOML content into (packages, dependency_map).
+///
+/// Pure function: no I/O, no `&self`. Suitable for reuse by any adapter
+/// that has the raw lockfile bytes (filesystem, git blob, in-memory, etc.).
+pub fn parse_lockfile_content(content: &str, project_path: &Path) -> Result<LockfileParseResult> {
+    #[derive(Debug, Deserialize)]
+    struct UvPackage {
+        name: String,
+        version: String,
+        #[serde(default)]
+        dependencies: Vec<UvDependency>,
+        #[serde(default, rename = "dev-dependencies")]
+        dev_dependencies: Option<DevDependencies>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct UvLock {
+        package: Vec<UvPackage>,
+    }
+
+    let lockfile: UvLock =
+        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+            path: project_path.join("uv.lock"),
+            details: e.to_string(),
+        })?;
+
+    let mut packages = Vec::new();
+    let mut dependency_map = HashMap::new();
+
+    for pkg in lockfile.package {
+        packages.push(Package::new(pkg.name.clone(), pkg.version.clone())?);
+
+        let mut deps = Vec::new();
+        for dep in &pkg.dependencies {
+            deps.push(dep.name.clone());
+        }
+        if let Some(dev_deps) = &pkg.dev_dependencies {
+            for dep in &dev_deps.dev {
+                deps.push(dep.name.clone());
+            }
+        }
+        dependency_map.insert(pkg.name, deps);
+    }
+
+    Ok((packages, dependency_map))
+}
+
+/// Parse uv.lock TOML content and return only packages reachable from
+/// the workspace member named `member_name` (root excluded).
+///
+/// Identifies the member root package by matching `name == member_name` with either
+/// `source.editable` or `source.virtual` set (uv < 0.5 uses `editable`; uv >= 0.5
+/// uses `virtual` for packages without a build system), then performs BFS over the
+/// dependency graph to collect all transitively reachable packages. The member root
+/// itself is excluded.
+pub fn parse_lockfile_content_for_member(
+    content: &str,
+    project_path: &Path,
+    member_name: &str,
+) -> Result<LockfileParseResult> {
+    #[derive(Debug, Deserialize)]
+    struct UvPackage {
+        name: String,
+        version: String,
+        #[serde(default)]
+        dependencies: Vec<UvDependency>,
+        #[serde(default, rename = "dev-dependencies")]
+        dev_dependencies: Option<DevDependencies>,
+        source: Option<PackageSource>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct UvLock {
+        package: Vec<UvPackage>,
+    }
+
+    let lockfile: UvLock =
+        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+            path: project_path.join("uv.lock"),
+            details: e.to_string(),
+        })?;
+
+    let mut full_dep_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut pkg_lookup: HashMap<String, (String, String)> = HashMap::new();
+    let mut member_direct_deps: Option<Vec<String>> = None;
+
+    for pkg in &lockfile.package {
+        let deps = collect_all_deps(
+            &pkg.dependencies,
+            pkg.dev_dependencies.as_ref(),
+        );
+
+        let is_member_root = pkg.name == member_name
+            && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
+
+        if is_member_root {
+            member_direct_deps = Some(deps.clone());
+        }
+
+        full_dep_map.insert(pkg.name.clone(), deps);
+        pkg_lookup.insert(pkg.name.clone(), (pkg.name.clone(), pkg.version.clone()));
+    }
+
+    let direct_deps = member_direct_deps.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Workspace member '{}' not found in uv.lock (no package with source.editable or source.virtual set)",
+            member_name
+        )
+    })?;
+
+    let visited = bfs_reachable(&full_dep_map, direct_deps);
+
+    let mut packages = Vec::new();
+    let mut dependency_map = HashMap::new();
+
+    for name in &visited {
+        if let Some((pkg_name, pkg_version)) = pkg_lookup.get(name) {
+            packages.push(Package::new(pkg_name.clone(), pkg_version.clone())?);
+            if let Some(deps) = full_dep_map.get(name) {
+                dependency_map.insert(pkg_name.clone(), deps.clone());
+            }
+        }
+    }
+
+    Ok((packages, dependency_map))
+}
+
+/// Collect all dependency names from a package (runtime + dev).
+fn collect_all_deps(
+    dependencies: &[UvDependency],
+    dev_dependencies: Option<&DevDependencies>,
+) -> Vec<String> {
+    let mut deps: Vec<String> = dependencies.iter().map(|d| d.name.clone()).collect();
+    if let Some(dev_deps) = dev_dependencies {
+        for dep in &dev_deps.dev {
+            deps.push(dep.name.clone());
+        }
+    }
+    deps
+}
+
+/// BFS traversal starting from `seeds`, returning all transitively reachable package names.
+fn bfs_reachable(dep_map: &HashMap<String, Vec<String>>, seeds: Vec<String>) -> HashSet<String> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    for dep in seeds {
+        if !visited.contains(&dep) {
+            visited.insert(dep.clone());
+            queue.push_back(dep);
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if let Some(deps) = dep_map.get(&current) {
+            for dep in deps {
+                if !visited.contains(dep) {
+                    visited.insert(dep.clone());
+                    queue.push_back(dep.clone());
+                }
+            }
+        }
+    }
+
+    visited
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    const SIMPLE_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "urllib3" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    #[test]
+    fn test_parse_lockfile_content_basic_returns_packages_and_deps() {
+        let (packages, dep_map) =
+            parse_lockfile_content(SIMPLE_LOCK, Path::new("/project")).unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+        assert!(names.contains("requests"));
+        assert!(names.contains("urllib3"));
+        assert_eq!(dep_map["requests"], vec!["urllib3"]);
+        assert!(dep_map["urllib3"].is_empty());
+    }
+
+    #[test]
+    fn test_parse_lockfile_content_invalid_toml_returns_error() {
+        let result = parse_lockfile_content("not valid toml [[[", Path::new("/project"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_lockfile_content_empty_lockfile_returns_no_packages() {
+        let content = "version = 1\n";
+        let result = parse_lockfile_content(content, Path::new("/project"));
+        assert!(result.is_err());
+    }
+
+    // Workspace lock fixture used by member-scoped filtering tests.
+    //
+    // Dependency graph:
+    //   alpha (editable) -> requests, certifi
+    //   beta  (editable) -> urllib3
+    //   requests         -> urllib3
+    //   urllib3          -> (none)
+    //   certifi          -> (none)
+    //   shared-lib       -> certifi
+    const WORKSPACE_LOCK_FOR_MEMBER: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[manifest]
+members = [
+    "packages/alpha",
+    "packages/beta",
+]
+
+[[package]]
+name = "alpha"
+version = "0.1.0"
+source = { editable = "packages/alpha" }
+dependencies = [
+  { name = "certifi" },
+  { name = "requests" },
+]
+
+[[package]]
+name = "beta"
+version = "0.2.0"
+source = { editable = "packages/beta" }
+dependencies = [
+  { name = "urllib3" },
+]
+
+[[package]]
+name = "certifi"
+version = "2024.1.1"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "urllib3" },
+]
+
+[[package]]
+name = "shared-lib"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "certifi" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    #[test]
+    fn test_parse_lockfile_for_member_returns_correct_subtree_for_alpha() {
+        let (packages, dep_map) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "alpha",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("alpha"), "member root must be excluded");
+        assert!(!names.contains("beta"), "sibling member must be excluded");
+        assert!(
+            !names.contains("shared-lib"),
+            "unreachable package must be excluded"
+        );
+
+        assert!(names.contains("requests"));
+        assert!(names.contains("urllib3"));
+        assert!(names.contains("certifi"));
+
+        assert!(dep_map.contains_key("requests"));
+        assert!(dep_map.contains_key("urllib3"));
+        assert!(dep_map.contains_key("certifi"));
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_returns_correct_subtree_for_beta() {
+        let (packages, _dep_map) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "beta",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("beta"), "member root must be excluded");
+        assert!(!names.contains("alpha"), "sibling member must be excluded");
+        assert!(!names.contains("requests"), "unreachable from beta");
+        assert!(!names.contains("certifi"), "unreachable from beta");
+        assert!(!names.contains("shared-lib"), "unreachable from beta");
+
+        assert!(names.contains("urllib3"));
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_member_root_excluded() {
+        let (packages, _) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "alpha",
+        )
+        .unwrap();
+
+        let names: Vec<String> = packages.iter().map(|p| p.name().to_string()).collect();
+        assert!(
+            !names.contains(&"alpha".to_string()),
+            "member root must not appear in result"
+        );
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_nonexistent_member_returns_error() {
+        let result = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_FOR_MEMBER,
+            Path::new("/workspace"),
+            "nonexistent-member",
+        );
+
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("nonexistent-member"),
+            "error must mention the missing member name"
+        );
+    }
+
+    // uv >= 0.5 workspace lock fixture using `source.virtual` instead of `source.editable`.
+    //
+    // Dependency graph:
+    //   api    (virtual at packages/api)    -> requests, fastapi
+    //   worker (virtual at packages/worker) -> celery
+    const WORKSPACE_LOCK_VIRTUAL_FORMAT: &str = r#"
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[manifest]
+members = [
+    "api",
+    "worker",
+]
+
+[[package]]
+name = "api"
+version = "0.1.0"
+source = { virtual = "packages/api" }
+dependencies = [
+  { name = "fastapi" },
+  { name = "requests" },
+]
+
+[[package]]
+name = "celery"
+version = "5.4.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "worker"
+version = "0.1.0"
+source = { virtual = "packages/worker" }
+dependencies = [
+  { name = "celery" },
+]
+"#;
+
+    #[test]
+    fn test_parse_lockfile_for_member_handles_virtual_source_for_api() {
+        let (packages, _) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_VIRTUAL_FORMAT,
+            Path::new("/workspace"),
+            "api",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("api"), "member root must be excluded");
+        assert!(!names.contains("worker"), "sibling member must be excluded");
+        assert!(names.contains("requests"));
+        assert!(names.contains("fastapi"));
+        assert!(!names.contains("celery"), "unreachable from api");
+    }
+
+    #[test]
+    fn test_parse_lockfile_for_member_handles_virtual_source_for_worker() {
+        let (packages, _) = parse_lockfile_content_for_member(
+            WORKSPACE_LOCK_VIRTUAL_FORMAT,
+            Path::new("/workspace"),
+            "worker",
+        )
+        .unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+
+        assert!(!names.contains("worker"), "member root must be excluded");
+        assert!(!names.contains("api"), "sibling member must be excluded");
+        assert!(names.contains("celery"));
+        assert!(!names.contains("requests"), "unreachable from worker");
+        assert!(!names.contains("fastapi"), "unreachable from worker");
+    }
+}

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -53,11 +53,10 @@ pub fn parse_lockfile_content(content: &str, project_path: &Path) -> Result<Lock
         package: Vec<UvPackage>,
     }
 
-    let lockfile: UvLock =
-        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-            path: project_path.join("uv.lock"),
-            details: e.to_string(),
-        })?;
+    let lockfile: UvLock = toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+        path: project_path.join("uv.lock"),
+        details: e.to_string(),
+    })?;
 
     let mut packages = Vec::new();
     let mut dependency_map = HashMap::new();
@@ -109,24 +108,20 @@ pub fn parse_lockfile_content_for_member(
         package: Vec<UvPackage>,
     }
 
-    let lockfile: UvLock =
-        toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
-            path: project_path.join("uv.lock"),
-            details: e.to_string(),
-        })?;
+    let lockfile: UvLock = toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+        path: project_path.join("uv.lock"),
+        details: e.to_string(),
+    })?;
 
     let mut full_dep_map: HashMap<String, Vec<String>> = HashMap::new();
     let mut pkg_lookup: HashMap<String, (String, String)> = HashMap::new();
     let mut member_direct_deps: Option<Vec<String>> = None;
 
     for pkg in &lockfile.package {
-        let deps = collect_all_deps(
-            &pkg.dependencies,
-            pkg.dev_dependencies.as_ref(),
-        );
+        let deps = collect_all_deps(&pkg.dependencies, pkg.dev_dependencies.as_ref());
 
-        let is_member_root = pkg.name == member_name
-            && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
+        let is_member_root =
+            pkg.name == member_name && pkg.source.as_ref().map(|s| s.is_local()).unwrap_or(false);
 
         if is_member_root {
             member_direct_deps = Some(deps.clone());

--- a/src/adapters/outbound/filesystem/mod.rs
+++ b/src/adapters/outbound/filesystem/mod.rs
@@ -6,6 +6,4 @@ mod lockfile_parser;
 
 pub use file_reader::FileSystemReader;
 pub use file_writer::{FileSystemWriter, StdoutPresenter};
-// Note: Will be used in a subsequent CLI integration subtask of the dependency-diff feature (#224)
-#[allow(unused_imports)]
 pub use git_lockfile_reader::{determine_diff_source, GitLockfileReader};

--- a/src/adapters/outbound/filesystem/mod.rs
+++ b/src/adapters/outbound/filesystem/mod.rs
@@ -1,6 +1,7 @@
 /// Filesystem adapters for file I/O operations
 mod file_reader;
 mod file_writer;
+mod lockfile_parser;
 
 pub use file_reader::FileSystemReader;
 pub use file_writer::{FileSystemWriter, StdoutPresenter};

--- a/src/adapters/outbound/filesystem/mod.rs
+++ b/src/adapters/outbound/filesystem/mod.rs
@@ -1,7 +1,11 @@
 /// Filesystem adapters for file I/O operations
 mod file_reader;
 mod file_writer;
+mod git_lockfile_reader;
 mod lockfile_parser;
 
 pub use file_reader::FileSystemReader;
 pub use file_writer::{FileSystemWriter, StdoutPresenter};
+// Note: Will be used in a subsequent CLI integration subtask of the dependency-diff feature (#224)
+#[allow(unused_imports)]
+pub use git_lockfile_reader::{determine_diff_source, GitLockfileReader};

--- a/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
@@ -100,6 +100,7 @@ mod tests {
             license_compliance: None,
             resolution_guide: None,
             upgrade_recommendations: None,
+            abandoned_packages: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/diff_json_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_json_formatter.rs
@@ -1,8 +1,3 @@
-// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
-// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
-// (pub items are reachable by library consumers), making the expectation unfulfilled there.
-#![allow(dead_code)]
-
 use serde::Serialize;
 
 use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff};

--- a/src/adapters/outbound/formatters/diff_json_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_json_formatter.rs
@@ -1,0 +1,327 @@
+// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
+// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
+// (pub items are reachable by library consumers), making the expectation unfulfilled there.
+#![allow(dead_code)]
+
+use serde::Serialize;
+
+use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff};
+use crate::shared::Result;
+
+/// Formats a `DependencyDiff` as machine-readable JSON.
+///
+/// Output shape:
+/// ```json
+/// { "diff": { "base": "<ref>", "summary": {...}, "changes": [...] } }
+/// ```
+/// Version fields are omitted when not applicable (e.g. `old_version` for Added packages).
+pub struct DiffJsonFormatter;
+
+impl DiffJsonFormatter {
+    /// Creates a new `DiffJsonFormatter`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Serializes `diff` to a pretty-printed JSON string.
+    ///
+    /// # Errors
+    /// Returns an error if JSON serialization fails (in practice this cannot happen
+    /// because all field types are serializable).
+    pub fn format(&self, diff: &DependencyDiff) -> Result<String> {
+        let changes: Vec<ChangeDto> = diff
+            .changes
+            .iter()
+            .map(|c| {
+                let (old_version, new_version) = match c.change_type {
+                    ChangeType::Added => (None, c.new_version.as_deref()),
+                    ChangeType::Removed => (c.old_version.as_deref(), None),
+                    ChangeType::Updated | ChangeType::Unchanged => {
+                        (c.old_version.as_deref(), c.new_version.as_deref())
+                    }
+                };
+                ChangeDto {
+                    package: &c.package_name,
+                    change: change_label(&c.change_type),
+                    old_version,
+                    new_version,
+                    license: c.license.as_deref(),
+                }
+            })
+            .collect();
+
+        let envelope = DiffEnvelope {
+            diff: DiffBody {
+                base: &diff.base_ref,
+                summary: SummaryDto {
+                    added: diff.summary.added,
+                    removed: diff.summary.removed,
+                    updated: diff.summary.updated,
+                    unchanged: diff.summary.unchanged,
+                },
+                changes,
+            },
+        };
+
+        serde_json::to_string_pretty(&envelope).map_err(Into::into)
+    }
+}
+
+impl Default for DiffJsonFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn change_label(change_type: &ChangeType) -> &'static str {
+    match change_type {
+        ChangeType::Added => "added",
+        ChangeType::Removed => "removed",
+        ChangeType::Updated => "updated",
+        ChangeType::Unchanged => "unchanged",
+    }
+}
+
+#[derive(Serialize)]
+struct DiffEnvelope<'a> {
+    diff: DiffBody<'a>,
+}
+
+#[derive(Serialize)]
+struct DiffBody<'a> {
+    base: &'a str,
+    summary: SummaryDto,
+    changes: Vec<ChangeDto<'a>>,
+}
+
+#[derive(Serialize)]
+struct SummaryDto {
+    added: usize,
+    removed: usize,
+    updated: usize,
+    unchanged: usize,
+}
+
+#[derive(Serialize)]
+struct ChangeDto<'a> {
+    package: &'a str,
+    change: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    old_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<&'a str>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::dependency_diff::{
+        ChangeType, DependencyDiff, DiffSummary, PackageChange,
+    };
+    use serde_json::Value;
+
+    fn make_diff(changes: Vec<PackageChange>) -> DependencyDiff {
+        let summary = DiffSummary {
+            added: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Added)
+                .count(),
+            removed: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Removed)
+                .count(),
+            updated: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Updated)
+                .count(),
+            unchanged: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Unchanged)
+                .count(),
+        };
+        DependencyDiff {
+            base_ref: "main".to_string(),
+            changes,
+            summary,
+        }
+    }
+
+    fn make_change(
+        name: &str,
+        change_type: ChangeType,
+        old: Option<&str>,
+        new: Option<&str>,
+        license: Option<&str>,
+        vuln_count: usize,
+    ) -> PackageChange {
+        PackageChange {
+            package_name: name.to_string(),
+            change_type,
+            old_version: old.map(str::to_string),
+            new_version: new.map(str::to_string),
+            license: license.map(str::to_string),
+            vulnerability_count: vuln_count,
+        }
+    }
+
+    #[test]
+    fn test_top_level_shape_and_base_ref() {
+        let diff = make_diff(vec![]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+
+        assert!(json["diff"].is_object());
+        assert_eq!(json["diff"]["base"], "main");
+        assert!(json["diff"]["summary"].is_object());
+        assert!(json["diff"]["changes"].is_array());
+    }
+
+    #[test]
+    fn test_empty_diff() {
+        let diff = make_diff(vec![]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+
+        assert_eq!(json["diff"]["summary"]["added"], 0);
+        assert_eq!(json["diff"]["summary"]["removed"], 0);
+        assert_eq!(json["diff"]["summary"]["updated"], 0);
+        assert_eq!(json["diff"]["summary"]["unchanged"], 0);
+        assert_eq!(json["diff"]["changes"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_added_omits_old_version() {
+        let diff = make_diff(vec![make_change(
+            "pydantic",
+            ChangeType::Added,
+            None,
+            Some("2.9.0"),
+            Some("MIT"),
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "added");
+        assert_eq!(change["new_version"], "2.9.0");
+        assert!(change["old_version"].is_null());
+        assert_eq!(change["license"], "MIT");
+    }
+
+    #[test]
+    fn test_removed_omits_new_version() {
+        let diff = make_diff(vec![make_change(
+            "flask",
+            ChangeType::Removed,
+            Some("3.0.0"),
+            None,
+            Some("BSD-3-Clause"),
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "removed");
+        assert_eq!(change["old_version"], "3.0.0");
+        assert!(change["new_version"].is_null());
+    }
+
+    #[test]
+    fn test_updated_keeps_both_versions() {
+        let diff = make_diff(vec![make_change(
+            "requests",
+            ChangeType::Updated,
+            Some("2.31.0"),
+            Some("2.32.0"),
+            Some("Apache-2.0"),
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "updated");
+        assert_eq!(change["old_version"], "2.31.0");
+        assert_eq!(change["new_version"], "2.32.0");
+    }
+
+    #[test]
+    fn test_unchanged_keeps_both_versions() {
+        let diff = make_diff(vec![make_change(
+            "urllib3",
+            ChangeType::Unchanged,
+            Some("1.26.0"),
+            Some("1.26.0"),
+            None,
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let change = &json["diff"]["changes"][0];
+
+        assert_eq!(change["change"], "unchanged");
+        assert_eq!(change["old_version"], "1.26.0");
+        assert_eq!(change["new_version"], "1.26.0");
+    }
+
+    #[test]
+    fn test_missing_license_omits_field() {
+        let diff = make_diff(vec![make_change(
+            "somelib",
+            ChangeType::Added,
+            None,
+            Some("1.0.0"),
+            None,
+            0,
+        )]);
+        let formatter = DiffJsonFormatter::new();
+        let json_str = formatter.format(&diff).unwrap();
+        let json: Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(json["diff"]["changes"][0]["license"].is_null());
+        assert!(!json_str.contains("\"license\""));
+    }
+
+    #[test]
+    fn test_all_change_types_in_one_diff() {
+        let diff = make_diff(vec![
+            make_change("a", ChangeType::Added, None, Some("1.0.0"), Some("MIT"), 0),
+            make_change(
+                "b",
+                ChangeType::Removed,
+                Some("0.5.0"),
+                None,
+                Some("Apache-2.0"),
+                0,
+            ),
+            make_change(
+                "c",
+                ChangeType::Updated,
+                Some("2.0.0"),
+                Some("2.1.0"),
+                None,
+                1,
+            ),
+            make_change(
+                "d",
+                ChangeType::Unchanged,
+                Some("3.0.0"),
+                Some("3.0.0"),
+                None,
+                0,
+            ),
+        ]);
+        let formatter = DiffJsonFormatter::new();
+        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+
+        assert_eq!(json["diff"]["summary"]["added"], 1);
+        assert_eq!(json["diff"]["summary"]["removed"], 1);
+        assert_eq!(json["diff"]["summary"]["updated"], 1);
+        assert_eq!(json["diff"]["summary"]["unchanged"], 1);
+        assert_eq!(json["diff"]["changes"].as_array().unwrap().len(), 4);
+    }
+}

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -1,0 +1,322 @@
+// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
+// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
+// (pub items are reachable by library consumers), making the expectation unfulfilled there.
+#![allow(dead_code)]
+
+use std::fmt::Write;
+
+use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff, PackageChange};
+
+/// Formats a `DependencyDiff` as a human-readable Markdown report.
+///
+/// Produces a two-section report: a summary table with aggregate counts, and a
+/// changes table listing every package with its change type, versions, license,
+/// and vulnerability count.
+pub struct DiffMarkdownFormatter;
+
+impl DiffMarkdownFormatter {
+    /// Creates a new `DiffMarkdownFormatter`.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Formats `diff` as a Markdown string. This operation is infallible.
+    pub fn format(&self, diff: &DependencyDiff) -> String {
+        let mut out = String::new();
+
+        writeln!(out, "## Dependency Diff Report").unwrap();
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "Compared: `{}` vs current `uv.lock`",
+            diff.base_ref
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "### Summary").unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "| Metric | Count |").unwrap();
+        writeln!(out, "|--------|-------|").unwrap();
+        writeln!(out, "| Added | {} |", diff.summary.added).unwrap();
+        writeln!(out, "| Removed | {} |", diff.summary.removed).unwrap();
+        writeln!(out, "| Updated | {} |", diff.summary.updated).unwrap();
+        writeln!(out, "| Unchanged | {} |", diff.summary.unchanged).unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "### Changes").unwrap();
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "|---------|--------|-------------|-------------|---------|-----------------|"
+        )
+        .unwrap();
+
+        for change in &diff.changes {
+            writeln!(out, "{}", format_change_row(change)).unwrap();
+        }
+
+        out
+    }
+}
+
+impl Default for DiffMarkdownFormatter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn format_change_row(change: &PackageChange) -> String {
+    let change_label = match change.change_type {
+        ChangeType::Added => "Added",
+        ChangeType::Removed => "Removed",
+        ChangeType::Updated => "Updated",
+        ChangeType::Unchanged => "Unchanged",
+    };
+    let old = version_cell(&change.old_version);
+    let new = version_cell(&change.new_version);
+    let license = version_cell(&change.license);
+    let vulns = vuln_cell(&change.change_type, change.vulnerability_count);
+    format!(
+        "| {} | {} | {} | {} | {} | {} |",
+        change.package_name, change_label, old, new, license, vulns
+    )
+}
+
+fn version_cell(opt: &Option<String>) -> &str {
+    opt.as_deref().unwrap_or("-")
+}
+
+fn vuln_cell(change_type: &ChangeType, count: usize) -> String {
+    if matches!(change_type, ChangeType::Removed) {
+        return "-".to_string();
+    }
+    if count == 0 {
+        "None".to_string()
+    } else {
+        count.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::dependency_diff::{
+        ChangeType, DependencyDiff, DiffSummary, PackageChange,
+    };
+
+    fn make_diff(changes: Vec<PackageChange>) -> DependencyDiff {
+        let summary = DiffSummary {
+            added: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Added)
+                .count(),
+            removed: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Removed)
+                .count(),
+            updated: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Updated)
+                .count(),
+            unchanged: changes
+                .iter()
+                .filter(|c| c.change_type == ChangeType::Unchanged)
+                .count(),
+        };
+        DependencyDiff {
+            base_ref: "main".to_string(),
+            changes,
+            summary,
+        }
+    }
+
+    fn make_change(
+        name: &str,
+        change_type: ChangeType,
+        old: Option<&str>,
+        new: Option<&str>,
+        license: Option<&str>,
+        vuln_count: usize,
+    ) -> PackageChange {
+        PackageChange {
+            package_name: name.to_string(),
+            change_type,
+            old_version: old.map(str::to_string),
+            new_version: new.map(str::to_string),
+            license: license.map(str::to_string),
+            vulnerability_count: vuln_count,
+        }
+    }
+
+    #[test]
+    fn test_header_and_compared_line() {
+        let diff = make_diff(vec![]);
+        let formatter = DiffMarkdownFormatter::new();
+        let md = formatter.format(&diff);
+
+        assert!(md.contains("## Dependency Diff Report"));
+        assert!(md.contains("Compared: `main` vs current `uv.lock`"));
+    }
+
+    #[test]
+    fn test_summary_table_rows() {
+        let diff = DependencyDiff {
+            base_ref: "main".to_string(),
+            changes: vec![],
+            summary: DiffSummary {
+                added: 2,
+                removed: 1,
+                updated: 3,
+                unchanged: 45,
+            },
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| Added | 2 |"));
+        assert!(md.contains("| Removed | 1 |"));
+        assert!(md.contains("| Updated | 3 |"));
+        assert!(md.contains("| Unchanged | 45 |"));
+    }
+
+    #[test]
+    fn test_changes_table_header_always_present() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains(
+            "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
+        ));
+        assert!(md.contains(
+            "|---------|--------|-------------|-------------|---------|-----------------|"
+        ));
+    }
+
+    #[test]
+    fn test_added_package_row() {
+        let diff = make_diff(vec![make_change(
+            "pydantic",
+            ChangeType::Added,
+            None,
+            Some("2.9.0"),
+            Some("MIT"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| pydantic | Added | - | 2.9.0 | MIT | None |"));
+    }
+
+    #[test]
+    fn test_removed_package_row() {
+        let diff = make_diff(vec![make_change(
+            "flask",
+            ChangeType::Removed,
+            Some("3.0.0"),
+            None,
+            Some("BSD-3-Clause"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| flask | Removed | 3.0.0 | - | BSD-3-Clause | - |"));
+    }
+
+    #[test]
+    fn test_updated_package_row() {
+        let diff = make_diff(vec![make_change(
+            "requests",
+            ChangeType::Updated,
+            Some("2.31.0"),
+            Some("2.32.0"),
+            Some("Apache-2.0"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| requests | Updated | 2.31.0 | 2.32.0 | Apache-2.0 | None |"));
+    }
+
+    #[test]
+    fn test_unchanged_package_row() {
+        let diff = make_diff(vec![make_change(
+            "urllib3",
+            ChangeType::Unchanged,
+            Some("1.26.0"),
+            Some("1.26.0"),
+            Some("MIT"),
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| urllib3 | Unchanged | 1.26.0 | 1.26.0 | MIT | None |"));
+    }
+
+    #[test]
+    fn test_vuln_cell_shows_count_when_nonzero() {
+        let diff = make_diff(vec![make_change(
+            "vuln-pkg",
+            ChangeType::Updated,
+            Some("1.0.0"),
+            Some("1.1.0"),
+            None,
+            3,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| vuln-pkg | Updated | 1.0.0 | 1.1.0 | - | 3 |"));
+    }
+
+    #[test]
+    fn test_vuln_cell_dash_for_removed_regardless_of_count() {
+        let diff = make_diff(vec![make_change(
+            "gone",
+            ChangeType::Removed,
+            Some("1.0.0"),
+            None,
+            None,
+            5,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| gone | Removed | 1.0.0 | - | - | - |"));
+    }
+
+    #[test]
+    fn test_missing_license_shows_dash() {
+        let diff = make_diff(vec![make_change(
+            "nolic",
+            ChangeType::Added,
+            None,
+            Some("0.1.0"),
+            None,
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new().format(&diff);
+
+        assert!(md.contains("| nolic | Added | - | 0.1.0 | - | None |"));
+    }
+
+    #[test]
+    fn test_section_order() {
+        let diff = DependencyDiff {
+            base_ref: "main".to_string(),
+            changes: vec![],
+            summary: DiffSummary {
+                added: 0,
+                removed: 0,
+                updated: 0,
+                unchanged: 0,
+            },
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff);
+        let summary_pos = md.find("### Summary").unwrap();
+        let changes_pos = md.find("### Changes").unwrap();
+        assert!(summary_pos < changes_pos);
+    }
+}

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -26,12 +26,7 @@ impl DiffMarkdownFormatter {
 
         writeln!(out, "## Dependency Diff Report").unwrap();
         writeln!(out).unwrap();
-        writeln!(
-            out,
-            "Compared: `{}` vs current `uv.lock`",
-            diff.base_ref
-        )
-        .unwrap();
+        writeln!(out, "Compared: `{}` vs current `uv.lock`", diff.base_ref).unwrap();
         writeln!(out).unwrap();
 
         writeln!(out, "### Summary").unwrap();

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -1,8 +1,3 @@
-// Dead in the bin target until wired to CLI in a subsequent subtask of #224.
-// #[expect(dead_code)] cannot be used: the lib target does not see this as dead code
-// (pub items are reachable by library consumers), making the expectation unfulfilled there.
-#![allow(dead_code)]
-
 use std::fmt::Write;
 
 use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff, PackageChange};

--- a/src/adapters/outbound/formatters/markdown_formatter/links.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/links.rs
@@ -106,6 +106,7 @@ mod tests {
             license_compliance: None,
             resolution_guide: None,
             upgrade_recommendations: None,
+            abandoned_packages: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -54,6 +54,7 @@ impl MarkdownFormatter {
             &model.components,
             model.vulnerabilities.as_ref(),
             model.license_compliance.as_ref(),
+            model.abandoned_packages.as_ref(),
         );
         sections::header::render(self.messages, output);
         sections::components::render(
@@ -64,8 +65,8 @@ impl MarkdownFormatter {
         );
     }
 
-    /// Renders the four conditional sections when present: dependencies, vulnerabilities,
-    /// resolution guide, and license compliance.
+    /// Renders the five conditional sections when present: dependencies, vulnerabilities,
+    /// license compliance, abandoned packages, and resolution guide.
     fn render_optional_sections(&self, output: &mut String, model: &SbomReadModel) {
         if let Some(deps) = &model.dependencies {
             sections::dependencies::render(
@@ -84,6 +85,12 @@ impl MarkdownFormatter {
                 vulns,
             );
         }
+        if let Some(compliance) = &model.license_compliance {
+            sections::license_compliance::render(self.messages, output, compliance);
+        }
+        if let Some(report) = &model.abandoned_packages {
+            sections::abandoned_packages::render(self.messages, output, report);
+        }
         if let Some(guide) = &model.resolution_guide {
             if !guide.entries.is_empty() {
                 sections::resolution_guide::render(
@@ -93,9 +100,6 @@ impl MarkdownFormatter {
                     model.upgrade_recommendations.as_ref(),
                 );
             }
-        }
-        if let Some(compliance) = &model.license_compliance {
-            sections::license_compliance::render(self.messages, output, compliance);
         }
     }
 }
@@ -120,9 +124,11 @@ mod tests {
 
     mod test_fixtures {
         use crate::application::read_models::{
-            ComponentView, LicenseView, SbomMetadataView, SbomReadModel, SeverityView,
-            VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
+            AbandonedPackageView, AbandonedPackagesReport, ComponentView, LicenseView,
+            SbomMetadataView, SbomReadModel, SeverityView, VulnerabilityReportView,
+            VulnerabilitySummary, VulnerabilityView,
         };
+        use chrono::NaiveDate;
 
         pub(super) fn base_model() -> SbomReadModel {
             SbomReadModel {
@@ -166,6 +172,7 @@ mod tests {
                 license_compliance: None,
                 resolution_guide: None,
                 upgrade_recommendations: None,
+                abandoned_packages: None,
             }
         }
 
@@ -283,6 +290,24 @@ mod tests {
                     total_count: 2,
                     affected_package_count: 2,
                 },
+            });
+            model
+        }
+
+        pub(super) fn with_abandoned_packages(count: usize) -> SbomReadModel {
+            let mut model = base_model();
+            let packages = (0..count)
+                .map(|i| AbandonedPackageView {
+                    name: format!("old-pkg-{i}"),
+                    version: "0.1.0".to_string(),
+                    last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                    days_inactive: 800 + i as i64,
+                    is_direct: i % 2 == 0,
+                })
+                .collect();
+            model.abandoned_packages = Some(AbandonedPackagesReport {
+                packages,
+                threshold_days: 730,
             });
             model
         }
@@ -771,5 +796,113 @@ mod tests {
         let markdown = formatter.format(&model).unwrap();
 
         assert!(markdown.contains("Some Custom License"));
+    }
+
+    // ===== Abandoned packages section tests =====
+
+    #[test]
+    fn test_abandoned_section_present_when_report_provided() {
+        let model = test_fixtures::with_abandoned_packages(2);
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("## Abandoned Packages"));
+        assert!(markdown.contains("old-pkg-0"));
+        assert!(markdown.contains("old-pkg-1"));
+    }
+
+    #[test]
+    fn test_abandoned_section_absent_when_none() {
+        let model = test_fixtures::base_model(); // abandoned_packages: None
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(!markdown.contains("## Abandoned Packages"));
+    }
+
+    #[test]
+    fn test_abandoned_empty_report_renders_no_packages_message() {
+        let mut model = test_fixtures::base_model();
+        model.abandoned_packages = Some(crate::application::read_models::AbandonedPackagesReport {
+            packages: vec![],
+            threshold_days: 730,
+        });
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("## Abandoned Packages"));
+        assert!(markdown.contains("No abandoned packages detected."));
+        assert!(!markdown.contains("| Package | Version | Last Release |"));
+    }
+
+    #[test]
+    fn test_abandoned_section_order_after_license_before_resolution_guide() {
+        use crate::application::read_models::{
+            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView, LicenseComplianceView,
+            LicenseComplianceSummary, ResolutionEntryView, ResolutionGuideView,
+        };
+        use chrono::NaiveDate;
+
+        let mut model = test_fixtures::base_model();
+        model.license_compliance = Some(LicenseComplianceView {
+            has_violations: false,
+            violations: vec![],
+            warnings: vec![],
+            summary: LicenseComplianceSummary {
+                violation_count: 0,
+                warning_count: 0,
+            },
+        });
+        model.abandoned_packages = Some(AbandonedPackagesReport {
+            packages: vec![AbandonedPackageView {
+                name: "stale-lib".to_string(),
+                version: "1.0.0".to_string(),
+                last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                days_inactive: 900,
+                is_direct: true,
+            }],
+            threshold_days: 730,
+        });
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "requests".to_string(),
+                current_version: "2.31.0".to_string(),
+                fixed_version: Some("2.32.0".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-0001".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![],
+            }],
+        });
+
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert_section_order(
+            &markdown,
+            &[
+                "## License Compliance Report",
+                "## Abandoned Packages",
+                "## Vulnerability Resolution Guide",
+            ],
+        );
+    }
+
+    #[test]
+    fn test_abandoned_section_ja_locale() {
+        let model = test_fixtures::with_abandoned_packages(1);
+        let markdown = MarkdownFormatter::new(Locale::Ja).format(&model).unwrap();
+        assert!(markdown.contains("## 廃止パッケージ"));
+        assert!(markdown.contains("old-pkg-0"));
+    }
+
+    #[test]
+    fn test_summary_shows_abandoned_skipped_when_none() {
+        let model = test_fixtures::base_model();
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("_Abandoned package check skipped._"));
+    }
+
+    #[test]
+    fn test_summary_shows_abandoned_row_when_report_present() {
+        let model = test_fixtures::with_abandoned_packages(2);
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(markdown.contains("| Abandoned packages | 2 | ⚠️ |"));
+        assert!(!markdown.contains("_Abandoned package check skipped._"));
     }
 }

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -832,8 +832,9 @@ mod tests {
     #[test]
     fn test_abandoned_section_order_after_license_before_resolution_guide() {
         use crate::application::read_models::{
-            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView, LicenseComplianceView,
-            LicenseComplianceSummary, ResolutionEntryView, ResolutionGuideView,
+            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView,
+            LicenseComplianceSummary, LicenseComplianceView, ResolutionEntryView,
+            ResolutionGuideView,
         };
         use chrono::NaiveDate;
 

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
@@ -120,8 +120,9 @@ mod tests {
         };
         let output = render_ja(&report);
         assert!(output.contains("## 廃止パッケージ"));
-        assert!(output
-            .contains("| パッケージ | バージョン | 最終リリース | 非アクティブ日数 | 種別 |"));
+        assert!(
+            output.contains("| パッケージ | バージョン | 最終リリース | 非アクティブ日数 | 種別 |")
+        );
         assert!(output.contains("| requests | 1.0.0 | 2022-06-15 | 800 | 直接依存パッケージ |"));
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/abandoned_packages.rs
@@ -1,0 +1,154 @@
+use crate::application::read_models::AbandonedPackagesReport;
+use crate::i18n::Messages;
+
+/// Renders the abandoned packages section
+pub(in super::super) fn render(
+    messages: &'static Messages,
+    output: &mut String,
+    report: &AbandonedPackagesReport,
+) {
+    output.push('\n');
+    output.push_str(messages.section_abandoned_packages);
+    output.push_str("\n\n");
+    output.push_str(messages.desc_abandoned_packages);
+    output.push_str("\n\n");
+
+    if report.packages.is_empty() {
+        output.push_str(messages.label_no_abandoned_packages);
+        output.push('\n');
+        return;
+    }
+
+    output.push_str(&format!(
+        "| {} | {} | {} | {} | {} |\n",
+        messages.col_package,
+        messages.col_version,
+        messages.col_last_release,
+        messages.col_days_inactive,
+        messages.col_type,
+    ));
+    output.push_str(&super::super::table::make_separator(&[
+        messages.col_package,
+        messages.col_version,
+        messages.col_last_release,
+        messages.col_days_inactive,
+        messages.col_type,
+    ]));
+
+    for pkg in &report.packages {
+        let type_label = if pkg.is_direct {
+            messages.label_direct_deps
+        } else {
+            messages.label_transitive_deps
+        };
+        output.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            super::super::table::escape_markdown_table_cell(&pkg.name),
+            super::super::table::escape_markdown_table_cell(&pkg.version),
+            pkg.last_release_date,
+            pkg.days_inactive,
+            type_label,
+        ));
+    }
+    output.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::AbandonedPackageView;
+    use crate::i18n::{Locale, Messages};
+    use chrono::NaiveDate;
+
+    fn make_view(name: &str, days: i64, is_direct: bool) -> AbandonedPackageView {
+        AbandonedPackageView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            last_release_date: NaiveDate::from_ymd_opt(2022, 6, 15).unwrap(),
+            days_inactive: days,
+            is_direct,
+        }
+    }
+
+    fn render_en(report: &AbandonedPackagesReport) -> String {
+        let mut output = String::new();
+        render(Messages::for_locale(Locale::En), &mut output, report);
+        output
+    }
+
+    fn render_ja(report: &AbandonedPackagesReport) -> String {
+        let mut output = String::new();
+        render(Messages::for_locale(Locale::Ja), &mut output, report);
+        output
+    }
+
+    #[test]
+    fn test_empty_report_renders_no_packages_message_en() {
+        let report = AbandonedPackagesReport::default();
+        let output = render_en(&report);
+        assert!(output.contains("## Abandoned Packages"));
+        assert!(output.contains("No abandoned packages detected."));
+        assert!(!output.contains("| Package |"));
+    }
+
+    #[test]
+    fn test_empty_report_renders_no_packages_message_ja() {
+        let report = AbandonedPackagesReport::default();
+        let output = render_ja(&report);
+        assert!(output.contains("## 廃止パッケージ"));
+        assert!(output.contains("廃止パッケージは検出されませんでした。"));
+        assert!(!output.contains("| パッケージ |"));
+    }
+
+    #[test]
+    fn test_table_rendered_with_packages_en() {
+        let report = AbandonedPackagesReport {
+            packages: vec![make_view("requests", 800, true)],
+            threshold_days: 730,
+        };
+        let output = render_en(&report);
+        assert!(output.contains("## Abandoned Packages"));
+        assert!(output.contains("| Package | Version | Last Release | Days Inactive | Type |"));
+        assert!(output.contains("| requests | 1.0.0 | 2022-06-15 | 800 | Direct dependencies |"));
+    }
+
+    #[test]
+    fn test_table_rendered_with_packages_ja() {
+        let report = AbandonedPackagesReport {
+            packages: vec![make_view("requests", 800, true)],
+            threshold_days: 730,
+        };
+        let output = render_ja(&report);
+        assert!(output.contains("## 廃止パッケージ"));
+        assert!(output
+            .contains("| パッケージ | バージョン | 最終リリース | 非アクティブ日数 | 種別 |"));
+        assert!(output.contains("| requests | 1.0.0 | 2022-06-15 | 800 | 直接依存パッケージ |"));
+    }
+
+    #[test]
+    fn test_direct_vs_transitive_type_label_en() {
+        let report = AbandonedPackagesReport {
+            packages: vec![
+                make_view("pkg-direct", 900, true),
+                make_view("pkg-transitive", 1000, false),
+            ],
+            threshold_days: 730,
+        };
+        let output = render_en(&report);
+        assert!(output.contains("| pkg-direct | 1.0.0 | 2022-06-15 | 900 | Direct dependencies |"));
+        assert!(output
+            .contains("| pkg-transitive | 1.0.0 | 2022-06-15 | 1000 | Transitive dependencies |"));
+    }
+
+    #[test]
+    fn test_package_name_with_pipe_is_escaped() {
+        let mut pkg = make_view("pkg|evil", 800, true);
+        pkg.name = "pkg|evil".to_string();
+        let report = AbandonedPackagesReport {
+            packages: vec![pkg],
+            threshold_days: 730,
+        };
+        let output = render_en(&report);
+        assert!(output.contains("pkg\\|evil"));
+    }
+}

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
@@ -1,3 +1,4 @@
+pub(super) mod abandoned_packages;
 pub(super) mod components;
 pub(super) mod dependencies;
 pub(super) mod header;

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -189,6 +189,7 @@ mod tests {
             license_compliance: None,
             resolution_guide: None,
             upgrade_recommendations: None,
+            abandoned_packages: None,
         }
     }
 

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
@@ -1,5 +1,5 @@
 use crate::application::read_models::{
-    ComponentView, LicenseComplianceView, VulnerabilityReportView,
+    AbandonedPackagesReport, ComponentView, LicenseComplianceView, VulnerabilityReportView,
 };
 use crate::i18n::Messages;
 
@@ -10,6 +10,7 @@ pub(in super::super) fn render(
     components: &[ComponentView],
     vulnerabilities: Option<&VulnerabilityReportView>,
     license_compliance: Option<&LicenseComplianceView>,
+    abandoned_packages: Option<&AbandonedPackagesReport>,
 ) {
     output.push_str(messages.section_summary);
     output.push_str("\n\n");
@@ -104,6 +105,28 @@ pub(in super::super) fn render(
         messages.label_license_violations, violation_count, license_status
     ));
 
+    // Abandoned packages row
+    match abandoned_packages {
+        Some(report) => {
+            let n = report.total_count();
+            let abandoned_status = if n > 0 {
+                has_warning = true;
+                "⚠️"
+            } else {
+                "✅"
+            };
+            output.push_str(&format!(
+                "| {} | {} | {} |\n",
+                messages.label_abandoned_packages, n, abandoned_status
+            ));
+        }
+        None => {
+            output.push('\n');
+            output.push_str(messages.label_abandoned_check_skipped);
+            output.push('\n');
+        }
+    }
+
     // Overall line
     output.push('\n');
     let overall = if has_critical {
@@ -121,10 +144,11 @@ pub(in super::super) fn render(
 mod tests {
     use super::*;
     use crate::application::read_models::{
-        LicenseComplianceSummary, LicenseComplianceView, SeverityView, VulnerabilityReportView,
-        VulnerabilityView,
+        AbandonedPackageView, AbandonedPackagesReport, LicenseComplianceSummary,
+        LicenseComplianceView, SeverityView, VulnerabilityReportView, VulnerabilityView,
     };
     use crate::i18n::{Locale, Messages};
+    use chrono::NaiveDate;
 
     fn make_component(is_direct: bool) -> ComponentView {
         ComponentView {
@@ -173,6 +197,16 @@ mod tests {
         vulnerabilities: Option<&VulnerabilityReportView>,
         license_compliance: Option<&LicenseComplianceView>,
     ) -> String {
+        render_summary_with_abandoned(locale, components, vulnerabilities, license_compliance, None)
+    }
+
+    fn render_summary_with_abandoned(
+        locale: Locale,
+        components: &[ComponentView],
+        vulnerabilities: Option<&VulnerabilityReportView>,
+        license_compliance: Option<&LicenseComplianceView>,
+        abandoned_packages: Option<&AbandonedPackagesReport>,
+    ) -> String {
         let messages = Messages::for_locale(locale);
         let mut output = String::new();
         render(
@@ -181,6 +215,7 @@ mod tests {
             components,
             vulnerabilities,
             license_compliance,
+            abandoned_packages,
         );
         output
     }
@@ -357,6 +392,80 @@ mod tests {
             ..Default::default()
         };
         let output = render_summary(Locale::En, &[], Some(&report), None);
+        assert!(output.contains("**Overall: Action required**"));
+        assert!(!output.contains("**Overall: Attention recommended**"));
+    }
+
+    fn make_abandoned_report(count: usize) -> AbandonedPackagesReport {
+        let packages = (0..count)
+            .map(|i| AbandonedPackageView {
+                name: format!("pkg-{i}"),
+                version: "1.0.0".to_string(),
+                last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                days_inactive: 800,
+                is_direct: true,
+            })
+            .collect();
+        AbandonedPackagesReport {
+            packages,
+            threshold_days: 730,
+        }
+    }
+
+    #[test]
+    fn test_abandoned_check_skipped_en() {
+        let output = render_summary(Locale::En, &[], None, None);
+        assert!(output.contains("_Abandoned package check skipped._"));
+        assert!(!output.contains("Abandoned packages"));
+    }
+
+    #[test]
+    fn test_abandoned_check_skipped_ja() {
+        let output = render_summary(Locale::Ja, &[], None, None);
+        assert!(output.contains("_廃止パッケージチェックはスキップされました。_"));
+    }
+
+    #[test]
+    fn test_abandoned_zero_shows_ok_en() {
+        let report = make_abandoned_report(0);
+        let output =
+            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        assert!(output.contains("| Abandoned packages | 0 | ✅ |"));
+        assert!(!output.contains("_Abandoned package check skipped._"));
+    }
+
+    #[test]
+    fn test_abandoned_nonzero_shows_warning_en() {
+        let report = make_abandoned_report(3);
+        let output =
+            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        assert!(output.contains("| Abandoned packages | 3 | ⚠️ |"));
+        assert!(output.contains("**Overall: Attention recommended**"));
+    }
+
+    #[test]
+    fn test_abandoned_nonzero_shows_warning_ja() {
+        let report = make_abandoned_report(2);
+        let output =
+            render_summary_with_abandoned(Locale::Ja, &[], None, None, Some(&report));
+        assert!(output.contains("| 廃止パッケージ | 2 | ⚠️ |"));
+        assert!(output.contains("**総合判定: 注意が必要です**"));
+    }
+
+    #[test]
+    fn test_abandoned_warning_does_not_override_critical() {
+        let vuln_report = VulnerabilityReportView {
+            actionable: vec![make_vuln(SeverityView::Critical)],
+            ..Default::default()
+        };
+        let abandoned = make_abandoned_report(1);
+        let output = render_summary_with_abandoned(
+            Locale::En,
+            &[],
+            Some(&vuln_report),
+            None,
+            Some(&abandoned),
+        );
         assert!(output.contains("**Overall: Action required**"));
         assert!(!output.contains("**Overall: Attention recommended**"));
     }

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/summary.rs
@@ -197,7 +197,13 @@ mod tests {
         vulnerabilities: Option<&VulnerabilityReportView>,
         license_compliance: Option<&LicenseComplianceView>,
     ) -> String {
-        render_summary_with_abandoned(locale, components, vulnerabilities, license_compliance, None)
+        render_summary_with_abandoned(
+            locale,
+            components,
+            vulnerabilities,
+            license_compliance,
+            None,
+        )
     }
 
     fn render_summary_with_abandoned(
@@ -428,8 +434,7 @@ mod tests {
     #[test]
     fn test_abandoned_zero_shows_ok_en() {
         let report = make_abandoned_report(0);
-        let output =
-            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        let output = render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
         assert!(output.contains("| Abandoned packages | 0 | ✅ |"));
         assert!(!output.contains("_Abandoned package check skipped._"));
     }
@@ -437,8 +442,7 @@ mod tests {
     #[test]
     fn test_abandoned_nonzero_shows_warning_en() {
         let report = make_abandoned_report(3);
-        let output =
-            render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
+        let output = render_summary_with_abandoned(Locale::En, &[], None, None, Some(&report));
         assert!(output.contains("| Abandoned packages | 3 | ⚠️ |"));
         assert!(output.contains("**Overall: Attention recommended**"));
     }
@@ -446,8 +450,7 @@ mod tests {
     #[test]
     fn test_abandoned_nonzero_shows_warning_ja() {
         let report = make_abandoned_report(2);
-        let output =
-            render_summary_with_abandoned(Locale::Ja, &[], None, None, Some(&report));
+        let output = render_summary_with_abandoned(Locale::Ja, &[], None, None, Some(&report));
         assert!(output.contains("| 廃止パッケージ | 2 | ⚠️ |"));
         assert!(output.contains("**総合判定: 注意が必要です**"));
     }

--- a/src/adapters/outbound/formatters/mod.rs
+++ b/src/adapters/outbound/formatters/mod.rs
@@ -5,8 +5,6 @@ mod diff_markdown_formatter;
 mod markdown_formatter;
 
 pub use cyclonedx_formatter::CycloneDxFormatter;
-#[allow(unused_imports)]
 pub use diff_json_formatter::DiffJsonFormatter;
-#[allow(unused_imports)]
 pub use diff_markdown_formatter::DiffMarkdownFormatter;
 pub use markdown_formatter::MarkdownFormatter;

--- a/src/adapters/outbound/formatters/mod.rs
+++ b/src/adapters/outbound/formatters/mod.rs
@@ -1,6 +1,12 @@
 /// Formatter adapters for different SBOM output formats
 mod cyclonedx_formatter;
+mod diff_json_formatter;
+mod diff_markdown_formatter;
 mod markdown_formatter;
 
 pub use cyclonedx_formatter::CycloneDxFormatter;
+#[allow(unused_imports)]
+pub use diff_json_formatter::DiffJsonFormatter;
+#[allow(unused_imports)]
+pub use diff_markdown_formatter::DiffMarkdownFormatter;
 pub use markdown_formatter::MarkdownFormatter;

--- a/src/adapters/outbound/network/mod.rs
+++ b/src/adapters/outbound/network/mod.rs
@@ -2,6 +2,7 @@
 mod caching_pypi_client;
 mod osv_client;
 mod pypi_client;
+mod pypi_maintenance_client;
 
 pub use caching_pypi_client::CachingPyPiLicenseRepository;
 // Note: This will be used in subsequent subtasks for CVE check feature

--- a/src/adapters/outbound/network/mod.rs
+++ b/src/adapters/outbound/network/mod.rs
@@ -5,7 +5,6 @@ mod pypi_client;
 mod pypi_maintenance_client;
 
 pub use caching_pypi_client::CachingPyPiLicenseRepository;
-// Note: This will be used in subsequent subtasks for CVE check feature
-#[allow(unused_imports)]
 pub use osv_client::OsvClient;
 pub use pypi_client::PyPiLicenseRepository;
+pub use pypi_maintenance_client::PyPiMaintenanceRepository;

--- a/src/adapters/outbound/network/pypi_maintenance_client.rs
+++ b/src/adapters/outbound/network/pypi_maintenance_client.rs
@@ -1,6 +1,3 @@
-// No binary consumer until Issue #555 wires this adapter into GenerateSbomUseCase.
-#![allow(dead_code)]
-
 use crate::ports::outbound::{MaintenanceInfo, MaintenanceRepository};
 use crate::shared::Result;
 use async_trait::async_trait;

--- a/src/adapters/outbound/network/pypi_maintenance_client.rs
+++ b/src/adapters/outbound/network/pypi_maintenance_client.rs
@@ -1,0 +1,302 @@
+// No binary consumer until Issue #555 wires this adapter into GenerateSbomUseCase.
+#![allow(dead_code)]
+
+use crate::ports::outbound::{MaintenanceInfo, MaintenanceRepository};
+use crate::shared::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate};
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct PyPiPackageResponse {
+    #[serde(default)]
+    urls: Vec<PyPiUploadEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PyPiUploadEntry {
+    #[serde(default)]
+    upload_time_iso_8601: Option<String>,
+}
+
+/// PyPiMaintenanceRepository adapter for fetching package maintenance information from PyPI
+///
+/// Queries the package-level endpoint (`/pypi/{name}/json`, no version segment) to
+/// retrieve the latest release date, used for abandoned-package detection.
+#[derive(Clone)]
+pub struct PyPiMaintenanceRepository {
+    client: reqwest::Client,
+}
+
+impl PyPiMaintenanceRepository {
+    const MAX_RETRIES: u32 = 3;
+    // 10 MB — well above any realistic PyPI package metadata response
+    const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+
+    /// Creates a new PyPI maintenance repository with default configuration
+    pub fn new() -> Result<Self> {
+        let version = env!("CARGO_PKG_VERSION");
+        let user_agent = format!("uv-sbom/{}", version);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent(user_agent)
+            .build()?;
+
+        Ok(Self { client })
+    }
+
+    /// Validates a URL component to prevent injection attacks
+    fn validate_url_component(component: &str, component_type: &str) -> Result<()> {
+        if component.contains('/') || component.contains('\\') {
+            anyhow::bail!(
+                "Security: {} contains path separators which are not allowed",
+                component_type
+            );
+        }
+        if component.contains("..") {
+            anyhow::bail!(
+                "Security: {} contains '..' which is not allowed",
+                component_type
+            );
+        }
+        if component.contains('#') || component.contains('?') || component.contains('@') {
+            anyhow::bail!(
+                "Security: {} contains URL-unsafe characters",
+                component_type
+            );
+        }
+        Ok(())
+    }
+
+    async fn fetch_from_pypi(&self, package_name: &str) -> Result<PyPiPackageResponse> {
+        Self::validate_url_component(package_name, "Package name")?;
+        let encoded = urlencoding::encode(package_name);
+        let url = format!("https://pypi.org/pypi/{}/json", encoded);
+
+        let response = self.client.get(&url).send().await?;
+        if !response.status().is_success() {
+            anyhow::bail!("PyPI API returned status code {}", response.status());
+        }
+        // Reject oversized responses before allocating memory
+        if let Some(len) = response.content_length() {
+            if len as usize > Self::MAX_RESPONSE_BYTES {
+                anyhow::bail!("PyPI API response too large: {} bytes", len);
+            }
+        }
+        let bytes = response.bytes().await?;
+        if bytes.len() > Self::MAX_RESPONSE_BYTES {
+            anyhow::bail!(
+                "PyPI API response exceeded {} byte limit",
+                Self::MAX_RESPONSE_BYTES
+            );
+        }
+        Ok(serde_json::from_slice::<PyPiPackageResponse>(&bytes)?)
+    }
+
+    async fn fetch_with_retry(&self, package_name: &str) -> Result<PyPiPackageResponse> {
+        let mut last_error = None;
+        for attempt in 1..=Self::MAX_RETRIES {
+            match self.fetch_from_pypi(package_name).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    last_error = Some(e);
+                    if attempt < Self::MAX_RETRIES {
+                        // Linear back-off: 100 ms, 200 ms — matches PyPiLicenseRepository
+                        tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
+                    }
+                }
+            }
+        }
+        Err(last_error.unwrap())
+    }
+
+    /// Parses the latest release date from a PyPI package response.
+    ///
+    /// Returns the maximum `upload_time_iso_8601` across all `urls[]` entries,
+    /// converted to UTC date. Returns `None` when `urls` is empty or all entries
+    /// have unparseable timestamps.
+    fn parse_last_release_date(response: &PyPiPackageResponse) -> Option<NaiveDate> {
+        response
+            .urls
+            .iter()
+            .filter_map(|u| u.upload_time_iso_8601.as_deref())
+            .filter_map(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.naive_utc().date())
+            .max()
+    }
+}
+
+#[async_trait]
+impl MaintenanceRepository for PyPiMaintenanceRepository {
+    async fn fetch_maintenance_info(&self, package_name: &str) -> Result<MaintenanceInfo> {
+        let resp = self.fetch_with_retry(package_name).await?;
+        Ok(MaintenanceInfo {
+            last_release_date: Self::parse_last_release_date(&resp),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pypi_maintenance_client_creation() {
+        assert!(PyPiMaintenanceRepository::new().is_ok());
+    }
+
+    #[test]
+    fn test_parse_last_release_date_valid() {
+        let response = PyPiPackageResponse {
+            urls: vec![PyPiUploadEntry {
+                upload_time_iso_8601: Some("2024-01-15T10:30:00.000000+00:00".to_string()),
+            }],
+        };
+        let date = PyPiMaintenanceRepository::parse_last_release_date(&response);
+        assert_eq!(date, Some(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()));
+    }
+
+    #[test]
+    fn test_parse_last_release_date_picks_max() {
+        let response = PyPiPackageResponse {
+            urls: vec![
+                PyPiUploadEntry {
+                    upload_time_iso_8601: Some("2023-06-01T00:00:00.000000+00:00".to_string()),
+                },
+                PyPiUploadEntry {
+                    upload_time_iso_8601: Some("2024-03-20T12:00:00.000000+00:00".to_string()),
+                },
+                PyPiUploadEntry {
+                    upload_time_iso_8601: Some("2022-12-31T23:59:59.000000+00:00".to_string()),
+                },
+            ],
+        };
+        let date = PyPiMaintenanceRepository::parse_last_release_date(&response);
+        assert_eq!(date, Some(NaiveDate::from_ymd_opt(2024, 3, 20).unwrap()));
+    }
+
+    #[test]
+    fn test_parse_last_release_date_empty_urls() {
+        let response = PyPiPackageResponse { urls: vec![] };
+        assert!(PyPiMaintenanceRepository::parse_last_release_date(&response).is_none());
+    }
+
+    #[test]
+    fn test_parse_last_release_date_malformed_string() {
+        let response = PyPiPackageResponse {
+            urls: vec![PyPiUploadEntry {
+                upload_time_iso_8601: Some("not-a-date".to_string()),
+            }],
+        };
+        assert!(PyPiMaintenanceRepository::parse_last_release_date(&response).is_none());
+    }
+
+    #[test]
+    fn test_parse_last_release_date_malformed_skipped_when_mixed() {
+        let response = PyPiPackageResponse {
+            urls: vec![
+                PyPiUploadEntry {
+                    upload_time_iso_8601: Some("not-a-date".to_string()),
+                },
+                PyPiUploadEntry {
+                    upload_time_iso_8601: Some("2024-05-01T00:00:00.000000+00:00".to_string()),
+                },
+            ],
+        };
+        let date = PyPiMaintenanceRepository::parse_last_release_date(&response);
+        assert_eq!(date, Some(NaiveDate::from_ymd_opt(2024, 5, 1).unwrap()));
+    }
+
+    #[test]
+    fn test_parse_last_release_date_null_upload_time() {
+        let response = PyPiPackageResponse {
+            urls: vec![PyPiUploadEntry {
+                upload_time_iso_8601: None,
+            }],
+        };
+        assert!(PyPiMaintenanceRepository::parse_last_release_date(&response).is_none());
+    }
+
+    #[test]
+    fn test_deserialize_minimal_response() {
+        let json = r#"{}"#;
+        let response: PyPiPackageResponse = serde_json::from_str(json).unwrap();
+        assert!(response.urls.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_with_upload_times() {
+        let json = r#"{
+            "urls": [
+                {"upload_time_iso_8601": "2024-01-15T10:30:00.000000+00:00"},
+                {"upload_time_iso_8601": "2024-01-16T08:00:00.000000+00:00"}
+            ]
+        }"#;
+        let response: PyPiPackageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.urls.len(), 2);
+    }
+
+    #[test]
+    fn test_deserialize_with_extra_fields() {
+        let json = r#"{
+            "info": {"name": "requests", "version": "2.31.0"},
+            "urls": [{"upload_time_iso_8601": "2024-01-15T10:30:00.000000+00:00", "filename": "requests-2.31.0.tar.gz"}]
+        }"#;
+        let response: PyPiPackageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.urls.len(), 1);
+    }
+
+    #[test]
+    fn test_validate_url_component_accepts_normal_name() {
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("requests", "Package name").is_ok()
+        );
+        assert!(PyPiMaintenanceRepository::validate_url_component(
+            "my-package-123",
+            "Package name"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_component_rejects_path_separators() {
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("pkg/evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("pkg\\evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("pkg..evil", "Package name").is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_url_component_rejects_unsafe_chars() {
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("pkg#evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("pkg?evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiMaintenanceRepository::validate_url_component("pkg@evil", "Package name").is_err()
+        );
+    }
+
+    // Integration tests - require network access
+    // Uncomment to run with real PyPI API
+    // #[tokio::test]
+    // async fn test_fetch_maintenance_info_real() {
+    //     let client = PyPiMaintenanceRepository::new().unwrap();
+    //     let info = client.fetch_maintenance_info("requests").await.unwrap();
+    //     assert!(info.last_release_date.is_some());
+    // }
+    //
+    // #[tokio::test]
+    // async fn test_fetch_maintenance_info_nonexistent_real() {
+    //     let client = PyPiMaintenanceRepository::new().unwrap();
+    //     assert!(client.fetch_maintenance_info("nonexistent-pkg-xyz-123456").await.is_err());
+    // }
+}

--- a/src/application/dto/diff_request.rs
+++ b/src/application/dto/diff_request.rs
@@ -1,0 +1,55 @@
+use crate::application::dto::OutputFormat;
+use crate::ports::outbound::DiffSource;
+use std::path::PathBuf;
+
+/// DiffRequest - Internal request DTO for dependency diff generation use case.
+///
+/// Carries everything `GenerateDiffUseCase::execute` needs: where to read the
+/// "base" lockfile from, the project root holding the "current" `uv.lock`,
+/// the desired output format, and whether to enrich with CVE data.
+// Wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct DiffRequest {
+    pub source: DiffSource,
+    pub project_path: PathBuf,
+    pub format: OutputFormat,
+    /// Whether to enrich results with CVE data. Currently a no-op; enrichment
+    /// will be implemented in a follow-up issue.
+    pub check_cve: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diff_request_with_git_ref() {
+        let req = DiffRequest {
+            source: DiffSource::GitRef("main".to_string()),
+            project_path: PathBuf::from("/project"),
+            format: OutputFormat::Json,
+            check_cve: false,
+        };
+        assert_eq!(req.source, DiffSource::GitRef("main".to_string()));
+        assert_eq!(req.project_path, PathBuf::from("/project"));
+        assert_eq!(req.format, OutputFormat::Json);
+        assert!(!req.check_cve);
+    }
+
+    #[test]
+    fn test_diff_request_with_file_path() {
+        let req = DiffRequest {
+            source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
+            project_path: PathBuf::from("/project"),
+            format: OutputFormat::Markdown,
+            check_cve: true,
+        };
+        assert_eq!(
+            req.source,
+            DiffSource::FilePath(PathBuf::from("/tmp/uv.lock"))
+        );
+        assert_eq!(req.format, OutputFormat::Markdown);
+        assert!(req.check_cve);
+    }
+}

--- a/src/application/dto/diff_request.rs
+++ b/src/application/dto/diff_request.rs
@@ -1,4 +1,3 @@
-use crate::application::dto::OutputFormat;
 use crate::ports::outbound::DiffSource;
 use std::path::PathBuf;
 
@@ -6,14 +5,11 @@ use std::path::PathBuf;
 ///
 /// Carries everything `GenerateDiffUseCase::execute` needs: where to read the
 /// "base" lockfile from, the project root holding the "current" `uv.lock`,
-/// the desired output format, and whether to enrich with CVE data.
-// Wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(dead_code)]
+/// and whether to enrich with CVE data.
 #[derive(Debug, Clone)]
 pub struct DiffRequest {
     pub source: DiffSource,
     pub project_path: PathBuf,
-    pub format: OutputFormat,
     /// Whether to enrich results with CVE data. Currently a no-op; enrichment
     /// will be implemented in a follow-up issue.
     pub check_cve: bool,
@@ -28,12 +24,10 @@ mod tests {
         let req = DiffRequest {
             source: DiffSource::GitRef("main".to_string()),
             project_path: PathBuf::from("/project"),
-            format: OutputFormat::Json,
             check_cve: false,
         };
         assert_eq!(req.source, DiffSource::GitRef("main".to_string()));
         assert_eq!(req.project_path, PathBuf::from("/project"));
-        assert_eq!(req.format, OutputFormat::Json);
         assert!(!req.check_cve);
     }
 
@@ -42,14 +36,12 @@ mod tests {
         let req = DiffRequest {
             source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
             project_path: PathBuf::from("/project"),
-            format: OutputFormat::Markdown,
             check_cve: true,
         };
         assert_eq!(
             req.source,
             DiffSource::FilePath(PathBuf::from("/tmp/uv.lock"))
         );
-        assert_eq!(req.format, OutputFormat::Markdown);
         assert!(req.check_cve);
     }
 }

--- a/src/application/dto/mod.rs
+++ b/src/application/dto/mod.rs
@@ -7,10 +7,9 @@ mod output_format;
 mod sbom_request;
 mod sbom_response;
 
-// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(unused_imports)]
 pub use diff_request::DiffRequest;
 pub use output_format::OutputFormat;
+pub use sbom_request::SbomRequest;
 #[allow(unused_imports)]
-pub use sbom_request::{SbomRequest, SbomRequestBuilder};
+pub use sbom_request::SbomRequestBuilder;
 pub use sbom_response::SbomResponse;

--- a/src/application/dto/mod.rs
+++ b/src/application/dto/mod.rs
@@ -2,10 +2,14 @@
 ///
 /// DTOs are used to transfer data between the application layer
 /// and adapters, keeping the domain layer isolated.
+mod diff_request;
 mod output_format;
 mod sbom_request;
 mod sbom_response;
 
+// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(unused_imports)]
+pub use diff_request::DiffRequest;
 pub use output_format::OutputFormat;
 #[allow(unused_imports)]
 pub use sbom_request::{SbomRequest, SbomRequestBuilder};

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -35,6 +35,11 @@ pub struct SbomRequest {
     /// Whether to suggest direct dependency upgrade versions to fix transitive vulnerabilities.
     /// Only meaningful when `check_cve` is true.
     pub suggest_fix: bool,
+    /// Whether to check for abandoned/unmaintained packages.
+    pub check_abandoned: bool,
+    /// Inactivity threshold in days for abandoned-package detection.
+    /// Only meaningful when `check_abandoned` is true.
+    pub abandoned_threshold_days: u64,
     /// Output locale for human-readable formats
     pub locale: Locale,
 }
@@ -97,6 +102,8 @@ pub struct SbomRequestBuilder {
     check_license: bool,
     license_policy: Option<LicensePolicy>,
     suggest_fix: bool,
+    check_abandoned: bool,
+    abandoned_threshold_days: u64,
     locale: Locale,
 }
 
@@ -124,6 +131,8 @@ impl SbomRequestBuilder {
             check_license: false,
             license_policy: None,
             suggest_fix: false,
+            check_abandoned: false,
+            abandoned_threshold_days: 730,
             locale: Locale::default(),
         }
     }
@@ -202,6 +211,18 @@ impl SbomRequestBuilder {
         self
     }
 
+    /// Sets whether to check for abandoned/unmaintained packages.
+    pub fn check_abandoned(mut self, check: bool) -> Self {
+        self.check_abandoned = check;
+        self
+    }
+
+    /// Sets the inactivity threshold in days for abandoned-package detection.
+    pub fn abandoned_threshold_days(mut self, days: u64) -> Self {
+        self.abandoned_threshold_days = days;
+        self
+    }
+
     /// Sets the output locale for human-readable formats.
     pub fn locale(mut self, locale: Locale) -> Self {
         self.locale = locale;
@@ -230,6 +251,8 @@ impl SbomRequestBuilder {
             check_license: self.check_license,
             license_policy: self.license_policy,
             suggest_fix: self.suggest_fix,
+            check_abandoned: self.check_abandoned,
+            abandoned_threshold_days: self.abandoned_threshold_days,
             locale: self.locale,
         })
     }

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -1,3 +1,4 @@
+use crate::application::read_models::abandoned_package::AbandonedPackagesReport;
 use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
@@ -29,6 +30,9 @@ pub struct SbomResponse {
     /// Upgrade recommendations for vulnerable transitive dependencies.
     /// Populated only when `suggest_fix` was true in the request.
     pub upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
+    /// Abandoned packages report.
+    /// Populated only when `check_abandoned` was true in the request.
+    pub abandoned_packages_report: Option<AbandonedPackagesReport>,
 }
 
 impl SbomResponse {
@@ -46,6 +50,7 @@ pub struct SbomResponseBuilder {
     license_compliance_result: Option<LicenseComplianceResult>,
     has_license_violations: bool,
     upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
+    abandoned_packages_report: Option<AbandonedPackagesReport>,
 }
 
 impl SbomResponseBuilder {
@@ -59,6 +64,7 @@ impl SbomResponseBuilder {
             license_compliance_result: None,
             has_license_violations: false,
             upgrade_recommendations: None,
+            abandoned_packages_report: None,
         }
     }
 
@@ -108,6 +114,11 @@ impl SbomResponseBuilder {
         self
     }
 
+    pub fn abandoned_packages_report(mut self, report: AbandonedPackagesReport) -> Self {
+        self.abandoned_packages_report = Some(report);
+        self
+    }
+
     pub fn build(self) -> Result<SbomResponse, SbomError> {
         let metadata = self.metadata.ok_or_else(|| SbomError::Validation {
             message: "metadata is required".into(),
@@ -122,6 +133,7 @@ impl SbomResponseBuilder {
             license_compliance_result: self.license_compliance_result,
             has_license_violations: self.has_license_violations,
             upgrade_recommendations: self.upgrade_recommendations,
+            abandoned_packages_report: self.abandoned_packages_report,
         })
     }
 }

--- a/src/application/read_models/abandoned_package.rs
+++ b/src/application/read_models/abandoned_package.rs
@@ -18,9 +18,16 @@ pub struct AbandonedPackageView {
     pub name: String,
     /// Package version as listed in the lockfile
     pub version: String,
-    /// Date of the most recent upstream release
+    /// Date of the most recent upstream release.
+    ///
+    /// Packages whose `MaintenanceInfo.last_release_date` is `None` (unknown release
+    /// date) are excluded at report construction time and never appear in this struct.
     pub last_release_date: NaiveDate,
-    /// Number of days between `last_release_date` and the report's reference date
+    /// Number of days between `last_release_date` and the report's reference date.
+    ///
+    /// Uses `i64` to match `chrono::Duration::num_days()` return type directly,
+    /// avoiding a lossy cast in the use case. Negative values are theoretically
+    /// possible for future-dated releases but are never classified as abandoned.
     pub days_inactive: i64,
     /// Whether the package is a direct dependency of the current project
     pub is_direct: bool,
@@ -32,12 +39,25 @@ pub struct AbandonedPackageView {
 /// threshold used to classify them. The threshold is captured so downstream
 /// formatters can render messages like "abandoned (>730 days inactive)".
 #[allow(dead_code)]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct AbandonedPackagesReport {
     /// Packages classified as abandoned
     pub packages: Vec<AbandonedPackageView>,
     /// Inactivity threshold (in days) used to build this report
     pub threshold_days: u64,
+}
+
+impl Default for AbandonedPackagesReport {
+    /// Returns a report with no packages and the standard 730-day threshold.
+    ///
+    /// The threshold matches the application default configured in `MergedConfig`.
+    /// Use explicit construction when a different threshold is required.
+    fn default() -> Self {
+        Self {
+            packages: Vec::new(),
+            threshold_days: 730,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -84,7 +104,7 @@ mod tests {
         assert_eq!(report.total_count(), 0);
         assert_eq!(report.direct_count(), 0);
         assert_eq!(report.transitive_count(), 0);
-        assert_eq!(report.threshold_days, 0);
+        assert_eq!(report.threshold_days, 730);
     }
 
     #[test]

--- a/src/application/read_models/abandoned_package.rs
+++ b/src/application/read_models/abandoned_package.rs
@@ -1,0 +1,133 @@
+//! Abandoned package view structs for read model
+//!
+//! These structs provide a query-optimized view of abandoned-package data
+//! with pre-computed inactivity duration for efficient reporting.
+
+use chrono::NaiveDate;
+
+/// View representation of a single abandoned package
+///
+/// All fields are pre-computed at construction time so consumers (formatters,
+/// presenters) do not need to perform date arithmetic or re-derive directness.
+// Consumed by the Markdown formatter (#556) and use case integration (#555).
+// Suppressed here because this is a foundational subtask with no binary consumer yet.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbandonedPackageView {
+    /// Package name as listed in the lockfile
+    pub name: String,
+    /// Package version as listed in the lockfile
+    pub version: String,
+    /// Date of the most recent upstream release
+    pub last_release_date: NaiveDate,
+    /// Number of days between `last_release_date` and the report's reference date
+    pub days_inactive: i64,
+    /// Whether the package is a direct dependency of the current project
+    pub is_direct: bool,
+}
+
+/// View representation of an abandoned-packages report
+///
+/// Holds the pre-categorized list of abandoned packages along with the
+/// threshold used to classify them. The threshold is captured so downstream
+/// formatters can render messages like "abandoned (>730 days inactive)".
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default)]
+pub struct AbandonedPackagesReport {
+    /// Packages classified as abandoned
+    pub packages: Vec<AbandonedPackageView>,
+    /// Inactivity threshold (in days) used to build this report
+    pub threshold_days: u64,
+}
+
+#[allow(dead_code)]
+impl AbandonedPackagesReport {
+    /// Returns the total number of abandoned packages.
+    pub fn total_count(&self) -> usize {
+        self.packages.len()
+    }
+
+    /// Returns the number of abandoned packages that are direct dependencies.
+    pub fn direct_count(&self) -> usize {
+        self.packages.iter().filter(|p| p.is_direct).count()
+    }
+
+    /// Returns the number of abandoned packages that are transitive dependencies.
+    pub fn transitive_count(&self) -> usize {
+        self.packages.iter().filter(|p| !p.is_direct).count()
+    }
+
+    /// Returns `true` when no packages were classified as abandoned.
+    pub fn is_empty(&self) -> bool {
+        self.packages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_view(name: &str, days_inactive: i64, is_direct: bool) -> AbandonedPackageView {
+        AbandonedPackageView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+            days_inactive,
+            is_direct,
+        }
+    }
+
+    #[test]
+    fn test_default_report_is_empty() {
+        let report = AbandonedPackagesReport::default();
+        assert!(report.is_empty());
+        assert_eq!(report.total_count(), 0);
+        assert_eq!(report.direct_count(), 0);
+        assert_eq!(report.transitive_count(), 0);
+        assert_eq!(report.threshold_days, 0);
+    }
+
+    #[test]
+    fn test_total_count() {
+        let report = AbandonedPackagesReport {
+            packages: vec![
+                make_view("a", 400, true),
+                make_view("b", 500, false),
+                make_view("c", 600, false),
+            ],
+            threshold_days: 365,
+        };
+        assert_eq!(report.total_count(), 3);
+        assert!(!report.is_empty());
+    }
+
+    #[test]
+    fn test_direct_and_transitive_counts() {
+        let report = AbandonedPackagesReport {
+            packages: vec![
+                make_view("a", 400, true),
+                make_view("b", 500, true),
+                make_view("c", 600, false),
+            ],
+            threshold_days: 365,
+        };
+        assert_eq!(report.direct_count(), 2);
+        assert_eq!(report.transitive_count(), 1);
+    }
+
+    #[test]
+    fn test_view_clone_and_eq() {
+        let a = make_view("requests", 800, true);
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_threshold_days_preserved() {
+        let report = AbandonedPackagesReport {
+            packages: vec![],
+            threshold_days: 730,
+        };
+        assert_eq!(report.threshold_days, 730);
+    }
+}

--- a/src/application/read_models/abandoned_package.rs
+++ b/src/application/read_models/abandoned_package.rs
@@ -9,9 +9,6 @@ use chrono::NaiveDate;
 ///
 /// All fields are pre-computed at construction time so consumers (formatters,
 /// presenters) do not need to perform date arithmetic or re-derive directness.
-// Consumed by the Markdown formatter (#556) and use case integration (#555).
-// Suppressed here because this is a foundational subtask with no binary consumer yet.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AbandonedPackageView {
     /// Package name as listed in the lockfile
@@ -38,7 +35,6 @@ pub struct AbandonedPackageView {
 /// Holds the pre-categorized list of abandoned packages along with the
 /// threshold used to classify them. The threshold is captured so downstream
 /// formatters can render messages like "abandoned (>730 days inactive)".
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct AbandonedPackagesReport {
     /// Packages classified as abandoned
@@ -60,7 +56,6 @@ impl Default for AbandonedPackagesReport {
     }
 }
 
-#[allow(dead_code)]
 impl AbandonedPackagesReport {
     /// Returns the total number of abandoned packages.
     pub fn total_count(&self) -> usize {

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains view-optimized structs that provide
 //! a denormalized representation of domain data for queries.
 
+pub mod abandoned_package;
 pub mod component_view;
 pub mod dependency_view;
 pub mod license_compliance_view;
@@ -12,6 +13,8 @@ pub mod sbom_read_model_builder;
 pub mod upgrade_recommendation_view;
 pub mod vulnerability_view;
 
+#[allow(unused_imports)]
+pub use abandoned_package::{AbandonedPackageView, AbandonedPackagesReport};
 #[allow(unused_imports)]
 pub use component_view::{ComponentView, LicenseView};
 #[allow(unused_imports)]

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -3,6 +3,7 @@
 //! This module provides the main read model struct that aggregates
 //! all SBOM data in a query-optimized format.
 
+use super::abandoned_package::AbandonedPackagesReport;
 use super::component_view::ComponentView;
 use super::dependency_view::DependencyView;
 use super::license_compliance_view::LicenseComplianceView;
@@ -31,6 +32,9 @@ pub struct SbomReadModel {
     /// Upgrade recommendations for vulnerable transitive dependencies.
     /// Populated only when `suggest_fix` was true in the request.
     pub upgrade_recommendations: Option<UpgradeRecommendationView>,
+    /// Abandoned packages report.
+    /// Populated only when `check_abandoned` was true in the request.
+    pub abandoned_packages: Option<AbandonedPackagesReport>,
 }
 
 /// View representation of SBOM metadata

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -11,6 +11,7 @@ mod resolution_guide_builder;
 mod upgrade_recommendation_builder;
 mod vulnerability_builder;
 
+use super::abandoned_package::AbandonedPackagesReport;
 use super::resolution_guide_view::ResolutionGuideView;
 use super::sbom_read_model::SbomReadModel;
 use crate::ports::outbound::EnrichedPackage;
@@ -28,6 +29,7 @@ pub struct SbomReadModelBuilder;
 
 impl SbomReadModelBuilder {
     /// Builds a SbomReadModel from domain objects with optional project metadata component
+    #[allow(clippy::too_many_arguments)]
     pub fn build_with_project(
         packages: Vec<EnrichedPackage>,
         metadata: &SbomMetadata,
@@ -36,6 +38,7 @@ impl SbomReadModelBuilder {
         license_compliance_result: Option<&LicenseComplianceResult>,
         project_component: Option<(&str, &str)>,
         upgrade_recommendations: Option<&[UpgradeRecommendation]>,
+        abandoned_packages_report: Option<&AbandonedPackagesReport>,
     ) -> SbomReadModel {
         let metadata_view = metadata_builder::build_metadata(metadata, project_component);
         let components = component_builder::build_components(&packages, dependency_graph);
@@ -56,6 +59,8 @@ impl SbomReadModelBuilder {
         let upgrade_recommendations = upgrade_recommendations
             .map(upgrade_recommendation_builder::build_upgrade_recommendations);
 
+        let abandoned_packages = abandoned_packages_report.cloned();
+
         SbomReadModel {
             metadata: metadata_view,
             components,
@@ -64,6 +69,7 @@ impl SbomReadModelBuilder {
             license_compliance,
             resolution_guide,
             upgrade_recommendations,
+            abandoned_packages,
         }
     }
 
@@ -200,6 +206,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(read_model.metadata.tool_name, "uv-sbom");
@@ -217,7 +224,7 @@ mod tests {
         let metadata = th::metadata();
 
         let read_model = SbomReadModelBuilder::build_with_project(
-            packages, &metadata, None, None, None, None, None,
+            packages, &metadata, None, None, None, None, None, None,
         );
 
         assert!(read_model.components.is_empty());
@@ -242,6 +249,7 @@ mod tests {
             &metadata,
             None,
             Some(&vuln_result),
+            None,
             None,
             None,
             None,
@@ -288,6 +296,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(read_model.resolution_guide.is_some());
@@ -318,6 +327,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert!(read_model.resolution_guide.is_none());
@@ -333,6 +343,7 @@ mod tests {
             packages,
             &metadata,
             Some(&graph),
+            None,
             None,
             None,
             None,
@@ -364,6 +375,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         // requests is a direct dep, so ResolutionAnalyzer skips it → empty → None
@@ -382,6 +394,7 @@ mod tests {
             None,
             None,
             Some(("my-project", "1.0.0")),
+            None,
             None,
         );
 

--- a/src/application/use_cases/check_abandoned_packages.rs
+++ b/src/application/use_cases/check_abandoned_packages.rs
@@ -1,0 +1,176 @@
+use crate::ports::outbound::{MaintenanceInfo, MaintenanceRepository};
+use crate::sbom_generation::domain::Package;
+use crate::shared::Result;
+use indicatif::{ProgressBar, ProgressStyle};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Delay between maintenance info fetch requests (ms)
+const MAINTENANCE_FETCH_DELAY_MS: u64 = 100;
+
+/// Use case for fetching package maintenance information for a list of packages.
+///
+/// Handles progress bar display and sequential fetching, delegating the actual
+/// retrieval to the injected `MaintenanceRepository`. Errors per package are
+/// collected and surfaced as warnings rather than aborting the whole check.
+///
+/// # Type Parameters
+/// * `MR` - `MaintenanceRepository` implementation
+pub struct CheckAbandonedPackagesUseCase<MR: MaintenanceRepository> {
+    maintenance_repository: MR,
+}
+
+impl<MR: MaintenanceRepository> CheckAbandonedPackagesUseCase<MR> {
+    /// Creates a new `CheckAbandonedPackagesUseCase` with the given repository.
+    pub fn new(maintenance_repository: MR) -> Self {
+        Self {
+            maintenance_repository,
+        }
+    }
+
+    /// Fetches maintenance information for all packages with a progress bar.
+    ///
+    /// Returns `(results, errors)` where:
+    /// - `results` is `(Package, MaintenanceInfo)` pairs for successful fetches
+    /// - `errors` is `(package_name, error_message)` pairs for failed fetches
+    ///
+    /// Failed packages are omitted from `results` (no entry with `None` — callers
+    /// skip packages with unknown release dates anyway).
+    pub async fn fetch_with_progress(
+        &self,
+        packages: Vec<Package>,
+    ) -> Result<(Vec<(Package, MaintenanceInfo)>, Vec<(String, String)>)> {
+        let total = packages.len();
+        let progress_current = Arc::new(AtomicUsize::new(0));
+        let is_done = Arc::new(AtomicBool::new(false));
+
+        let progress_handle = {
+            let cur = progress_current.clone();
+            let done = is_done.clone();
+            thread::spawn(move || {
+                let pb = ProgressBar::new(total as u64);
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template("   {spinner:.green} [{bar:40.cyan/blue}] {pos}/{len} - {msg}")
+                        .expect("Failed to set progress bar template")
+                        .progress_chars("=>-"),
+                );
+                pb.set_message("Fetching maintenance information..."); // i18n-ok: internal progress bar label
+                while !done.load(Ordering::Relaxed) {
+                    pb.set_position(cur.load(Ordering::Relaxed) as u64);
+                    thread::sleep(Duration::from_millis(50));
+                }
+                pb.finish_and_clear();
+            })
+        };
+
+        let mut results: Vec<(Package, MaintenanceInfo)> = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
+
+        for (idx, package) in packages.into_iter().enumerate() {
+            let name = package.name().to_string();
+            match self
+                .maintenance_repository
+                .fetch_maintenance_info(&name)
+                .await
+            {
+                Ok(info) => results.push((package, info)),
+                Err(e) => errors.push((name, e.to_string())),
+            }
+            progress_current.store(idx + 1, Ordering::Relaxed);
+            if idx < total - 1 {
+                tokio::time::sleep(Duration::from_millis(MAINTENANCE_FETCH_DELAY_MS)).await;
+            }
+        }
+
+        is_done.store(true, Ordering::Relaxed);
+        let _ = progress_handle.join();
+
+        Ok((results, errors))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::use_cases::test_doubles::MockMaintenanceRepository;
+    use chrono::NaiveDate;
+
+    fn pkg(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    fn info(date: Option<NaiveDate>) -> MaintenanceInfo {
+        MaintenanceInfo {
+            last_release_date: date,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_success() {
+        let repo = MockMaintenanceRepository::with_responses([Ok(info(Some(
+            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+        )))]);
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let (results, errors) = use_case
+            .fetch_with_progress(vec![pkg("requests", "2.31.0")])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(errors.is_empty());
+        assert_eq!(results[0].0.name(), "requests");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_error_collected() {
+        let repo = MockMaintenanceRepository::with_responses([Err("network error".to_string())]);
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let (results, errors) = use_case
+            .fetch_with_progress(vec![pkg("requests", "2.31.0")])
+            .await
+            .unwrap();
+
+        assert!(results.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, "requests");
+        assert!(errors[0].1.contains("network error"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_empty() {
+        let repo = MockMaintenanceRepository::new();
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let (results, errors) = use_case.fetch_with_progress(vec![]).await.unwrap();
+
+        assert!(results.is_empty());
+        assert!(errors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_progress_mixed_success_and_error() {
+        let repo = MockMaintenanceRepository::with_responses([
+            Ok(info(Some(NaiveDate::from_ymd_opt(2021, 6, 1).unwrap()))),
+            Err("not found".to_string()),
+            Ok(info(None)),
+        ]);
+        let use_case = CheckAbandonedPackagesUseCase::new(repo);
+
+        let packages = vec![
+            pkg("requests", "2.31.0"),
+            pkg("unknown-pkg", "1.0.0"),
+            pkg("certifi", "2024.1.1"),
+        ];
+
+        let (results, errors) = use_case.fetch_with_progress(packages).await.unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, "unknown-pkg");
+    }
+}

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -4,8 +4,6 @@ use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
 use crate::sbom_generation::domain::services::DependencyDiffAnalyzer;
 use crate::shared::Result;
 
-// Wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(dead_code)]
 pub struct GenerateDiffUseCase<LR, DLR>
 where
     LR: LockfileReader,
@@ -15,7 +13,6 @@ where
     diff_reader: DLR,
 }
 
-#[allow(dead_code)]
 impl<LR, DLR> GenerateDiffUseCase<LR, DLR>
 where
     LR: LockfileReader,
@@ -123,7 +120,6 @@ mod tests {
         DiffRequest {
             source: DiffSource::GitRef(ref_name.to_string()),
             project_path: PathBuf::from("/project"),
-            format: crate::application::dto::OutputFormat::Json,
             check_cve: false,
         }
     }
@@ -186,7 +182,6 @@ mod tests {
         let req = DiffRequest {
             source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
             project_path: PathBuf::from("/project"),
-            format: crate::application::dto::OutputFormat::Json,
             check_cve: false,
         };
         let diff = uc.execute(req).unwrap();

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -1,0 +1,209 @@
+use crate::application::dto::DiffRequest;
+use crate::ports::outbound::{DiffLockfileReader, DiffSource, LockfileReader};
+use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
+use crate::sbom_generation::domain::services::DependencyDiffAnalyzer;
+use crate::shared::Result;
+
+// Wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(dead_code)]
+pub struct GenerateDiffUseCase<LR, DLR>
+where
+    LR: LockfileReader,
+    DLR: DiffLockfileReader,
+{
+    lockfile_reader: LR,
+    diff_reader: DLR,
+}
+
+#[allow(dead_code)]
+impl<LR, DLR> GenerateDiffUseCase<LR, DLR>
+where
+    LR: LockfileReader,
+    DLR: DiffLockfileReader,
+{
+    pub fn new(lockfile_reader: LR, diff_reader: DLR) -> Self {
+        Self {
+            lockfile_reader,
+            diff_reader,
+        }
+    }
+
+    /// Execute the diff use case.
+    ///
+    /// Reads the current `uv.lock` via `lockfile_reader`, reads the base packages
+    /// via `diff_reader`, and returns a `DependencyDiff` with `base_ref` set to
+    /// the string representation of the source. Non-UTF-8 path bytes are replaced
+    /// with U+FFFD (display use only — the string is never round-tripped to the FS).
+    ///
+    /// CVE enrichment (`check_cve`) is accepted but currently a no-op; it will be
+    /// wired in a follow-up issue.
+    pub fn execute(&self, request: DiffRequest) -> Result<DependencyDiff> {
+        let (current, _deps) = self
+            .lockfile_reader
+            .read_and_parse_lockfile(&request.project_path)?;
+
+        let base = self
+            .diff_reader
+            .read_base_packages(&request.source, &request.project_path)?;
+
+        let mut diff = DependencyDiffAnalyzer::analyze(&base, &current);
+
+        diff.base_ref = match &request.source {
+            DiffSource::GitRef(r) => r.clone(),
+            DiffSource::FilePath(p) => p.to_string_lossy().into_owned(),
+        };
+
+        // CVE enrichment deferred to a follow-up issue.
+        let _ = request.check_cve;
+
+        Ok(diff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::outbound::lockfile_reader::LockfileParseResult;
+    use crate::sbom_generation::domain::dependency_diff::ChangeType;
+    use crate::sbom_generation::domain::Package;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+
+    fn pkg(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    struct StubLockfileReader {
+        packages: Vec<Package>,
+    }
+
+    impl LockfileReader for StubLockfileReader {
+        fn read_lockfile(&self, _project_path: &Path) -> Result<String> {
+            Ok(String::new())
+        }
+
+        fn read_and_parse_lockfile(&self, _project_path: &Path) -> Result<LockfileParseResult> {
+            Ok((self.packages.clone(), HashMap::new()))
+        }
+
+        fn read_and_parse_lockfile_for_member(
+            &self,
+            _project_path: &Path,
+            _member_name: &str,
+        ) -> Result<LockfileParseResult> {
+            Ok((self.packages.clone(), HashMap::new()))
+        }
+    }
+
+    struct StubDiffLockfileReader {
+        packages: Vec<Package>,
+    }
+
+    impl DiffLockfileReader for StubDiffLockfileReader {
+        fn read_base_packages(
+            &self,
+            _source: &DiffSource,
+            _project_path: &Path,
+        ) -> Result<Vec<Package>> {
+            Ok(self.packages.clone())
+        }
+    }
+
+    fn make_use_case(
+        current: Vec<Package>,
+        base: Vec<Package>,
+    ) -> GenerateDiffUseCase<StubLockfileReader, StubDiffLockfileReader> {
+        GenerateDiffUseCase::new(
+            StubLockfileReader { packages: current },
+            StubDiffLockfileReader { packages: base },
+        )
+    }
+
+    fn git_ref_request(ref_name: &str) -> DiffRequest {
+        DiffRequest {
+            source: DiffSource::GitRef(ref_name.to_string()),
+            project_path: PathBuf::from("/project"),
+            format: crate::application::dto::OutputFormat::Json,
+            check_cve: false,
+        }
+    }
+
+    #[test]
+    fn test_execute_detects_added_package() {
+        let uc = make_use_case(vec![pkg("requests", "2.31.0")], vec![]);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
+        assert_eq!(diff.changes[0].package_name, "requests");
+        assert_eq!(diff.summary.added, 1);
+    }
+
+    #[test]
+    fn test_execute_detects_removed_package() {
+        let uc = make_use_case(vec![], vec![pkg("requests", "2.31.0")]);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Removed);
+        assert_eq!(diff.summary.removed, 1);
+    }
+
+    #[test]
+    fn test_execute_detects_updated_package() {
+        let uc = make_use_case(
+            vec![pkg("urllib3", "2.0.7")],
+            vec![pkg("urllib3", "1.26.5")],
+        );
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
+        assert_eq!(diff.changes[0].old_version, Some("1.26.5".to_string()));
+        assert_eq!(diff.changes[0].new_version, Some("2.0.7".to_string()));
+        assert_eq!(diff.summary.updated, 1);
+    }
+
+    #[test]
+    fn test_execute_mixed_changes() {
+        let base = vec![pkg("a", "1.0"), pkg("b", "1.0"), pkg("c", "1.0")];
+        let current = vec![pkg("a", "1.0"), pkg("b", "2.0"), pkg("d", "1.0")];
+        let uc = make_use_case(current, base);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.summary.added, 1);
+        assert_eq!(diff.summary.updated, 1);
+        assert_eq!(diff.summary.removed, 1);
+        assert_eq!(diff.summary.unchanged, 1);
+    }
+
+    #[test]
+    fn test_execute_base_ref_uses_git_ref_string() {
+        let uc = make_use_case(vec![], vec![]);
+        let diff = uc.execute(git_ref_request("main")).unwrap();
+        assert_eq!(diff.base_ref, "main");
+    }
+
+    #[test]
+    fn test_execute_base_ref_uses_file_path_string() {
+        let uc = make_use_case(vec![], vec![]);
+        let req = DiffRequest {
+            source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
+            project_path: PathBuf::from("/project"),
+            format: crate::application::dto::OutputFormat::Json,
+            check_cve: false,
+        };
+        let diff = uc.execute(req).unwrap();
+        assert_eq!(diff.base_ref, "/tmp/uv.lock");
+    }
+
+    #[test]
+    fn test_execute_check_cve_flag_is_currently_a_noop() {
+        let base = vec![pkg("a", "1.0")];
+        let current = vec![pkg("a", "2.0")];
+        let uc_false = make_use_case(current.clone(), base.clone());
+        let uc_true = make_use_case(current, base);
+        let diff_false = uc_false.execute(git_ref_request("main")).unwrap();
+        let mut req_cve = git_ref_request("main");
+        req_cve.check_cve = true;
+        let diff_true = uc_true.execute(req_cve).unwrap();
+        assert_eq!(diff_false.changes, diff_true.changes);
+        assert_eq!(diff_false.summary, diff_true.summary);
+    }
+}

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -74,6 +74,9 @@ where
     /// # Returns
     /// SbomResponse containing enriched packages, optional dependency graph, and metadata
     pub async fn execute(&self, request: SbomRequest) -> Result<SbomResponse> {
+        // Acknowledge --check-abandoned flag; detection logic ships in a follow-up issue.
+        self.notify_abandoned_check_deferred_if_requested(&request);
+
         // Step 1: Read and parse lockfile
         let (packages, dependency_map) = self.read_and_report_lockfile(&request)?;
 
@@ -129,6 +132,23 @@ where
             license_compliance_result,
             upgrade_recommendations,
         ))
+    }
+
+    /// Emits a localised notice when `check_abandoned` is enabled.
+    /// Detection logic ships in a follow-up issue; this method is the current consumer of
+    /// `request.check_abandoned` and `request.abandoned_threshold_days`.
+    fn notify_abandoned_check_deferred_if_requested(&self, request: &SbomRequest) {
+        if !request.check_abandoned {
+            return;
+        }
+        let msgs = Messages::for_locale(self.locale);
+        eprintln!(
+            "{}",
+            Messages::format(
+                msgs.info_check_abandoned_deferred,
+                &[&request.abandoned_threshold_days.to_string()]
+            )
+        );
     }
 
     /// Reads and parses the lockfile, reporting progress

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -22,6 +22,7 @@ use crate::sbom_generation::domain::{
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
 use chrono::Utc;
+use std::cmp::Reverse;
 use std::collections::HashSet;
 
 /// Type alias for package list with dependency map
@@ -212,7 +213,7 @@ where
             })
             .collect();
 
-        abandoned_packages.sort_by(|a, b| b.days_inactive.cmp(&a.days_inactive));
+        abandoned_packages.sort_by_key(|p| Reverse(p.days_inactive));
 
         let report = AbandonedPackagesReport {
             packages: abandoned_packages,

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -1,19 +1,28 @@
 use crate::adapters::outbound::uv::UvLockAdapter;
 use crate::application::dto::{SbomRequest, SbomResponse};
-use crate::application::use_cases::{CheckVulnerabilitiesUseCase, FetchLicensesUseCase};
+use crate::application::read_models::abandoned_package::{
+    AbandonedPackageView, AbandonedPackagesReport,
+};
+use crate::application::use_cases::{
+    CheckAbandonedPackagesUseCase, CheckVulnerabilitiesUseCase, FetchLicensesUseCase,
+};
 use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::{
-    EnrichedPackage, LicenseRepository, LockfileReader, ProgressReporter, ProjectConfigReader,
-    VulnerabilityRepository,
+    EnrichedPackage, LicenseRepository, LockfileReader, MaintenanceRepository, ProgressReporter,
+    ProjectConfigReader, VulnerabilityRepository,
 };
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::{
     LicenseComplianceChecker, ResolutionAnalyzer, ThresholdConfig, UpgradeAdvisor,
     VulnerabilityCheckResult, VulnerabilityChecker,
 };
-use crate::sbom_generation::domain::{Package, PackageName, UpgradeRecommendation};
+use crate::sbom_generation::domain::{
+    DependencyGraph, Package, PackageName, UpgradeRecommendation,
+};
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
+use chrono::Utc;
+use std::collections::HashSet;
 
 /// Type alias for package list with dependency map
 /// Used to simplify complex return types and satisfy clippy::type_complexity
@@ -30,22 +39,25 @@ type PackagesWithDependencyMap = (Vec<Package>, std::collections::HashMap<String
 /// * `LREPO` - LicenseRepository implementation
 /// * `PR` - ProgressReporter implementation
 /// * `VREPO` - VulnerabilityRepository implementation (optional)
-pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO> {
+/// * `MREPO` - MaintenanceRepository implementation (optional)
+pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO> {
     lockfile_reader: LR,
     project_config_reader: PCR,
     license_repository: LREPO,
     progress_reporter: PR,
     vulnerability_repository: Option<VREPO>,
+    maintenance_repository: Option<MREPO>,
     locale: Locale,
 }
 
-impl<LR, PCR, LREPO, PR, VREPO> GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO>
+impl<LR, PCR, LREPO, PR, VREPO, MREPO> GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO>
 where
     LR: LockfileReader,
     PCR: ProjectConfigReader,
     LREPO: LicenseRepository + Clone,
     PR: ProgressReporter,
     VREPO: VulnerabilityRepository + Clone,
+    MREPO: MaintenanceRepository + Clone,
 {
     /// Creates a new GenerateSbomUseCase with injected dependencies
     pub fn new(
@@ -54,6 +66,7 @@ where
         license_repository: LREPO,
         progress_reporter: PR,
         vulnerability_repository: Option<VREPO>,
+        maintenance_repository: Option<MREPO>,
         locale: Locale,
     ) -> Self {
         Self {
@@ -62,6 +75,7 @@ where
             license_repository,
             progress_reporter,
             vulnerability_repository,
+            maintenance_repository,
             locale,
         }
     }
@@ -74,9 +88,6 @@ where
     /// # Returns
     /// SbomResponse containing enriched packages, optional dependency graph, and metadata
     pub async fn execute(&self, request: SbomRequest) -> Result<SbomResponse> {
-        // Acknowledge --check-abandoned flag; detection logic ships in a follow-up issue.
-        self.notify_abandoned_check_deferred_if_requested(&request);
-
         // Step 1: Read and parse lockfile
         let (packages, dependency_map) = self.read_and_report_lockfile(&request)?;
 
@@ -124,31 +135,108 @@ where
             )
             .await;
 
-        // Step 9: Build and return response
+        // Step 9: Abandoned package check if requested
+        let abandoned_packages_report = self
+            .check_abandoned_if_requested(&request, &filtered_packages, dependency_graph.as_ref())
+            .await?;
+
+        // Step 10: Build and return response
         Ok(self.build_response(
             enriched_packages,
             dependency_graph,
             vulnerability_check_result,
             license_compliance_result,
             upgrade_recommendations,
+            abandoned_packages_report,
         ))
     }
 
-    /// Emits a localised notice when `check_abandoned` is enabled.
-    /// Detection logic ships in a follow-up issue; this method is the current consumer of
-    /// `request.check_abandoned` and `request.abandoned_threshold_days`.
-    fn notify_abandoned_check_deferred_if_requested(&self, request: &SbomRequest) {
+    /// Checks for abandoned packages if `check_abandoned` is enabled.
+    ///
+    /// Returns `None` when the check is disabled or no maintenance repository is configured.
+    /// When `dependency_graph` is `None` (e.g. JSON output without dep analysis),
+    /// `is_direct` defaults to `false` for all packages — consistent with the existing
+    /// pattern for the resolution guide.
+    async fn check_abandoned_if_requested(
+        &self,
+        request: &SbomRequest,
+        packages: &[Package],
+        dependency_graph: Option<&DependencyGraph>,
+    ) -> Result<Option<AbandonedPackagesReport>> {
         if !request.check_abandoned {
-            return;
+            return Ok(None);
         }
+        let Some(repo) = &self.maintenance_repository else {
+            return Ok(None);
+        };
+
         let msgs = Messages::for_locale(self.locale);
-        eprintln!(
-            "{}",
-            Messages::format(
-                msgs.info_check_abandoned_deferred,
-                &[&request.abandoned_threshold_days.to_string()]
-            )
-        );
+        self.progress_reporter
+            .report(msgs.progress_fetching_abandoned);
+
+        let maint_use_case = CheckAbandonedPackagesUseCase::new(repo.clone());
+        let (results, errors) = maint_use_case
+            .fetch_with_progress(packages.to_vec())
+            .await?;
+
+        eprintln!(); // newline after progress bar
+
+        for (pkg_name, error_msg) in &errors {
+            self.progress_reporter.report_error(&Messages::format(
+                msgs.warn_abandoned_fetch_failed,
+                &[pkg_name, error_msg],
+            ));
+        }
+
+        let today = Utc::now().date_naive();
+        let direct_names: HashSet<&str> = dependency_graph
+            .map(|g| g.direct_dependencies().iter().map(|p| p.as_str()).collect())
+            .unwrap_or_default();
+
+        let threshold = request.abandoned_threshold_days as i64;
+        let mut abandoned_packages: Vec<AbandonedPackageView> = results
+            .into_iter()
+            .filter_map(|(pkg, info)| {
+                let release_date = info.last_release_date?;
+                let days_inactive = (today - release_date).num_days();
+                if days_inactive < threshold {
+                    return None;
+                }
+                Some(AbandonedPackageView {
+                    name: pkg.name().to_string(),
+                    version: pkg.version().to_string(),
+                    last_release_date: release_date,
+                    days_inactive,
+                    is_direct: direct_names.contains(pkg.name()),
+                })
+            })
+            .collect();
+
+        abandoned_packages.sort_by(|a, b| b.days_inactive.cmp(&a.days_inactive));
+
+        let report = AbandonedPackagesReport {
+            packages: abandoned_packages,
+            threshold_days: request.abandoned_threshold_days,
+        };
+
+        if report.is_empty() {
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_abandoned_none,
+                &[&report.threshold_days.to_string()],
+            ));
+        } else {
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_abandoned_found,
+                &[
+                    &report.total_count().to_string(),
+                    &report.direct_count().to_string(),
+                    &report.transitive_count().to_string(),
+                    &report.threshold_days.to_string(),
+                ],
+            ));
+        }
+
+        Ok(Some(report))
     }
 
     /// Reads and parses the lockfile, reporting progress
@@ -533,10 +621,11 @@ where
     fn build_response(
         &self,
         enriched_packages: Vec<EnrichedPackage>,
-        dependency_graph: Option<crate::sbom_generation::domain::DependencyGraph>,
+        dependency_graph: Option<DependencyGraph>,
         vulnerability_check_result: Option<VulnerabilityCheckResult>,
         license_compliance_result: Option<LicenseComplianceResult>,
         upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
+        abandoned_packages_report: Option<AbandonedPackagesReport>,
     ) -> SbomResponse {
         let metadata = SbomGenerator::generate_default_metadata();
 
@@ -568,6 +657,9 @@ where
         }
         if let Some(recommendations) = upgrade_recommendations {
             builder = builder.upgrade_recommendations(recommendations);
+        }
+        if let Some(report) = abandoned_packages_report {
+            builder = builder.abandoned_packages_report(report);
         }
 
         builder.build().expect("response build should not fail")

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -198,6 +198,9 @@ where
         let mut abandoned_packages: Vec<AbandonedPackageView> = results
             .into_iter()
             .filter_map(|(pkg, info)| {
+                // Packages with no recorded release date are excluded: their
+                // maintenance status cannot be determined, so we do not classify
+                // them as abandoned.
                 let release_date = info.last_release_date?;
                 let days_inactive = (today - release_date).num_days();
                 if days_inactive < threshold {

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::application::use_cases::test_doubles::MockVulnerabilityRepository;
+use crate::application::use_cases::test_doubles::{
+    MockMaintenanceRepository, MockVulnerabilityRepository,
+};
 use crate::ports::outbound::{LockfileParseResult, PyPiMetadata};
 use crate::sbom_generation::domain::Package;
 use std::collections::HashMap;
@@ -76,6 +78,7 @@ mod test_helpers {
         MockLicenseRepository,
         MockProgressReporter,
         MockVulnerabilityRepository,
+        MockMaintenanceRepository,
     >;
 
     pub(super) struct UseCaseBuilder {
@@ -83,6 +86,7 @@ mod test_helpers {
         deps: HashMap<String, Vec<String>>,
         project_name: String,
         vuln: Option<MockVulnerabilityRepository>,
+        maint: Option<MockMaintenanceRepository>,
     }
 
     impl Default for UseCaseBuilder {
@@ -92,6 +96,7 @@ mod test_helpers {
                 deps: HashMap::new(),
                 project_name: "test-project".to_string(),
                 vuln: None,
+                maint: None,
             }
         }
     }
@@ -122,6 +127,11 @@ mod test_helpers {
             self
         }
 
+        pub(super) fn with_maintenance_repo(mut self, repo: MockMaintenanceRepository) -> Self {
+            self.maint = Some(repo);
+            self
+        }
+
         pub(super) fn build(self) -> TestUseCase {
             GenerateSbomUseCase::new(
                 MockLockfileReader {
@@ -134,6 +144,7 @@ mod test_helpers {
                 MockLicenseRepository,
                 MockProgressReporter,
                 self.vuln,
+                self.maint,
                 Locale::default(),
             )
         }
@@ -388,7 +399,7 @@ mod tests_response {
             Some("Test description".to_string()),
         )];
 
-        let response = use_case.build_response(enriched_packages, None, None, None, None);
+        let response = use_case.build_response(enriched_packages, None, None, None, None, None);
 
         assert_eq!(response.enriched_packages.len(), 1);
         assert!(response.dependency_graph.is_none());
@@ -426,8 +437,14 @@ mod tests_response {
             threshold_exceeded: true,
         };
 
-        let response =
-            use_case.build_response(enriched_packages, None, Some(check_result), None, None);
+        let response = use_case.build_response(
+            enriched_packages,
+            None,
+            Some(check_result),
+            None,
+            None,
+            None,
+        );
 
         assert!(response.has_vulnerabilities_above_threshold);
         assert!(
@@ -467,8 +484,14 @@ mod tests_response {
             threshold_exceeded: false,
         };
 
-        let response =
-            use_case.build_response(enriched_packages, None, Some(check_result), None, None);
+        let response = use_case.build_response(
+            enriched_packages,
+            None,
+            Some(check_result),
+            None,
+            None,
+            None,
+        );
 
         assert!(!response.has_vulnerabilities_above_threshold);
         assert!(
@@ -568,6 +591,173 @@ mod tests_vulnerabilities {
         let config = TestUseCase::build_threshold_config(&request);
 
         assert_eq!(config, ThresholdConfig::Cvss(7.0));
+    }
+}
+
+mod tests_abandoned {
+    use super::test_helpers::*;
+    use super::*;
+    use crate::application::use_cases::test_doubles::MockMaintenanceRepository;
+    use crate::ports::outbound::MaintenanceInfo;
+    use chrono::NaiveDate;
+
+    #[tokio::test]
+    async fn test_check_abandoned_disabled_returns_none() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+
+        let result = use_case
+            .check_abandoned_if_requested(&default_request(), &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_no_repo_returns_none() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_with_old_package_returns_report() {
+        let old_date = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
+        let maint_repo = MockMaintenanceRepository::with_responses([Ok(MaintenanceInfo {
+            last_release_date: Some(old_date),
+        })]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        let report = result.unwrap();
+        assert_eq!(report.total_count(), 1);
+        assert_eq!(report.packages[0].name, "requests");
+        assert!(report.packages[0].days_inactive >= 365);
+        assert_eq!(report.threshold_days, 365);
+        assert_eq!(report.direct_count(), 0); // no graph supplied → all non-direct
+        assert_eq!(report.transitive_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_recent_package_produces_empty_report() {
+        use chrono::Utc;
+        let recent_date = Utc::now().date_naive();
+        let maint_repo = MockMaintenanceRepository::with_responses([Ok(MaintenanceInfo {
+            last_release_date: Some(recent_date),
+        })]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_unknown_release_date_excluded() {
+        let maint_repo = MockMaintenanceRepository::with_responses([Ok(MaintenanceInfo {
+            last_release_date: None,
+        })]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("old-pkg", "1.0.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("old-pkg", "1.0.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(1)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        // Package with unknown release date is excluded from the report
+        assert!(result.is_some());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_abandoned_sorted_by_days_inactive_descending() {
+        let older_date = NaiveDate::from_ymd_opt(2018, 1, 1).unwrap();
+        let newer_date = NaiveDate::from_ymd_opt(2021, 1, 1).unwrap();
+        let maint_repo = MockMaintenanceRepository::with_responses([
+            Ok(MaintenanceInfo {
+                last_release_date: Some(newer_date),
+            }),
+            Ok(MaintenanceInfo {
+                last_release_date: Some(older_date),
+            }),
+        ]);
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("newer-pkg", "1.0.0"), pkg("older-pkg", "1.0.0")])
+            .with_maintenance_repo(maint_repo)
+            .build();
+        let packages = [pkg("newer-pkg", "1.0.0"), pkg("older-pkg", "1.0.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_abandoned_if_requested(&request, &packages, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_some());
+        let report = result.unwrap();
+        assert_eq!(report.total_count(), 2);
+        // Sorted descending: older-pkg (more days inactive) should be first
+        assert!(report.packages[0].days_inactive >= report.packages[1].days_inactive);
     }
 }
 

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -702,4 +702,24 @@ mod tests_regression {
         let graph = response.dependency_graph.unwrap();
         assert_eq!(graph.direct_dependency_count(), 2);
     }
+
+    #[tokio::test]
+    async fn test_execute_with_check_abandoned_enabled_completes_successfully() {
+        // Exercises the check_abandoned=true path through execute().
+        // Detection is deferred; the use case must complete without error and
+        // consume both check_abandoned and abandoned_threshold_days.
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("certifi", "2024.8.30")])
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_abandoned(true)
+            .abandoned_threshold_days(365)
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+        assert_eq!(response.enriched_packages.len(), 1);
+    }
 }

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -1,4 +1,5 @@
 /// Use cases module containing application business logic orchestration
+mod check_abandoned_packages;
 mod check_vulnerabilities;
 mod fetch_licenses;
 mod generate_sbom;
@@ -6,7 +7,7 @@ mod generate_sbom;
 #[cfg(test)]
 pub(crate) mod test_doubles;
 
-#[allow(unused_imports)]
+pub use check_abandoned_packages::CheckAbandonedPackagesUseCase;
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
 pub use fetch_licenses::FetchLicensesUseCase;
 pub use generate_sbom::GenerateSbomUseCase;

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -11,7 +11,5 @@ pub(crate) mod test_doubles;
 pub use check_abandoned_packages::CheckAbandonedPackagesUseCase;
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
 pub use fetch_licenses::FetchLicensesUseCase;
-// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(unused_imports)]
 pub use generate_diff::GenerateDiffUseCase;
 pub use generate_sbom::GenerateSbomUseCase;

--- a/src/application/use_cases/mod.rs
+++ b/src/application/use_cases/mod.rs
@@ -2,6 +2,7 @@
 mod check_abandoned_packages;
 mod check_vulnerabilities;
 mod fetch_licenses;
+mod generate_diff;
 mod generate_sbom;
 
 #[cfg(test)]
@@ -10,4 +11,7 @@ pub(crate) mod test_doubles;
 pub use check_abandoned_packages::CheckAbandonedPackagesUseCase;
 pub use check_vulnerabilities::CheckVulnerabilitiesUseCase;
 pub use fetch_licenses::FetchLicensesUseCase;
+// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
+#[allow(unused_imports)]
+pub use generate_diff::GenerateDiffUseCase;
 pub use generate_sbom::GenerateSbomUseCase;

--- a/src/application/use_cases/test_doubles.rs
+++ b/src/application/use_cases/test_doubles.rs
@@ -1,7 +1,61 @@
-use crate::ports::outbound::{ProgressCallback, VulnerabilityRepository};
+use crate::ports::outbound::{
+    MaintenanceInfo, MaintenanceRepository, ProgressCallback, VulnerabilityRepository,
+};
 use crate::sbom_generation::domain::{Package, PackageVulnerabilities};
 use crate::shared::Result;
 use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+/// Configurable in-memory mock implementing `MaintenanceRepository`.
+///
+/// Each call to `fetch_maintenance_info` pops the next response from the queue.
+/// When the queue is exhausted, returns `Ok(MaintenanceInfo { last_release_date: None })`.
+///
+/// `Clone` clones the `Arc`, so both copies share the same queue — consistent with
+/// how the production code clones the repository into sub-use-cases.
+#[derive(Clone)]
+pub(crate) struct MockMaintenanceRepository {
+    queue: Arc<Mutex<VecDeque<std::result::Result<MaintenanceInfo, String>>>>,
+}
+
+impl MockMaintenanceRepository {
+    /// Creates an empty mock (all calls return `last_release_date: None`).
+    pub fn new() -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    /// Creates a mock with pre-loaded ordered responses.
+    pub fn with_responses(
+        responses: impl IntoIterator<Item = std::result::Result<MaintenanceInfo, String>>,
+    ) -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(responses.into_iter().collect())),
+        }
+    }
+}
+
+impl Default for MockMaintenanceRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MaintenanceRepository for MockMaintenanceRepository {
+    async fn fetch_maintenance_info(&self, _package_name: &str) -> Result<MaintenanceInfo> {
+        let next = self.queue.lock().unwrap().pop_front();
+        match next {
+            Some(Ok(info)) => Ok(info),
+            Some(Err(msg)) => Err(anyhow::anyhow!("{}", msg)),
+            None => Ok(MaintenanceInfo {
+                last_release_date: None,
+            }),
+        }
+    }
+}
 
 /// Configurable in-memory mock implementing `VulnerabilityRepository`.
 ///

--- a/src/cli/config_resolver.rs
+++ b/src/cli/config_resolver.rs
@@ -18,6 +18,8 @@ pub struct MergedConfig {
     pub check_license: bool,
     pub license_policy: Option<LicensePolicy>,
     pub suggest_fix: bool,
+    pub check_abandoned: bool,
+    pub abandoned_threshold_days: u64,
 }
 
 /// Load a config file from an explicit path or via auto-discovery.
@@ -129,6 +131,8 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
                 check_license: args.check_license,
                 license_policy,
                 suggest_fix: args.suggest_fix,
+                check_abandoned: args.check_abandoned,
+                abandoned_threshold_days: args.abandoned_threshold_days.unwrap_or(730),
             };
         }
     };
@@ -233,6 +237,17 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
     // suggest_fix: CLI flag takes priority over config value
     let suggest_fix = args.suggest_fix || config.suggest_fix.unwrap_or(false);
 
+    // check_abandoned: CLI flag || config value (mirrors check_license / suggest_fix)
+    let check_abandoned = args.check_abandoned || config.check_abandoned.unwrap_or(false);
+
+    // abandoned_threshold_days: CLI > config > default 730.
+    // args.abandoned_threshold_days is Option<u64>: None when the flag was not passed, Some when
+    // the user explicitly provided a value. This cleanly expresses "not provided" vs "provided."
+    let abandoned_threshold_days = args
+        .abandoned_threshold_days
+        .or(config.abandoned_threshold_days)
+        .unwrap_or(730);
+
     MergedConfig {
         format,
         exclude_patterns,
@@ -243,6 +258,8 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
         check_license,
         license_policy,
         suggest_fix,
+        check_abandoned,
+        abandoned_threshold_days,
     }
 }
 
@@ -263,6 +280,8 @@ mod tests {
         assert!(result.severity_threshold.is_none());
         assert!(result.cvss_threshold.is_none());
         assert!(result.ignore_cves.is_empty());
+        assert!(!result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
     }
 
     #[test]
@@ -288,6 +307,8 @@ mod tests {
         assert_eq!(result.cvss_threshold, Some(7.0));
         assert_eq!(result.ignore_cves.len(), 1);
         assert_eq!(result.ignore_cves[0].id, "CVE-2024-1");
+        assert!(!result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
     }
 
     #[test]
@@ -543,5 +564,109 @@ mod tests {
         assert_eq!(result[0].id, "CVE-2024-1");
         assert_eq!(result[0].reason.as_deref(), Some("cli reason"));
         assert_eq!(result[1].id, "CVE-2024-2");
+    }
+
+    // --- check_abandoned / abandoned_threshold_days merge tests ---
+
+    #[test]
+    fn test_merge_config_check_abandoned_default_false() {
+        // No CLI flag, no config → defaults: check_abandoned=false, threshold=730
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(!result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
+    }
+
+    #[test]
+    fn test_merge_config_check_abandoned_from_config() {
+        // config: true, no CLI flag → check_abandoned=true
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            check_abandoned: Some(true),
+            abandoned_threshold_days: Some(365),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 365);
+    }
+
+    #[test]
+    fn test_merge_config_check_abandoned_cli_flag() {
+        // CLI: --check-abandoned, no config → check_abandoned=true, threshold=730 (default)
+        let args = Args::parse_from(["uv-sbom", "--check-abandoned"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 730);
+    }
+
+    #[test]
+    fn test_merge_config_check_abandoned_cli_wins_over_config_false() {
+        // CLI flag + config: false → CLI wins, check_abandoned=true
+        let args = Args::parse_from(["uv-sbom", "--check-abandoned"]);
+        let config = Some(ConfigFile {
+            check_abandoned: Some(false),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.check_abandoned);
+    }
+
+    #[test]
+    fn test_merge_config_abandoned_threshold_from_config() {
+        // config: 365, no explicit CLI → uses config value
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            abandoned_threshold_days: Some(365),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.abandoned_threshold_days, 365);
+    }
+
+    #[test]
+    fn test_merge_config_abandoned_threshold_cli_wins() {
+        // CLI: --abandoned-threshold-days 90 + config: 365 → CLI wins (Some(90) overrides config)
+        let args = Args::parse_from([
+            "uv-sbom",
+            "--check-abandoned",
+            "--abandoned-threshold-days",
+            "90",
+        ]);
+        let config = Some(ConfigFile {
+            check_abandoned: Some(true),
+            abandoned_threshold_days: Some(365),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.abandoned_threshold_days, 90);
+    }
+
+    #[test]
+    fn test_merge_config_abandoned_threshold_default_when_neither() {
+        // No CLI, no config → default 730
+        let args = Args::parse_from(["uv-sbom"]);
+        let result = merge_config(&args, &None);
+        assert_eq!(result.abandoned_threshold_days, 730);
+    }
+
+    #[test]
+    fn test_merge_config_no_config_file_uses_cli_abandoned() {
+        // No config file; exercises the early-return branch
+        let args = Args::parse_from([
+            "uv-sbom",
+            "--check-abandoned",
+            "--abandoned-threshold-days",
+            "180",
+        ]);
+        let result = merge_config(&args, &None);
+        assert!(result.check_abandoned);
+        assert_eq!(result.abandoned_threshold_days, 180);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,6 +72,14 @@ pub struct Args {
     #[arg(long)]
     pub check_license: bool,
 
+    /// Check for abandoned/unmaintained packages (no upstream release within threshold days)
+    #[arg(long)]
+    pub check_abandoned: bool,
+
+    /// Inactivity threshold in days for abandoned-package detection (default: 730)
+    #[arg(long, value_name = "DAYS", requires = "check_abandoned")]
+    pub abandoned_threshold_days: Option<u64>,
+
     /// Allowed license patterns (comma-separated, requires --check-license)
     /// Supports wildcards: "MIT,Apache-2.0,BSD-*"
     #[arg(long, value_delimiter = ',', requires = "check_license")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -98,6 +98,10 @@ pub struct Args {
     #[arg(long, conflicts_with = "output")]
     pub workspace: bool,
 
+    /// Compare current uv.lock against a base (git ref, tag, commit SHA, or path to a uv.lock file)
+    #[arg(long, value_name = "REF_OR_PATH", conflicts_with_all = ["workspace", "init"])]
+    pub diff: Option<String>,
+
     /// Output language for human-readable formats: en (default) or ja
     #[arg(long, default_value = "en", value_parser = parse_lang)]
     pub lang: Locale,

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,12 @@ const CONFIG_TEMPLATE: &str = r#"# uv-sbom configuration file
 
 # Enable workspace mode: generate per-member SBOMs for uv workspaces (equivalent to --workspace flag)
 # workspace: false
+
+# Enable abandoned/unmaintained package detection
+# check_abandoned: false
+
+# Inactivity threshold in days for abandoned-package detection (default: 730)
+# abandoned_threshold_days: 730
 "#;
 
 /// Generate a config template file in the specified directory.
@@ -101,6 +107,8 @@ pub struct ConfigFile {
     pub check_license: Option<bool>,
     pub license_policy: Option<LicensePolicyConfig>,
     pub suggest_fix: Option<bool>,
+    pub check_abandoned: Option<bool>,
+    pub abandoned_threshold_days: Option<u64>,
     /// Captures unknown fields for warnings.
     #[serde(flatten)]
     pub unknown_fields: HashMap<String, serde_yaml_ng::Value>,
@@ -365,6 +373,8 @@ another_unknown: value
         assert!(config.severity_threshold.is_none());
         assert!(config.cvss_threshold.is_none());
         assert!(config.ignore_cves.is_none());
+        assert!(config.check_abandoned.is_none());
+        assert!(config.abandoned_threshold_days.is_none());
         assert!(config.unknown_fields.is_empty());
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -170,6 +170,16 @@ pub struct Messages {
     pub overall_action_required: &'static str,
     pub overall_attention_recommended: &'static str,
     pub overall_no_issues: &'static str,
+
+    // Abandoned packages section
+    pub section_abandoned_packages: &'static str,
+    pub desc_abandoned_packages: &'static str,
+    pub label_abandoned_packages: &'static str,
+    pub label_abandoned_check_skipped: &'static str,
+    pub label_no_abandoned_packages: &'static str,
+    pub col_last_release: &'static str,
+    pub col_days_inactive: &'static str,
+    pub col_type: &'static str,
 }
 
 impl Messages {
@@ -343,6 +353,16 @@ static EN_MESSAGES: Messages = Messages {
     overall_action_required: "**Overall: Action required**",
     overall_attention_recommended: "**Overall: Attention recommended**",
     overall_no_issues: "**Overall: No issues found** ✅",
+
+    // Abandoned packages section
+    section_abandoned_packages: "## Abandoned Packages",
+    desc_abandoned_packages: "Packages whose most recent upstream release exceeds the configured inactivity threshold. Inactive projects may carry unpatched vulnerabilities and pose long-term maintenance risk.",
+    label_abandoned_packages: "Abandoned packages",
+    label_abandoned_check_skipped: "_Abandoned package check skipped._",
+    label_no_abandoned_packages: "No abandoned packages detected.",
+    col_last_release: "Last Release",
+    col_days_inactive: "Days Inactive",
+    col_type: "Type",
 };
 
 static JA_MESSAGES: Messages = Messages {
@@ -487,6 +507,16 @@ static JA_MESSAGES: Messages = Messages {
     overall_action_required: "**総合判定: 対応が必要です**",
     overall_attention_recommended: "**総合判定: 注意が必要です**",
     overall_no_issues: "**総合判定: 問題なし** ✅",
+
+    // Abandoned packages section
+    section_abandoned_packages: "## 廃止パッケージ",
+    desc_abandoned_packages: "設定された非アクティブ閾値を超えて更新されていないパッケージです。メンテナンスが停止しているプロジェクトは未修正の脆弱性を含む可能性があり、長期的な保守リスクとなります。",
+    label_abandoned_packages: "廃止パッケージ",
+    label_abandoned_check_skipped: "_廃止パッケージチェックはスキップされました。_",
+    label_no_abandoned_packages: "廃止パッケージは検出されませんでした。",
+    col_last_release: "最終リリース",
+    col_days_inactive: "非アクティブ日数",
+    col_type: "種別",
 };
 
 #[cfg(test)]
@@ -926,5 +956,41 @@ mod tests {
             result,
             "### ⚠️警告 2件の脆弱性が1個のパッケージで見つかりました。"
         );
+    }
+
+    #[test]
+    fn test_messages_abandoned_section_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(msgs.section_abandoned_packages, "## Abandoned Packages");
+        assert_eq!(msgs.label_abandoned_packages, "Abandoned packages");
+        assert_eq!(
+            msgs.label_abandoned_check_skipped,
+            "_Abandoned package check skipped._"
+        );
+        assert_eq!(
+            msgs.label_no_abandoned_packages,
+            "No abandoned packages detected."
+        );
+        assert_eq!(msgs.col_last_release, "Last Release");
+        assert_eq!(msgs.col_days_inactive, "Days Inactive");
+        assert_eq!(msgs.col_type, "Type");
+    }
+
+    #[test]
+    fn test_messages_abandoned_section_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(msgs.section_abandoned_packages, "## 廃止パッケージ");
+        assert_eq!(msgs.label_abandoned_packages, "廃止パッケージ");
+        assert_eq!(
+            msgs.label_abandoned_check_skipped,
+            "_廃止パッケージチェックはスキップされました。_"
+        );
+        assert_eq!(
+            msgs.label_no_abandoned_packages,
+            "廃止パッケージは検出されませんでした。"
+        );
+        assert_eq!(msgs.col_last_release, "最終リリース");
+        assert_eq!(msgs.col_days_inactive, "非アクティブ日数");
+        assert_eq!(msgs.col_type, "種別");
     }
 }

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -89,6 +89,7 @@ pub struct Messages {
     pub warn_check_cve_no_effect: &'static str,
     pub warn_check_license_no_effect: &'static str,
     pub warn_verify_links_no_effect: &'static str,
+    pub info_check_abandoned_deferred: &'static str,
 
     // Section description paragraphs
     pub desc_sbom_report: &'static str,
@@ -259,6 +260,7 @@ static EN_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  Warning: --check-cve has no effect with JSON format.",
     warn_check_license_no_effect: "⚠️  Warning: --check-license has no effect with JSON format.",
     warn_verify_links_no_effect: "⚠️  Warning: --verify-links has no effect with JSON format.",
+    info_check_abandoned_deferred: "ℹ️  --check-abandoned acknowledged (threshold: {} days). Detection arrives in a future release.",
 
     // Section description paragraphs
     desc_sbom_report: "A comprehensive list of all software components and libraries included in this project.",
@@ -397,6 +399,7 @@ static JA_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  警告: JSON形式では --check-cve は効果がありません。",
     warn_check_license_no_effect: "⚠️  警告: JSON形式では --check-license は効果がありません。",
     warn_verify_links_no_effect: "⚠️  警告: JSON形式では --verify-links は効果がありません。",
+    info_check_abandoned_deferred: "ℹ️  --check-abandoned を確認しました（閾値: {} 日）。検出機能は今後のリリースで追加されます。",
 
     // Section description paragraphs
     desc_sbom_report: "このプロジェクトに含まれるすべてのソフトウェアコンポーネントとライブラリの一覧です。",

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -89,7 +89,10 @@ pub struct Messages {
     pub warn_check_cve_no_effect: &'static str,
     pub warn_check_license_no_effect: &'static str,
     pub warn_verify_links_no_effect: &'static str,
-    pub info_check_abandoned_deferred: &'static str,
+    pub warn_abandoned_fetch_failed: &'static str,
+    pub progress_fetching_abandoned: &'static str,
+    pub progress_abandoned_found: &'static str,
+    pub progress_abandoned_none: &'static str,
 
     // Section description paragraphs
     pub desc_sbom_report: &'static str,
@@ -260,7 +263,10 @@ static EN_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  Warning: --check-cve has no effect with JSON format.",
     warn_check_license_no_effect: "⚠️  Warning: --check-license has no effect with JSON format.",
     warn_verify_links_no_effect: "⚠️  Warning: --verify-links has no effect with JSON format.",
-    info_check_abandoned_deferred: "ℹ️  --check-abandoned acknowledged (threshold: {} days). Detection arrives in a future release.",
+    warn_abandoned_fetch_failed: "⚠️  Warning: Failed to fetch maintenance info for {}: {}",
+    progress_fetching_abandoned: "🔍 Fetching package maintenance information...",
+    progress_abandoned_found: "✅ Abandoned check complete: {} package(s) abandoned ({} direct, {} transitive), threshold: {} days",
+    progress_abandoned_none: "✅ Abandoned check complete: No packages exceed {} day threshold",
 
     // Section description paragraphs
     desc_sbom_report: "A comprehensive list of all software components and libraries included in this project.",
@@ -399,7 +405,10 @@ static JA_MESSAGES: Messages = Messages {
     warn_check_cve_no_effect: "⚠️  警告: JSON形式では --check-cve は効果がありません。",
     warn_check_license_no_effect: "⚠️  警告: JSON形式では --check-license は効果がありません。",
     warn_verify_links_no_effect: "⚠️  警告: JSON形式では --verify-links は効果がありません。",
-    info_check_abandoned_deferred: "ℹ️  --check-abandoned を確認しました（閾値: {} 日）。検出機能は今後のリリースで追加されます。",
+    warn_abandoned_fetch_failed: "⚠️  警告: {}のメンテナンス情報の取得に失敗: {}",
+    progress_fetching_abandoned: "🔍 パッケージのメンテナンス情報を取得中...",
+    progress_abandoned_found: "✅ 廃止パッケージチェック完了: {}件廃止（直接: {}件、間接: {}件）、閾値: {}日",
+    progress_abandoned_none: "✅ 廃止パッケージチェック完了: {}日以上更新のないパッケージはありません",
 
     // Section description paragraphs
     desc_sbom_report: "このプロジェクトに含まれるすべてのソフトウェアコンポーネントとライブラリの一覧です。",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,13 @@
 //! let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::default());
 //!
 //! // Create use case
-//! let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+//! let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
 //!     lockfile_reader,
 //!     project_config_reader,
 //!     license_repository,
 //!     progress_reporter,
 //!     None, // No vulnerability checking in this example
+//!     None, // No abandoned-package checking in this example
 //!     uv_sbom::i18n::Locale::default(),
 //! );
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 //!     None,
 //!     None,
 //!     None,
+//!     None, // No abandoned-package report in this example
 //! );
 //! let formatter = CycloneDxFormatter::new();
 //! let output = formatter.format(&read_model)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,8 @@ async fn run(args: Args) -> Result<bool> {
         .check_license(merged.check_license)
         .license_policy(merged.license_policy)
         .suggest_fix(suggest_fix)
+        .check_abandoned(merged.check_abandoned)
+        .abandoned_threshold_days(merged.abandoned_threshold_days)
         .locale(locale)
         .build()?;
 
@@ -403,6 +405,8 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             .check_license(merged.check_license)
             .license_policy(merged.license_policy.clone())
             .suggest_fix(false)
+            .check_abandoned(merged.check_abandoned)
+            .abandoned_threshold_days(merged.abandoned_threshold_days)
             .locale(locale)
             .build()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,7 @@ async fn run(args: Args) -> Result<bool> {
             .as_ref()
             .map(|(n, v)| (n.as_str(), v.as_str())),
         response.upgrade_recommendations.as_deref(),
+        response.abandoned_packages_report.as_ref(),
     );
 
     // Verify PyPI links if requested
@@ -443,6 +444,7 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             response.license_compliance_result.as_ref(),
             None,
             response.upgrade_recommendations.as_deref(),
+            response.abandoned_packages_report.as_ref(),
         );
 
         let formatter = FormatterFactory::create(merged.format, None, locale);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ mod shared;
 
 use adapters::outbound::console::StderrProgressReporter;
 use adapters::outbound::filesystem::FileSystemReader;
-use adapters::outbound::network::{CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository};
+use adapters::outbound::network::{
+    CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository, PyPiMaintenanceRepository,
+};
 use adapters::outbound::uv::UvWorkspaceReader;
 use application::dto::{OutputFormat, SbomRequest};
 use application::factories::{FormatterFactory, PresenterFactory, PresenterType};
@@ -217,6 +219,13 @@ async fn run(args: Args) -> Result<bool> {
         None
     };
 
+    // Create maintenance repository if abandoned check is requested
+    let maintenance_repository = if merged.check_abandoned {
+        Some(PyPiMaintenanceRepository::new()?)
+    } else {
+        None
+    };
+
     // Create use case with injected dependencies
     let use_case = GenerateSbomUseCase::new(
         lockfile_reader,
@@ -224,6 +233,7 @@ async fn run(args: Args) -> Result<bool> {
         license_repository,
         progress_reporter,
         vulnerability_repository,
+        maintenance_repository,
         locale,
     );
 
@@ -321,9 +331,15 @@ async fn run(args: Args) -> Result<bool> {
     let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted_output)?;
 
-    // Determine if vulnerabilities or license violations were detected
-    let has_issues =
-        response.has_vulnerabilities_above_threshold || response.has_license_violations;
+    // Determine if vulnerabilities, license violations, or abandoned packages were detected
+    let has_abandoned = response
+        .abandoned_packages_report
+        .as_ref()
+        .map(|r| !r.is_empty())
+        .unwrap_or(false);
+    let has_issues = response.has_vulnerabilities_above_threshold
+        || response.has_license_violations
+        || has_abandoned;
 
     Ok(has_issues)
 }
@@ -384,12 +400,19 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             None
         };
 
+        let maintenance_repository = if merged.check_abandoned {
+            Some(PyPiMaintenanceRepository::new()?)
+        } else {
+            None
+        };
+
         let use_case = GenerateSbomUseCase::new(
             lockfile_reader,
             project_config_reader,
             license_repository,
             progress_reporter,
             vulnerability_repository,
+            maintenance_repository,
             locale,
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,21 +7,24 @@ mod sbom_generation;
 mod shared;
 
 use adapters::outbound::console::StderrProgressReporter;
-use adapters::outbound::filesystem::FileSystemReader;
+use adapters::outbound::filesystem::{determine_diff_source, FileSystemReader, GitLockfileReader};
+use adapters::outbound::formatters::{DiffJsonFormatter, DiffMarkdownFormatter};
 use adapters::outbound::network::{
     CachingPyPiLicenseRepository, OsvClient, PyPiLicenseRepository, PyPiMaintenanceRepository,
 };
 use adapters::outbound::uv::UvWorkspaceReader;
-use application::dto::{OutputFormat, SbomRequest};
+use application::dto::{DiffRequest, OutputFormat, SbomRequest};
 use application::factories::{FormatterFactory, PresenterFactory, PresenterType};
 use application::read_models::SbomReadModelBuilder;
-use application::use_cases::GenerateSbomUseCase;
+use application::use_cases::{GenerateDiffUseCase, GenerateSbomUseCase};
 use clap::Parser;
 use cli::config_resolver::{load_config, merge_config};
 use cli::runner::{display_banner, resolve_suggest_fix, validate_project_path};
 use cli::Args;
 use i18n::Messages;
-use ports::outbound::{LockfileParseResult, LockfileReader, ProjectConfigReader, WorkspaceReader};
+use ports::outbound::{
+    DiffSource, LockfileParseResult, LockfileReader, ProjectConfigReader, WorkspaceReader,
+};
 use shared::error::ExitCode;
 use shared::Result;
 use std::path::{Path, PathBuf};
@@ -122,6 +125,30 @@ async fn main() {
             }
             Err(e) => {
                 eprintln!("Error: {}", e);
+                process::exit(ExitCode::ApplicationError.as_i32());
+            }
+        }
+    }
+
+    // Handle --diff before normal flow
+    if let Some(ref diff_arg) = args.diff {
+        let source = determine_diff_source(diff_arg);
+        match run_diff(args, source).await {
+            Ok(has_vulnerabilities) => {
+                if has_vulnerabilities {
+                    process::exit(ExitCode::VulnerabilitiesDetected.as_i32());
+                }
+                process::exit(ExitCode::Success.as_i32());
+            }
+            Err(e) => {
+                eprintln!("\n❌ An error occurred:\n");
+                eprintln!("{}", e);
+                let mut source = e.source();
+                while let Some(err) = source {
+                    eprintln!("\nCaused by: {}", err);
+                    source = err.source();
+                }
+                eprintln!();
                 process::exit(ExitCode::ApplicationError.as_i32());
             }
         }
@@ -471,4 +498,49 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
     eprintln!("{}", "─".repeat(60));
 
     Ok(())
+}
+
+/// Runs --diff mode: compares the current uv.lock against a base source.
+///
+/// Returns `Ok(true)` if vulnerabilities were detected in new/updated packages
+/// and CVE checking is enabled, `Ok(false)` otherwise.
+///
+/// Note: CVE enrichment is currently a no-op in `GenerateDiffUseCase::execute`,
+/// so this will always return `Ok(false)` until a follow-up issue wires it in.
+async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
+    display_banner();
+
+    let locale = args.lang;
+    let project_dir = args.path.as_deref().unwrap_or(".");
+    let project_path = PathBuf::from(project_dir);
+    validate_project_path(&project_path)?;
+
+    let config = load_config(&args, &project_path)?;
+    let merged = merge_config(&args, &config);
+
+    let check_cve = merged.check_cve;
+    let request = DiffRequest {
+        source,
+        project_path: project_path.clone(),
+        check_cve,
+    };
+
+    // execute() is synchronous — call directly without .await
+    let use_case = GenerateDiffUseCase::new(FileSystemReader::new(), GitLockfileReader::new());
+    let diff = use_case.execute(request)?;
+
+    let formatted = match merged.format {
+        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(&diff),
+        OutputFormat::Json => DiffJsonFormatter::new().format(&diff)?,
+    };
+
+    let presenter_type = if let Some(output_path) = args.output {
+        PresenterType::File(PathBuf::from(output_path))
+    } else {
+        PresenterType::Stdout
+    };
+    let presenter = PresenterFactory::create(presenter_type, locale);
+    presenter.present(&formatted)?;
+
+    Ok(diff.changes.iter().any(|c| c.vulnerability_count > 0) && check_cve)
 }

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -3,8 +3,6 @@ use crate::shared::Result;
 use std::path::{Path, PathBuf};
 
 /// Identifies where a base `uv.lock` should be read from for diff comparison.
-// Wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffSource {
     /// A git ref (branch, tag, or commit SHA). The lockfile is read from
@@ -16,12 +14,6 @@ pub enum DiffSource {
 
 /// Outbound port for retrieving a "base" set of packages to diff against
 /// the current project's `uv.lock`.
-///
-/// Implementations:
-/// - `GitLockfileReader` (future, Issue #224) for `DiffSource::GitRef`
-/// - A filesystem-backed reader (future) for `DiffSource::FilePath`
-// Wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(dead_code)]
 pub trait DiffLockfileReader {
     /// Read the lockfile identified by `source` (interpreted relative to
     /// `project_path` when applicable) and return its packages.

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -1,0 +1,35 @@
+use crate::sbom_generation::domain::Package;
+use crate::shared::Result;
+use std::path::{Path, PathBuf};
+
+/// Identifies where a base `uv.lock` should be read from for diff comparison.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffSource {
+    /// A git ref (branch, tag, or commit SHA). The lockfile is read from
+    /// that revision of the repository.
+    GitRef(String),
+    /// A path on the local filesystem pointing directly to a `uv.lock` file.
+    FilePath(PathBuf),
+}
+
+/// Outbound port for retrieving a "base" set of packages to diff against
+/// the current project's `uv.lock`.
+///
+/// Implementations:
+/// - `GitLockfileReader` (future, Issue #224) for `DiffSource::GitRef`
+/// - A filesystem-backed reader (future) for `DiffSource::FilePath`
+#[allow(dead_code)]
+pub trait DiffLockfileReader {
+    /// Read the lockfile identified by `source` (interpreted relative to
+    /// `project_path` when applicable) and return its packages.
+    ///
+    /// # Errors
+    /// Returns an error if the source cannot be resolved, the lockfile cannot
+    /// be read, or TOML parsing fails.
+    fn read_base_packages(
+        &self,
+        source: &DiffSource,
+        project_path: &Path,
+    ) -> Result<Vec<Package>>;
+}

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -3,6 +3,7 @@ use crate::shared::Result;
 use std::path::{Path, PathBuf};
 
 /// Identifies where a base `uv.lock` should be read from for diff comparison.
+// Wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffSource {
@@ -19,6 +20,7 @@ pub enum DiffSource {
 /// Implementations:
 /// - `GitLockfileReader` (future, Issue #224) for `DiffSource::GitRef`
 /// - A filesystem-backed reader (future) for `DiffSource::FilePath`
+// Wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(dead_code)]
 pub trait DiffLockfileReader {
     /// Read the lockfile identified by `source` (interpreted relative to

--- a/src/ports/outbound/diff_lockfile_reader.rs
+++ b/src/ports/outbound/diff_lockfile_reader.rs
@@ -27,9 +27,5 @@ pub trait DiffLockfileReader {
     /// # Errors
     /// Returns an error if the source cannot be resolved, the lockfile cannot
     /// be read, or TOML parsing fails.
-    fn read_base_packages(
-        &self,
-        source: &DiffSource,
-        project_path: &Path,
-    ) -> Result<Vec<Package>>;
+    fn read_base_packages(&self, source: &DiffSource, project_path: &Path) -> Result<Vec<Package>>;
 }

--- a/src/ports/outbound/lockfile_reader.rs
+++ b/src/ports/outbound/lockfile_reader.rs
@@ -48,9 +48,9 @@ pub trait LockfileReader {
     /// Parse the lockfile and return only packages reachable from the given member.
     ///
     /// Performs a BFS traversal starting from the `[[package]]` entry whose
-    /// `name == member_name` and `source.editable` is set, collecting all
-    /// transitively reachable packages. The member package itself is excluded
-    /// from the result.
+    /// `name == member_name` and `source.editable` (uv < 0.5) or `source.virtual`
+    /// (uv >= 0.5) is set, collecting all transitively reachable packages. The member
+    /// package itself is excluded from the result.
     ///
     /// # Arguments
     /// * `project_path` - Path to the project directory containing uv.lock
@@ -64,7 +64,7 @@ pub trait LockfileReader {
     /// Returns an error if:
     /// - The uv.lock file does not exist or cannot be read
     /// - The TOML parsing fails
-    /// - No package with `name == member_name` and `source.editable` set is found
+    /// - No package with `name == member_name` and `source.editable` or `source.virtual` set is found
     fn read_and_parse_lockfile_for_member(
         &self,
         project_path: &Path,

--- a/src/ports/outbound/maintenance_repository.rs
+++ b/src/ports/outbound/maintenance_repository.rs
@@ -11,9 +11,6 @@ use chrono::NaiveDate;
 /// - `last_release_date` is `None` when the package has no published releases
 ///   on the upstream registry (extremely rare for installed packages, but
 ///   possible for yanked-only or pre-release-only packages).
-// Consumed by the PyPI maintenance adapter (#553) and use case integration (#555).
-// Suppressed here because this is a foundational subtask with no binary consumer yet.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaintenanceInfo {
     /// Date of the most recent release on the upstream registry (UTC).
@@ -60,8 +57,6 @@ pub struct MaintenanceInfo {
 /// # Ok(())
 /// # }
 /// ```
-// Implemented by PyPiMaintenanceRepository in #553; used in GenerateSbomUseCase in #555.
-#[allow(dead_code)]
 #[async_trait]
 pub trait MaintenanceRepository: Send + Sync {
     /// Fetches maintenance information for a single package

--- a/src/ports/outbound/maintenance_repository.rs
+++ b/src/ports/outbound/maintenance_repository.rs
@@ -1,0 +1,125 @@
+use crate::shared::Result;
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+/// Maintenance information for a single package
+///
+/// Captures the latest signal of upstream activity used to detect
+/// abandoned/unmaintained packages.
+///
+/// # Notes
+/// - `last_release_date` is `None` when the package has no published releases
+///   on the upstream registry (extremely rare for installed packages, but
+///   possible for yanked-only or pre-release-only packages).
+// Consumed by the PyPI maintenance adapter (#553) and use case integration (#555).
+// Suppressed here because this is a foundational subtask with no binary consumer yet.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaintenanceInfo {
+    /// Date of the most recent release on the upstream registry (UTC).
+    /// `None` when no release date is available.
+    pub last_release_date: Option<NaiveDate>,
+}
+
+/// Port for fetching package maintenance information from external sources
+///
+/// This trait defines the interface for querying upstream registries
+/// (e.g., PyPI JSON API) to determine when a package was last released,
+/// which is used to detect abandoned/unmaintained dependencies.
+///
+/// # Security Considerations
+/// - Implementations must not send internal/private package names to public APIs
+/// - Implementations should implement rate limiting to prevent DoS
+/// - Implementations should have timeout mechanisms
+///
+/// # Implementation Notes
+/// - All methods are async to enable parallel fetching across packages
+/// - Implementations should treat "package not found" as an error, not as
+///   `MaintenanceInfo { last_release_date: None }`
+///
+/// # Example
+/// ```no_run
+/// # use uv_sbom::ports::outbound::MaintenanceRepository;
+/// # use async_trait::async_trait;
+/// # struct MockRepo;
+/// # #[async_trait]
+/// # impl MaintenanceRepository for MockRepo {
+/// #     async fn fetch_maintenance_info(
+/// #         &self,
+/// #         _package_name: &str,
+/// #     ) -> uv_sbom::shared::Result<uv_sbom::ports::outbound::MaintenanceInfo> {
+/// #         Ok(uv_sbom::ports::outbound::MaintenanceInfo { last_release_date: None })
+/// #     }
+/// # }
+/// # async fn example() -> uv_sbom::shared::Result<()> {
+/// # let repo = MockRepo;
+/// let info = repo.fetch_maintenance_info("requests").await?;
+/// if let Some(date) = info.last_release_date {
+///     println!("Last released on {}", date);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+// Implemented by PyPiMaintenanceRepository in #553; used in GenerateSbomUseCase in #555.
+#[allow(dead_code)]
+#[async_trait]
+pub trait MaintenanceRepository: Send + Sync {
+    /// Fetches maintenance information for a single package
+    ///
+    /// # Arguments
+    /// * `package_name` - Canonical package name (case-insensitive on PyPI)
+    ///
+    /// # Returns
+    /// `MaintenanceInfo` describing the package's most recent upstream activity.
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Network request fails
+    /// - Package is not found on the upstream registry
+    /// - API response is invalid
+    /// - Timeout occurs
+    async fn fetch_maintenance_info(&self, package_name: &str) -> Result<MaintenanceInfo>;
+}
+
+/// Dummy implementation of MaintenanceRepository for the unit type.
+/// Mirrors the `impl ... for ()` pattern in `VulnerabilityRepository`,
+/// allowing `Option<()>` when no maintenance checking is configured.
+#[async_trait]
+impl MaintenanceRepository for () {
+    async fn fetch_maintenance_info(&self, _package_name: &str) -> Result<MaintenanceInfo> {
+        unreachable!("MaintenanceRepository not configured")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_maintenance_info_with_date() {
+        let info = MaintenanceInfo {
+            last_release_date: Some(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()),
+        };
+        assert_eq!(
+            info.last_release_date,
+            Some(NaiveDate::from_ymd_opt(2024, 1, 15).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_maintenance_info_without_date() {
+        let info = MaintenanceInfo {
+            last_release_date: None,
+        };
+        assert!(info.last_release_date.is_none());
+    }
+
+    #[test]
+    fn test_maintenance_info_clone_and_eq() {
+        let a = MaintenanceInfo {
+            last_release_date: Some(NaiveDate::from_ymd_opt(2025, 6, 1).unwrap()),
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -6,6 +6,7 @@ pub mod enriched_package;
 pub mod formatter;
 pub mod license_repository;
 pub mod lockfile_reader;
+pub mod maintenance_repository;
 pub mod output_presenter;
 pub mod progress_reporter;
 pub mod project_config_reader;
@@ -17,6 +18,9 @@ pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};
 pub use lockfile_reader::{LockfileParseResult, LockfileReader};
+// Note: Will be used in subsequent subtasks (abandoned package detection)
+#[allow(unused_imports)]
+pub use maintenance_repository::{MaintenanceInfo, MaintenanceRepository};
 pub use output_presenter::OutputPresenter;
 pub use progress_reporter::{ProgressCallback, ProgressReporter};
 pub use project_config_reader::ProjectConfigReader;

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -15,8 +15,6 @@ pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
 
-// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
-#[allow(unused_imports)]
 pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
 pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -15,7 +15,7 @@ pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
 
-// Note: Will be used in a subsequent subtask of the dependency-diff feature (#224)
+// Note: Will be wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(unused_imports)]
 pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
 pub use enriched_package::EnrichedPackage;

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -2,6 +2,7 @@
 ///
 /// These ports define the interfaces that the application core uses
 /// to interact with external systems (file system, network, console, etc.).
+pub mod diff_lockfile_reader;
 pub mod enriched_package;
 pub mod formatter;
 pub mod license_repository;
@@ -14,6 +15,9 @@ pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
 
+// Note: Will be used in a subsequent subtask of the dependency-diff feature (#224)
+#[allow(unused_imports)]
+pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
 pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};

--- a/src/sbom_generation/domain/dependency_diff.rs
+++ b/src/sbom_generation/domain/dependency_diff.rs
@@ -1,0 +1,45 @@
+// Foundation types for the dependency-diff feature; used by subsequent subtasks of #224.
+#![allow(dead_code)]
+
+/// Classification of how a package changed between two dependency snapshots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChangeType {
+    Added,
+    Removed,
+    Updated,
+    Unchanged,
+}
+
+/// Per-package record describing how one package changed.
+///
+/// `old_version` / `new_version` semantics:
+/// - Added:     old = None,          new = Some(version)
+/// - Removed:   old = Some(version), new = None
+/// - Updated:   old = Some(_),       new = Some(_)  (versions differ)
+/// - Unchanged: old = Some(v),       new = Some(v)  (same version)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageChange {
+    pub package_name: String,
+    pub change_type: ChangeType,
+    pub old_version: Option<String>,
+    pub new_version: Option<String>,
+    pub license: Option<String>,
+    pub vulnerability_count: usize,
+}
+
+/// Aggregate counts across all changes in a diff.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DiffSummary {
+    pub added: usize,
+    pub removed: usize,
+    pub updated: usize,
+    pub unchanged: usize,
+}
+
+/// Result of comparing two dependency snapshots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyDiff {
+    pub base_ref: String,
+    pub changes: Vec<PackageChange>,
+    pub summary: DiffSummary,
+}

--- a/src/sbom_generation/domain/dependency_diff.rs
+++ b/src/sbom_generation/domain/dependency_diff.rs
@@ -1,4 +1,4 @@
-// Foundation types for the dependency-diff feature; used by subsequent subtasks of #224.
+// Types for the dependency-diff feature; wired to the binary in a subsequent CLI integration subtask of #224.
 #![allow(dead_code)]
 
 /// Classification of how a package changed between two dependency snapshots.

--- a/src/sbom_generation/domain/mod.rs
+++ b/src/sbom_generation/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod dependency_diff;
 pub mod dependency_graph;
 pub mod license_info;
 pub mod license_policy;
@@ -8,6 +9,9 @@ pub mod services;
 pub mod upgrade_recommendation;
 pub mod vulnerability;
 
+// Note: These will be used in subsequent subtasks of the dependency-diff feature (#224)
+#[allow(unused_imports)]
+pub use dependency_diff::{ChangeType, DependencyDiff, DiffSummary, PackageChange};
 pub use dependency_graph::DependencyGraph;
 pub use license_info::LicenseInfo;
 // Note: These types are used within the application layer via full paths
@@ -24,6 +28,9 @@ pub use sbom_metadata::SbomMetadata;
 // Note: ResolutionAnalyzer will be used in subsequent subtasks (Issue #221 sub-tasks 3-4)
 #[allow(unused_imports)]
 pub use services::ResolutionAnalyzer;
+// Note: These will be used in subsequent subtasks of the dependency-diff feature (#224)
+#[allow(unused_imports)]
+pub use services::DependencyDiffAnalyzer;
 // Note: These will be used in subsequent subtasks (Issue #94, #95)
 #[allow(unused_imports)]
 pub use services::{ThresholdConfig, VulnerabilityCheckResult, VulnerabilityChecker};

--- a/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
+++ b/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
@@ -10,10 +10,10 @@ use crate::sbom_generation::domain::package::Package;
 ///
 /// All inputs and outputs are pure value objects — no I/O is performed.
 ///
-/// Note: `base_ref` is set to `"base"` in this implementation. Subsequent
-/// subtasks of the dependency-diff feature (#224) will introduce an entry
-/// point that accepts the actual git ref.
-// Foundation service for the dependency-diff feature; used by subsequent subtasks of #224.
+/// Note: `base_ref` is set to `"base"` in this implementation. Callers
+/// (e.g., `GenerateDiffUseCase`) override `base_ref` after calling `analyze`
+/// to reflect the actual `DiffSource` label.
+// Wired to the binary in a subsequent CLI integration subtask of #224.
 #[allow(dead_code)]
 pub struct DependencyDiffAnalyzer;
 

--- a/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
+++ b/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
@@ -21,10 +21,8 @@ impl DependencyDiffAnalyzer {
     /// Compare two flat lists of packages and produce a fully populated `DependencyDiff`.
     #[allow(dead_code)]
     pub fn analyze(base: &[Package], current: &[Package]) -> DependencyDiff {
-        let base_map: HashMap<&str, &Package> =
-            base.iter().map(|p| (p.name(), p)).collect();
-        let current_map: HashMap<&str, &Package> =
-            current.iter().map(|p| (p.name(), p)).collect();
+        let base_map: HashMap<&str, &Package> = base.iter().map(|p| (p.name(), p)).collect();
+        let current_map: HashMap<&str, &Package> = current.iter().map(|p| (p.name(), p)).collect();
 
         let mut changes: Vec<PackageChange> = Vec::new();
 
@@ -125,9 +123,8 @@ fn version_jump(old: Option<&str>, new: Option<&str>) -> u64 {
         (Some(o), Some(n)) => (o, n),
         _ => return 0,
     };
-    let parse = |v: &str| -> Vec<u64> {
-        v.split('.').filter_map(|s| s.parse::<u64>().ok()).collect()
-    };
+    let parse =
+        |v: &str| -> Vec<u64> { v.split('.').filter_map(|s| s.parse::<u64>().ok()).collect() };
     let o = parse(old);
     let n = parse(new);
     if o.is_empty() || n.is_empty() {
@@ -162,10 +159,7 @@ mod tests {
         assert_eq!(diff.changes[0].change_type, ChangeType::Added);
         assert_eq!(diff.changes[0].package_name, "requests");
         assert_eq!(diff.changes[0].old_version, None);
-        assert_eq!(
-            diff.changes[0].new_version,
-            Some("2.31.0".to_string())
-        );
+        assert_eq!(diff.changes[0].new_version, Some("2.31.0".to_string()));
         assert_eq!(diff.summary.added, 1);
         assert_eq!(diff.summary.removed, 0);
         assert_eq!(diff.summary.updated, 0);
@@ -191,14 +185,8 @@ mod tests {
         let diff = DependencyDiffAnalyzer::analyze(&base, &current);
         assert_eq!(diff.changes.len(), 1);
         assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
-        assert_eq!(
-            diff.changes[0].old_version,
-            Some("1.26.5".to_string())
-        );
-        assert_eq!(
-            diff.changes[0].new_version,
-            Some("2.0.7".to_string())
-        );
+        assert_eq!(diff.changes[0].old_version, Some("1.26.5".to_string()));
+        assert_eq!(diff.changes[0].new_version, Some("2.0.7".to_string()));
         assert_eq!(diff.summary.updated, 1);
     }
 
@@ -209,14 +197,8 @@ mod tests {
         let diff = DependencyDiffAnalyzer::analyze(&base, &current);
         assert_eq!(diff.changes.len(), 1);
         assert_eq!(diff.changes[0].change_type, ChangeType::Unchanged);
-        assert_eq!(
-            diff.changes[0].old_version,
-            Some("2024.2.2".to_string())
-        );
-        assert_eq!(
-            diff.changes[0].new_version,
-            Some("2024.2.2".to_string())
-        );
+        assert_eq!(diff.changes[0].old_version, Some("2024.2.2".to_string()));
+        assert_eq!(diff.changes[0].new_version, Some("2024.2.2".to_string()));
         assert_eq!(diff.summary.unchanged, 1);
     }
 
@@ -239,7 +221,11 @@ mod tests {
         assert_eq!(diff.summary.updated, 1);
         assert_eq!(diff.summary.removed, 1);
         assert_eq!(diff.summary.unchanged, 2);
-        let names: Vec<&str> = diff.changes.iter().map(|c| c.package_name.as_str()).collect();
+        let names: Vec<&str> = diff
+            .changes
+            .iter()
+            .map(|c| c.package_name.as_str())
+            .collect();
         assert_eq!(names, vec!["e", "b", "c", "a", "d"]);
         assert_eq!(diff.changes[0].change_type, ChangeType::Added);
         assert_eq!(diff.changes[1].change_type, ChangeType::Updated);
@@ -262,7 +248,11 @@ mod tests {
         ];
         let diff = DependencyDiffAnalyzer::analyze(&base, &current);
         assert_eq!(diff.summary.updated, 3);
-        let names: Vec<&str> = diff.changes.iter().map(|c| c.package_name.as_str()).collect();
+        let names: Vec<&str> = diff
+            .changes
+            .iter()
+            .map(|c| c.package_name.as_str())
+            .collect();
         assert_eq!(names, vec!["major-bump", "minor-bump", "patch-bump"]);
     }
 

--- a/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
+++ b/src/sbom_generation/domain/services/dependency_diff_analyzer.rs
@@ -1,0 +1,293 @@
+use std::collections::HashMap;
+
+use crate::sbom_generation::domain::dependency_diff::{
+    ChangeType, DependencyDiff, DiffSummary, PackageChange,
+};
+use crate::sbom_generation::domain::package::Package;
+
+/// Stateless domain service that produces a `DependencyDiff` by comparing
+/// two snapshots of resolved packages (e.g., base branch vs current branch).
+///
+/// All inputs and outputs are pure value objects — no I/O is performed.
+///
+/// Note: `base_ref` is set to `"base"` in this implementation. Subsequent
+/// subtasks of the dependency-diff feature (#224) will introduce an entry
+/// point that accepts the actual git ref.
+// Foundation service for the dependency-diff feature; used by subsequent subtasks of #224.
+#[allow(dead_code)]
+pub struct DependencyDiffAnalyzer;
+
+impl DependencyDiffAnalyzer {
+    /// Compare two flat lists of packages and produce a fully populated `DependencyDiff`.
+    #[allow(dead_code)]
+    pub fn analyze(base: &[Package], current: &[Package]) -> DependencyDiff {
+        let base_map: HashMap<&str, &Package> =
+            base.iter().map(|p| (p.name(), p)).collect();
+        let current_map: HashMap<&str, &Package> =
+            current.iter().map(|p| (p.name(), p)).collect();
+
+        let mut changes: Vec<PackageChange> = Vec::new();
+
+        for pkg in current {
+            match base_map.get(pkg.name()) {
+                None => changes.push(PackageChange {
+                    package_name: pkg.name().to_string(),
+                    change_type: ChangeType::Added,
+                    old_version: None,
+                    new_version: Some(pkg.version().to_string()),
+                    license: None,
+                    vulnerability_count: 0,
+                }),
+                Some(base_pkg) if base_pkg.version() != pkg.version() => {
+                    changes.push(PackageChange {
+                        package_name: pkg.name().to_string(),
+                        change_type: ChangeType::Updated,
+                        old_version: Some(base_pkg.version().to_string()),
+                        new_version: Some(pkg.version().to_string()),
+                        license: None,
+                        vulnerability_count: 0,
+                    })
+                }
+                Some(base_pkg) => changes.push(PackageChange {
+                    package_name: pkg.name().to_string(),
+                    change_type: ChangeType::Unchanged,
+                    old_version: Some(base_pkg.version().to_string()),
+                    new_version: Some(pkg.version().to_string()),
+                    license: None,
+                    vulnerability_count: 0,
+                }),
+            }
+        }
+
+        for pkg in base {
+            if !current_map.contains_key(pkg.name()) {
+                changes.push(PackageChange {
+                    package_name: pkg.name().to_string(),
+                    change_type: ChangeType::Removed,
+                    old_version: Some(pkg.version().to_string()),
+                    new_version: None,
+                    license: None,
+                    vulnerability_count: 0,
+                });
+            }
+        }
+
+        changes.sort_by(|a, b| {
+            let group_order = |c: &ChangeType| -> u8 {
+                match c {
+                    ChangeType::Added => 0,
+                    ChangeType::Updated => 1,
+                    ChangeType::Removed => 2,
+                    ChangeType::Unchanged => 3,
+                }
+            };
+            let primary = group_order(&a.change_type).cmp(&group_order(&b.change_type));
+            if primary != std::cmp::Ordering::Equal {
+                return primary;
+            }
+            if a.change_type == ChangeType::Updated {
+                let jump_a = version_jump(a.old_version.as_deref(), a.new_version.as_deref());
+                let jump_b = version_jump(b.old_version.as_deref(), b.new_version.as_deref());
+                let by_jump = jump_b.cmp(&jump_a);
+                if by_jump != std::cmp::Ordering::Equal {
+                    return by_jump;
+                }
+            }
+            a.package_name.cmp(&b.package_name)
+        });
+
+        let mut summary = DiffSummary::default();
+        for c in &changes {
+            match c.change_type {
+                ChangeType::Added => summary.added += 1,
+                ChangeType::Removed => summary.removed += 1,
+                ChangeType::Updated => summary.updated += 1,
+                ChangeType::Unchanged => summary.unchanged += 1,
+            }
+        }
+
+        DependencyDiff {
+            base_ref: "base".to_string(),
+            changes,
+            summary,
+        }
+    }
+}
+
+/// Magnitude of a version change for sort ordering (larger = bigger jump).
+///
+/// Parses dot-separated numeric segments (PEP 440 style) and weights earlier
+/// segments much higher so a major bump always outranks a patch bump.
+/// Falls back to `1` when segments cannot be parsed, and `0` for equal versions.
+#[allow(dead_code)]
+fn version_jump(old: Option<&str>, new: Option<&str>) -> u64 {
+    let (old, new) = match (old, new) {
+        (Some(o), Some(n)) => (o, n),
+        _ => return 0,
+    };
+    let parse = |v: &str| -> Vec<u64> {
+        v.split('.').filter_map(|s| s.parse::<u64>().ok()).collect()
+    };
+    let o = parse(old);
+    let n = parse(new);
+    if o.is_empty() || n.is_empty() {
+        return if old == new { 0 } else { 1 };
+    }
+    let weights = [1_000_000_u64, 1_000_u64, 1_u64];
+    let max_len = o.len().max(n.len());
+    let mut score: u64 = 0;
+    for i in 0..max_len {
+        let a = o.get(i).copied().unwrap_or(0);
+        let b = n.get(i).copied().unwrap_or(0);
+        let w = weights.get(i).copied().unwrap_or(1);
+        score = score.saturating_add(a.abs_diff(b).saturating_mul(w));
+    }
+    score
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(name: &str, version: &str) -> Package {
+        Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    #[test]
+    fn test_added_package_detected() {
+        let base = vec![];
+        let current = vec![pkg("requests", "2.31.0")];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
+        assert_eq!(diff.changes[0].package_name, "requests");
+        assert_eq!(diff.changes[0].old_version, None);
+        assert_eq!(
+            diff.changes[0].new_version,
+            Some("2.31.0".to_string())
+        );
+        assert_eq!(diff.summary.added, 1);
+        assert_eq!(diff.summary.removed, 0);
+        assert_eq!(diff.summary.updated, 0);
+        assert_eq!(diff.summary.unchanged, 0);
+    }
+
+    #[test]
+    fn test_removed_package_detected() {
+        let base = vec![pkg("requests", "2.31.0")];
+        let current = vec![];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Removed);
+        assert_eq!(diff.changes[0].old_version, Some("2.31.0".to_string()));
+        assert_eq!(diff.changes[0].new_version, None);
+        assert_eq!(diff.summary.removed, 1);
+    }
+
+    #[test]
+    fn test_updated_package_detected() {
+        let base = vec![pkg("urllib3", "1.26.5")];
+        let current = vec![pkg("urllib3", "2.0.7")];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
+        assert_eq!(
+            diff.changes[0].old_version,
+            Some("1.26.5".to_string())
+        );
+        assert_eq!(
+            diff.changes[0].new_version,
+            Some("2.0.7".to_string())
+        );
+        assert_eq!(diff.summary.updated, 1);
+    }
+
+    #[test]
+    fn test_unchanged_package_detected() {
+        let base = vec![pkg("certifi", "2024.2.2")];
+        let current = vec![pkg("certifi", "2024.2.2")];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Unchanged);
+        assert_eq!(
+            diff.changes[0].old_version,
+            Some("2024.2.2".to_string())
+        );
+        assert_eq!(
+            diff.changes[0].new_version,
+            Some("2024.2.2".to_string())
+        );
+        assert_eq!(diff.summary.unchanged, 1);
+    }
+
+    #[test]
+    fn test_mixed_changes_sorted_added_updated_removed_unchanged() {
+        let base = vec![
+            pkg("a", "1.0"),
+            pkg("b", "1.0"),
+            pkg("c", "1.0"),
+            pkg("d", "1.0"),
+        ];
+        let current = vec![
+            pkg("a", "1.0"),
+            pkg("b", "2.0"),
+            pkg("d", "1.0"),
+            pkg("e", "1.0"),
+        ];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.summary.added, 1);
+        assert_eq!(diff.summary.updated, 1);
+        assert_eq!(diff.summary.removed, 1);
+        assert_eq!(diff.summary.unchanged, 2);
+        let names: Vec<&str> = diff.changes.iter().map(|c| c.package_name.as_str()).collect();
+        assert_eq!(names, vec!["e", "b", "c", "a", "d"]);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
+        assert_eq!(diff.changes[1].change_type, ChangeType::Updated);
+        assert_eq!(diff.changes[2].change_type, ChangeType::Removed);
+        assert_eq!(diff.changes[3].change_type, ChangeType::Unchanged);
+        assert_eq!(diff.changes[4].change_type, ChangeType::Unchanged);
+    }
+
+    #[test]
+    fn test_updated_largest_jump_first() {
+        let base = vec![
+            pkg("minor-bump", "1.2.0"),
+            pkg("major-bump", "1.0.0"),
+            pkg("patch-bump", "1.0.0"),
+        ];
+        let current = vec![
+            pkg("minor-bump", "1.3.0"),
+            pkg("major-bump", "2.0.0"),
+            pkg("patch-bump", "1.0.1"),
+        ];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.summary.updated, 3);
+        let names: Vec<&str> = diff.changes.iter().map(|c| c.package_name.as_str()).collect();
+        assert_eq!(names, vec!["major-bump", "minor-bump", "patch-bump"]);
+    }
+
+    #[test]
+    fn test_empty_inputs_returns_empty_diff() {
+        let diff = DependencyDiffAnalyzer::analyze(&[], &[]);
+        assert!(diff.changes.is_empty());
+        assert_eq!(diff.summary, DiffSummary::default());
+        assert_eq!(diff.base_ref, "base");
+    }
+
+    #[test]
+    fn test_added_package_fields_default_to_none_zero() {
+        let diff = DependencyDiffAnalyzer::analyze(&[], &[pkg("foo", "1.0.0")]);
+        let change = &diff.changes[0];
+        assert_eq!(change.license, None);
+        assert_eq!(change.vulnerability_count, 0);
+    }
+
+    #[test]
+    fn test_non_numeric_version_string_does_not_panic() {
+        let base = vec![pkg("foo", "abc")];
+        let current = vec![pkg("foo", "xyz")];
+        let diff = DependencyDiffAnalyzer::analyze(&base, &current);
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
+    }
+}

--- a/src/sbom_generation/domain/services/mod.rs
+++ b/src/sbom_generation/domain/services/mod.rs
@@ -1,9 +1,12 @@
 pub mod cve_filter;
+pub mod dependency_diff_analyzer;
 pub mod license_compliance_checker;
 pub mod resolution_analyzer;
 pub mod upgrade_advisor;
 pub mod vulnerability_checker;
 
+#[allow(unused_imports)]
+pub use dependency_diff_analyzer::DependencyDiffAnalyzer;
 pub use license_compliance_checker::LicenseComplianceChecker;
 pub use resolution_analyzer::ResolutionAnalyzer;
 pub use upgrade_advisor::UpgradeAdvisor;

--- a/tests/e2e_diff.rs
+++ b/tests/e2e_diff.rs
@@ -9,8 +9,9 @@ mod diff_tests {
     fn setup_diff_temp() -> (TempDir, std::path::PathBuf) {
         let temp = TempDir::new().expect("failed to create temp dir");
         let after_lock = std::path::Path::new("tests/fixtures/sample_uv_lock_after.lock");
-        let before_lock =
-            std::path::Path::new("tests/fixtures/sample_uv_lock_before.lock").canonicalize().expect("before lock must exist");
+        let before_lock = std::path::Path::new("tests/fixtures/sample_uv_lock_before.lock")
+            .canonicalize()
+            .expect("before lock must exist");
 
         fs::copy(after_lock, temp.path().join("uv.lock")).unwrap();
 

--- a/tests/e2e_diff.rs
+++ b/tests/e2e_diff.rs
@@ -1,0 +1,171 @@
+/// End-to-end tests for dependency diff mode (--diff flag)
+mod diff_tests {
+    use assert_cmd::cargo::cargo_bin_cmd;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Copies the "after" fixture lockfile into a temp directory as `uv.lock`.
+    /// Returns (temp_dir, abs_path_to_before_lock).
+    fn setup_diff_temp() -> (TempDir, std::path::PathBuf) {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let after_lock = std::path::Path::new("tests/fixtures/sample_uv_lock_after.lock");
+        let before_lock =
+            std::path::Path::new("tests/fixtures/sample_uv_lock_before.lock").canonicalize().expect("before lock must exist");
+
+        fs::copy(after_lock, temp.path().join("uv.lock")).unwrap();
+
+        (temp, before_lock)
+    }
+
+    /// --diff with a file path produces JSON output (exit 0)
+    #[test]
+    fn test_diff_with_file_path_json() {
+        let (temp, before_lock) = setup_diff_temp();
+
+        let output = cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--diff",
+                before_lock.to_str().unwrap(),
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+                "--format",
+                "json",
+            ])
+            .assert()
+            .code(0)
+            .get_output()
+            .stdout
+            .clone();
+
+        let json: serde_json::Value =
+            serde_json::from_slice(&output).expect("stdout must be valid JSON");
+
+        assert!(json["diff"].is_object(), "top-level key 'diff' must exist");
+        assert!(
+            json["diff"]["base"].is_string(),
+            "'diff.base' must be a string"
+        );
+        assert!(json["diff"]["summary"].is_object());
+        assert!(json["diff"]["changes"].is_array());
+
+        // before has certifi@2022.12.7, requests@2.31.0, urllib3@1.26.5
+        // after has certifi@2024.2.2, requests@2.32.3, urllib3@2.2.1 — all 3 updated
+        assert_eq!(json["diff"]["summary"]["updated"], 3);
+        assert_eq!(json["diff"]["summary"]["added"], 0);
+        assert_eq!(json["diff"]["summary"]["removed"], 0);
+    }
+
+    /// --diff with a file path produces Markdown output (exit 0)
+    #[test]
+    fn test_diff_with_file_path_markdown() {
+        let (temp, before_lock) = setup_diff_temp();
+
+        let output = cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--diff",
+                before_lock.to_str().unwrap(),
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+                "--format",
+                "markdown",
+            ])
+            .assert()
+            .code(0)
+            .get_output()
+            .stdout
+            .clone();
+
+        let md = String::from_utf8(output).expect("stdout must be UTF-8");
+        assert!(
+            md.contains("## Dependency Diff Report"),
+            "Markdown must contain the report header"
+        );
+        assert!(
+            md.contains("Compared:"),
+            "Markdown must contain the 'Compared:' line"
+        );
+        assert!(md.contains("### Summary"));
+        assert!(md.contains("### Changes"));
+    }
+
+    /// --diff with --output writes to a file instead of stdout
+    #[test]
+    fn test_diff_to_output_file() {
+        let (temp, before_lock) = setup_diff_temp();
+        let output_file = temp.path().join("diff.json");
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--diff",
+                before_lock.to_str().unwrap(),
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+                "--format",
+                "json",
+                "--output",
+                output_file.to_str().unwrap(),
+            ])
+            .assert()
+            .code(0);
+
+        assert!(output_file.exists(), "output file must be created");
+        let content = fs::read_to_string(&output_file).unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&content).expect("output file must be valid JSON");
+        assert!(json["diff"].is_object());
+    }
+
+    /// --diff conflicts with --workspace (exit 2)
+    #[test]
+    fn test_diff_conflicts_with_workspace() {
+        let temp = TempDir::new().unwrap();
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--diff",
+                "main",
+                "--workspace",
+                "--path",
+                temp.path().to_str().unwrap(),
+            ])
+            .assert()
+            .code(2);
+    }
+
+    /// --diff conflicts with --init (exit 2)
+    #[test]
+    fn test_diff_conflicts_with_init() {
+        let temp = TempDir::new().unwrap();
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--diff",
+                "main",
+                "--init",
+                "--path",
+                temp.path().to_str().unwrap(),
+            ])
+            .assert()
+            .code(2);
+    }
+
+    /// --diff with an invalid git ref containing a semicolon is rejected (exit 3)
+    #[test]
+    fn test_diff_invalid_git_ref_rejected_by_security_validator() {
+        let (temp, _) = setup_diff_temp();
+
+        cargo_bin_cmd!("uv-sbom")
+            .args([
+                "--diff",
+                "main;rm -rf /",
+                "--path",
+                temp.path().to_str().unwrap(),
+                "--no-check-cve",
+            ])
+            .assert()
+            .code(3);
+    }
+}

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -104,6 +104,7 @@ async fn test_e2e_json_format() {
         response.license_compliance_result.as_ref(),
         None,
         None,
+        None,
     );
     let formatter = CycloneDxFormatter::new();
     let json_output = formatter.format(&read_model);
@@ -154,6 +155,7 @@ async fn test_e2e_markdown_format() {
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
         None,
         None,
     );
@@ -501,6 +503,7 @@ async fn test_e2e_exclude_root_project_markdown_output() {
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
         None,
         None,
     );

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -76,11 +76,12 @@ async fn test_e2e_json_format() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -126,11 +127,12 @@ async fn test_e2e_markdown_format() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -178,11 +180,12 @@ async fn test_e2e_nonexistent_project() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -205,11 +208,12 @@ async fn test_e2e_package_count() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -244,11 +248,12 @@ async fn test_e2e_exclude_single_package() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -283,11 +288,12 @@ async fn test_e2e_exclude_multiple_packages() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -326,11 +332,12 @@ async fn test_e2e_exclude_with_wildcard() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -365,11 +372,12 @@ async fn test_e2e_exclude_all_packages_error() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -410,11 +418,12 @@ async fn test_e2e_exclude_root_project_preserves_dependency_classification() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -463,11 +472,12 @@ async fn test_e2e_exclude_root_project_markdown_output() {
     let license_repository = create_test_license_repository();
     let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -32,11 +32,12 @@ source = { registry = "https://pypi.org/simple" }
         .with_license("urllib3", "1.26.0", "MIT", "HTTP library");
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -85,11 +86,12 @@ source = { registry = "https://pypi.org/simple" }
         .with_license("urllib3", "1.26.0", "MIT", "HTTP library");
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -119,11 +121,12 @@ async fn test_generate_sbom_lockfile_read_failure() {
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -152,11 +155,12 @@ source = { registry = "https://pypi.org/simple" }
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -189,11 +193,12 @@ source = { registry = "https://pypi.org/simple" }
     let license_repository = MockLicenseRepository::with_failure();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter.clone(),
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -224,11 +229,12 @@ async fn test_generate_sbom_invalid_toml() {
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -261,11 +267,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter.clone(),
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -310,11 +317,12 @@ source = { registry = "https://pypi.org/simple" }
         .with_license("certifi", "2023.11.17", "MPL-2.0", "CA Bundle");
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -382,11 +390,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -439,11 +448,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -481,11 +491,12 @@ source = { registry = "https://pypi.org/simple" }
     let license_repository = MockLicenseRepository::new();
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );
@@ -543,11 +554,12 @@ source = { registry = "https://pypi.org/simple" }
     );
     let progress_reporter = MockProgressReporter::new();
 
-    let use_case: GenerateSbomUseCase<_, _, _, _, ()> = GenerateSbomUseCase::new(
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         uv_sbom::i18n::Locale::En,
     );


### PR DESCRIPTION
## Summary

Merge release v2.4.0 from `develop` into `main`.

## Changes in This Release

### Added
- **Dependency Diff (`--diff`)**: New `--diff <REF_OR_PATH>` flag compares the current `uv.lock` against a base version. Accepts a git ref (branch, tag, or commit SHA) or a path to a `uv.lock` file. Outputs a diff report in Markdown or JSON format (#581).
- `--check-abandoned` and `--abandoned-threshold-days <DAYS>` CLI flags with TOML config file support (#554).
- **Abandoned package detection**: When `--check-abandoned` is set, uv-sbom fetches maintenance metadata from PyPI, classifies inactive packages by threshold, and reports a summary (#555).
- **Abandoned Packages Markdown section**: New `## Abandoned Packages` section in Markdown output, fully localized for EN and JA (#556).
- **Abandoned packages example**: `examples/abandoned-packages-project/` demonstrating `--check-abandoned` (#567).

## Release PR
- Prepared by: #592 (`release/v2.4.0` → `develop`)

## Post-Merge Steps
After merging this PR:
1. Create tag: `git tag v2.4.0`
2. Push tag: `git push origin v2.4.0`
3. Verify CI release workflow completes (crates.io / PyPI)

---
Generated with [Claude Code](https://claude.com/claude-code)