### PR TITLE
docs(workflow): add Step 0 implementation check to Feature Discussions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,18 @@ When a user requests any operation listed above (even in Japanese), Claude MUST:
 When the user proposes, discusses, or asks Claude to evaluate a new feature idea,
 Claude MUST follow this process before responding with implementation suggestions.
 
+### Step 0: Check current implementation state (MANDATORY — run before Step 1)
+
+Before proposing or evaluating any feature, read these two files to build an exhaustive
+list of already-implemented capabilities:
+
+1. `src/cli/mod.rs` — all current CLI flags (e.g., `--severity-threshold`, `--license-allow`)
+2. `src/config.rs` — all current config keys (e.g., `severity_threshold`, `license_policy`)
+
+For each feature idea (your own or the user's), check whether it is already covered by an
+existing CLI flag or config key. If it is, do NOT propose it as a new feature — instead,
+state explicitly: "This is already implemented as `--flag-name` / config key `key_name`."
+
 ### Step 1: Read vision and triage files (MANDATORY)
 
 Before responding to any feature proposal, read these two files:


### PR DESCRIPTION
## Summary

- Add a mandatory **Step 0** to the Feature Discussions workflow in `.claude/CLAUDE.md`
- Step 0 requires reading `src/cli/mod.rs` and `src/config.rs` before evaluating any feature proposal
- Prevents Claude from proposing features that are already implemented in the codebase

## Related Issue

Closes #593

## Changes Made

- Added `### Step 0: Check current implementation state (MANDATORY — run before Step 1)` to the Feature Discussions section
- Step 0 instructs Claude to read the two authoritative source-of-truth files for user-facing capabilities before proposing features
- Any feature already covered by an existing CLI flag or config key must be explicitly labeled as "already implemented" rather than proposed as new
- Existing Step 1, 2, and 3 are unchanged

## Background

On 2026-05-21, all five candidate features proposed during a brainstorming session were already implemented in v2.4.0 (e.g., `--severity-threshold`, `--license-allow/deny`). This workflow change prevents the same class of error.

> **Note**: `src/cli/mod.rs` and `src/config.rs` are hardcoded by path. If either file is renamed or split in the future, Step 0 will need to be updated accordingly.

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] Documentation-only change; no runtime behavior affected

---
Generated with [Claude Code](https://claude.com/claude-code)