### PR TITLE
chore(workflow): introduce WIRE convention and Step 4.0 cleanup gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -218,6 +218,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
 | `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, check_cve) |
 | `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; wired to CLI via `--diff` flag (#581) |
+| `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; `#[allow(dead_code)]` until wired by #599/#600 |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants
@@ -257,13 +258,16 @@ Bulk removal is error-prone when multiple structs share field names.
 
 `#[allow(dead_code)]` is allowed ONLY for:
 
-| Use Case | Example |
-|----------|---------|
+| Use Case | Required Format |
+|----------|-----------------|
 | serde wire-format fields that are deserialized but not yet processed in Rust | `#[allow(dead_code)] pub experimental_flag: Option<bool>` on a `#[derive(Deserialize)]` struct |
 | `#[cfg(test)]`-bounded test helpers defined in a test module | Inside `#[cfg(test)] mod tests { ... }` only |
+| Foundational type/function in a sequential PR split whose consumer is a concrete tracked issue, not yet reachable from the binary | Must use the standardized format: `#[allow(dead_code)] // WIRE(#N): remove when <description>`. The attribute MUST be removed in Issue #N via the Step 4.0 cleanup gate. |
 
-In both cases, add a comment explaining WHY the field is intentionally unused in
-production code.
+In all cases, add a comment explaining WHY the field is intentionally unused in
+production code. For the WIRE case, the consuming issue number (#N) MUST exist as
+an open GitHub Issue, and the description after the colon MUST state the removal
+condition clearly.
 
 ### YAGNI Workflow
 
@@ -288,3 +292,10 @@ cargo clippy --lib -- -D warnings
 
 This is already enforced in `.claude/skills/commit/SKILL.md` and
 `.claude/skills/pr/SKILL.md`. Do not weaken this to `--lib` only.
+
+### Recent Incidents
+
+- **2026-05-24 (Issue #598)**: Added `CveDeltaView` and `CveDeltaEntry` read model
+  types with `#[allow(dead_code)]` in a standalone foundational PR. Free-form comment
+  was not machine-scannable, so removal in #599 was not enforced. Fixed by Issue #604
+  with the WIRE convention and the Step 4.0 cleanup gate.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -95,6 +95,28 @@ Accepted responses:
 - "Adjust X" → revise plan, re-present
 - "Cancel" → halt
 
+### Step 4.0: WIRE Annotation Cleanup Gate (MANDATORY)
+
+Scan the entire codebase for WIRE annotations that reference the current issue number:
+
+```bash
+git grep -rn "WIRE(#<issue-number>)" src/
+```
+
+**If matches are found**, each matched item MUST be cleaned up as part of this
+implementation:
+
+- [ ] Remove the `#[allow(dead_code)]` attribute
+- [ ] Remove the `// WIRE(#N): ...` comment line
+- [ ] Verify the item is now actually referenced in the production code added by
+  this issue (not just in `#[cfg(test)]`)
+- [ ] If the item is NOT yet referenced after your implementation, this is a scope
+  gap — pause and report to the user before proceeding
+
+**Do NOT proceed to Step 4 until every matched annotation has been addressed.**
+
+If no matches are found, continue to Step 4 without interruption.
+
 ### Step 4: Implement Changes
 
 - **Follow the confirmed plan from Step 3.5 exactly**

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -53,6 +53,20 @@ Execute all three checks above. If any fail:
 2. Commit the fixes using `/commit` skill
 3. Re-run the checks until all pass
 
+#### WIRE Annotation Notice (informational — does not block)
+
+```bash
+git diff origin/develop...HEAD | grep -E '^\+.*WIRE\(#[0-9]+\)' | grep -v '^+++'
+```
+
+If the output is non-empty, print:
+
+> ⚠️ This PR introduces WIRE(#N) annotation(s). Verify that Issue #N is open and
+> will consume these items. The annotation will be auto-detected by /implement Step 4.0
+> when Issue #N is implemented.
+
+This check is informational only and does not block PR creation.
+
 ### Step 2: Verify Branch Status
 
 ```bash

--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -7,7 +7,7 @@ use super::vulnerability_view::SeverityView;
 
 /// Container describing the change in CVE exposure between two SBOM snapshots.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaView is wired into GenerateDiffUseCase
 pub struct CveDeltaView {
     /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
     pub new: Vec<CveDeltaEntry>,
@@ -17,7 +17,7 @@ pub struct CveDeltaView {
 
 /// Single CVE change entry for a specific package/version.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry is wired into GenerateDiffUseCase
 pub struct CveDeltaEntry {
     /// Name of the affected package.
     pub package_name: String,
@@ -32,7 +32,7 @@ pub struct CveDeltaEntry {
     pub summary: String,
 }
 
-#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry::new is used in use case or formatter
 impl CveDeltaEntry {
     /// Creates a new [`CveDeltaEntry`].
     pub fn new(


### PR DESCRIPTION
## Summary

- Introduce a machine-scannable `WIRE(#N)` comment convention for intentionally temporary `#[allow(dead_code)]` annotations in sequential PR splits
- Add mandatory Step 4.0 (WIRE Annotation Cleanup Gate) to `/implement` skill, ensuring consuming issues automatically detect and remove these annotations
- Add informational WIRE pre-flight notice to `/pr` skill Step 1

## Related Issue

Closes #604

## Changes Made

- **`.claude/skills/implement/SKILL.md`**: Insert Step 4.0 between Step 3.5 confirmation and Step 4 — scans `src/` for `WIRE(#<issue-number>)` tags and requires cleanup before proceeding
- **`.claude/CLAUDE.md`**: Update Dead Code Policy with a third acceptable-use-case row for the WIRE pattern, plus a Recent Incidents entry for the 2026-05-24 (#598) incident
- **`.claude/skills/pr/SKILL.md`**: Add informational WIRE annotation notice to Step 1 (does not block PR creation)
- **`src/application/read_models/cve_delta_view.rs`**: Reformat three free-form `#[allow(dead_code)]` comments to the new `WIRE(#599) WIRE(#600)` standardized format

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo test --all` passes (703 tests)
- [x] `git grep -n "WIRE(#" src/` confirms exactly 3 matches in `cve_delta_view.rs` only

---
Generated with [Claude Code](https://claude.com/claude-code)