### PR TITLE
feat(application): add CveDeltaView and CveDeltaEntry read model types

### DIFF
--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -1,0 +1,127 @@
+//! CVE delta view model for read-side queries
+//!
+//! Captures the difference in CVE exposure between two SBOM snapshots:
+//! which CVEs are newly introduced and which have been resolved.
+
+use super::vulnerability_view::SeverityView;
+
+/// Container describing the change in CVE exposure between two SBOM snapshots.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+pub struct CveDeltaView {
+    /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
+    pub new: Vec<CveDeltaEntry>,
+    /// Resolved CVEs (present in the baseline, absent from the newer snapshot).
+    pub resolved: Vec<CveDeltaEntry>,
+}
+
+/// Single CVE change entry for a specific package/version.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+pub struct CveDeltaEntry {
+    /// Name of the affected package.
+    pub package_name: String,
+    /// Version of the affected package.
+    pub version: String,
+    /// CVE identifier (e.g., "CVE-2024-1234").
+    pub cve_id: String,
+    /// Severity level. `None` means the CVE has not yet been scored;
+    /// `Some(SeverityView::None)` means it was explicitly scored as no severity.
+    pub severity: Option<SeverityView>,
+    /// Short description of the vulnerability.
+    pub summary: String,
+}
+
+#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+impl CveDeltaEntry {
+    /// Creates a new [`CveDeltaEntry`].
+    pub fn new(
+        package_name: String,
+        version: String,
+        cve_id: String,
+        severity: Option<SeverityView>,
+        summary: String,
+    ) -> Self {
+        CveDeltaEntry {
+            package_name,
+            version,
+            cve_id,
+            severity,
+            summary,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(cve: &str, severity: Option<SeverityView>) -> CveDeltaEntry {
+        CveDeltaEntry::new(
+            "requests".to_string(),
+            "2.28.0".to_string(),
+            cve.to_string(),
+            severity,
+            "Test summary".to_string(),
+        )
+    }
+
+    #[test]
+    fn test_cve_delta_entry_new_all_fields_are_stored() {
+        let entry = make_entry("CVE-2024-1234", Some(SeverityView::High));
+        assert_eq!(entry.package_name, "requests");
+        assert_eq!(entry.version, "2.28.0");
+        assert_eq!(entry.cve_id, "CVE-2024-1234");
+        assert_eq!(entry.severity, Some(SeverityView::High));
+        assert_eq!(entry.summary, "Test summary");
+    }
+
+    #[test]
+    fn test_cve_delta_entry_severity_some_as_str_returns_variant_name() {
+        let entry = make_entry("CVE-2024-0001", Some(SeverityView::Critical));
+        assert_eq!(entry.severity, Some(SeverityView::Critical));
+        assert_eq!(entry.severity.unwrap().as_str(), "CRITICAL");
+    }
+
+    #[test]
+    fn test_cve_delta_entry_severity_none_differs_from_explicit_none_variant() {
+        let unscored = make_entry("CVE-2024-0002", None);
+        let explicit_none = make_entry("CVE-2024-0002", Some(SeverityView::None));
+        assert!(unscored.severity.is_none());
+        assert!(explicit_none.severity.is_some());
+        assert_ne!(unscored.severity, explicit_none.severity);
+    }
+
+    #[test]
+    fn test_cve_delta_view_default_produces_empty_lists() {
+        let view = CveDeltaView::default();
+        assert!(view.new.is_empty());
+        assert!(view.resolved.is_empty());
+    }
+
+    #[test]
+    fn test_cve_delta_view_new_and_resolved_are_independent() {
+        let view = CveDeltaView {
+            new: vec![make_entry("CVE-2024-0001", Some(SeverityView::High))],
+            resolved: vec![
+                make_entry("CVE-2023-9999", Some(SeverityView::Medium)),
+                make_entry("CVE-2023-8888", None),
+            ],
+        };
+        assert_eq!(view.new.len(), 1);
+        assert_eq!(view.resolved.len(), 2);
+        assert_eq!(view.new[0].cve_id, "CVE-2024-0001");
+        assert_eq!(view.resolved[0].cve_id, "CVE-2023-9999");
+    }
+
+    #[test]
+    fn test_cve_delta_entry_clone_produces_equal_fields() {
+        let original = make_entry("CVE-2024-0003", Some(SeverityView::Low));
+        let cloned = original.clone();
+        assert_eq!(cloned.package_name, original.package_name);
+        assert_eq!(cloned.version, original.version);
+        assert_eq!(cloned.cve_id, original.cve_id);
+        assert_eq!(cloned.severity, original.severity);
+        assert_eq!(cloned.summary, original.summary);
+    }
+}

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod abandoned_package;
 pub mod component_view;
+pub mod cve_delta_view;
 pub mod dependency_view;
 pub mod license_compliance_view;
 pub mod resolution_guide_view;
@@ -17,6 +18,8 @@ pub mod vulnerability_view;
 pub use abandoned_package::{AbandonedPackageView, AbandonedPackagesReport};
 #[allow(unused_imports)]
 pub use component_view::{ComponentView, LicenseView};
+#[allow(unused_imports)]
+pub use cve_delta_view::{CveDeltaEntry, CveDeltaView};
 #[allow(unused_imports)]
 pub use dependency_view::DependencyView;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

- Add `CveDeltaView` and `CveDeltaEntry` structs to `src/application/read_models/` as the foundational data layer for the CVE delta feature in `--diff` mode (Issue #596)
- `CveDeltaView` holds two `Vec<CveDeltaEntry>` fields (`new`, `resolved`) and derives `Default`
- `CveDeltaEntry` holds per-CVE metadata (package name, version, CVE ID, severity, summary) with a `pub fn new()` constructor

## Related Issue

Closes #598
Part of #596

## Changes Made

- `src/application/read_models/cve_delta_view.rs` — new module with `CveDeltaView`, `CveDeltaEntry`, and 6 unit tests
- `src/application/read_models/mod.rs` — register new module and re-export both types

## Design Notes

- `String` used for `package_name`, `version`, `cve_id` — consistent with the established read model pattern (`VulnerabilityView` uses the same approach)
- `severity: Option<SeverityView>`: `None` = unscored CVE; `Some(SeverityView::None)` = explicitly scored as no severity (distinct semantics)
- `#[allow(dead_code)]` annotations are temporary; will be removed when Issue #599 wires `CveDeltaView` into `GenerateDiffUseCase` and Issue #600 extends the diff formatters. This is the only viable approach for a standalone foundational-types PR in a binary crate — the binary target flags `pub` lib types as dead when not yet reachable from `main()`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test application::read_models::cve_delta_view` — 6 tests pass
- [x] `cargo test --all` passes

⚠️ CHANGELOG not updated — author confirmed internal-only (new read model types, no CLI or output changes).

---
Generated with [Claude Code](https://claude.com/claude-code)