### PR TITLE
feat(application): extend GenerateDiffUseCase with CVE delta computation

### DIFF
--- a/src/application/dto/diff_result.rs
+++ b/src/application/dto/diff_result.rs
@@ -1,0 +1,34 @@
+use crate::application::read_models::cve_delta_view::CveDeltaView;
+use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
+
+/// Application-layer result of running the diff use case.
+///
+/// Bundles the pure domain `DependencyDiff` with the optional application
+/// read model `CveDeltaView`, keeping the domain layer free of read-model
+/// dependencies.
+#[derive(Debug, Clone)]
+pub struct DiffResult {
+    pub diff: DependencyDiff,
+    #[allow(dead_code)] // WIRE(#600): remove when cve_delta is consumed by diff formatters
+    pub cve_delta: Option<CveDeltaView>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::dependency_diff::{DependencyDiff, DiffSummary};
+
+    #[test]
+    fn test_diff_result_cve_delta_defaults_to_none() {
+        let diff = DependencyDiff {
+            base_ref: "main".to_string(),
+            changes: vec![],
+            summary: DiffSummary::default(),
+        };
+        let result = DiffResult {
+            diff,
+            cve_delta: None,
+        };
+        assert!(result.cve_delta.is_none());
+    }
+}

--- a/src/application/dto/mod.rs
+++ b/src/application/dto/mod.rs
@@ -3,11 +3,13 @@
 /// DTOs are used to transfer data between the application layer
 /// and adapters, keeping the domain layer isolated.
 mod diff_request;
+mod diff_result;
 mod output_format;
 mod sbom_request;
 mod sbom_response;
 
 pub use diff_request::DiffRequest;
+pub use diff_result::DiffResult;
 pub use output_format::OutputFormat;
 pub use sbom_request::SbomRequest;
 #[allow(unused_imports)]

--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -7,7 +7,7 @@ use super::vulnerability_view::SeverityView;
 
 /// Container describing the change in CVE exposure between two SBOM snapshots.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaView is wired into GenerateDiffUseCase
+#[allow(dead_code)] // WIRE(#600): remove when CveDeltaView fields are consumed by diff formatters
 pub struct CveDeltaView {
     /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
     pub new: Vec<CveDeltaEntry>,
@@ -17,7 +17,7 @@ pub struct CveDeltaView {
 
 /// Single CVE change entry for a specific package/version.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry is wired into GenerateDiffUseCase
+#[allow(dead_code)] // WIRE(#600): remove when CveDeltaEntry fields are consumed by diff formatters
 pub struct CveDeltaEntry {
     /// Name of the affected package.
     pub package_name: String,
@@ -32,7 +32,6 @@ pub struct CveDeltaEntry {
     pub summary: String,
 }
 
-#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry::new is used in use case or formatter
 impl CveDeltaEntry {
     /// Creates a new [`CveDeltaEntry`].
     pub fn new(

--- a/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
@@ -1,6 +1,7 @@
 use super::super::resolution_guide_view::{
     IntroducedByView, ResolutionEntryView, ResolutionGuideView,
 };
+use crate::application::read_models::vulnerability_view::SeverityView;
 use crate::sbom_generation::domain::resolution_guide::ResolutionEntry;
 
 /// Builds resolution guide view from domain resolution entries
@@ -33,7 +34,7 @@ fn build_resolution_entry_view(entry: &ResolutionEntry) -> ResolutionEntryView {
         vulnerable_package: entry.vulnerable_package().to_string(),
         current_version: entry.current_version().to_string(),
         fixed_version: entry.fixed_version().map(|v| v.to_string()),
-        severity: super::vulnerability_builder::map_severity(&entry.severity()),
+        severity: SeverityView::from(entry.severity()),
         vulnerability_id: entry.vulnerability_id().to_string(),
         introduced_by,
         dependency_chains,

--- a/src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs
@@ -3,9 +3,7 @@ use super::super::vulnerability_view::{
     SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
 };
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
-use crate::sbom_generation::domain::vulnerability::{
-    PackageVulnerabilities, Severity, Vulnerability,
-};
+use crate::sbom_generation::domain::vulnerability::{PackageVulnerabilities, Vulnerability};
 use std::collections::HashSet;
 
 /// Builds vulnerability report view from vulnerability check result
@@ -88,21 +86,10 @@ pub(super) fn build_vulnerability_view(
         affected_version: package.current_version().to_string(),
         cvss_score: vuln.cvss_score().map(|s| s.value()),
         cvss_vector: None, // OSV API doesn't provide vector in our current implementation
-        severity: map_severity(&vuln.severity()),
+        severity: SeverityView::from(vuln.severity()),
         fixed_version: vuln.fixed_version().map(|s| s.to_string()),
         description: None, // Summary is not exposed in Vulnerability, could be added later
         source_url: None,  // Not available in current domain model
-    }
-}
-
-/// Converts domain Severity to SeverityView
-pub(super) fn map_severity(severity: &Severity) -> SeverityView {
-    match severity {
-        Severity::Critical => SeverityView::Critical,
-        Severity::High => SeverityView::High,
-        Severity::Medium => SeverityView::Medium,
-        Severity::Low => SeverityView::Low,
-        Severity::None => SeverityView::None,
     }
 }
 
@@ -115,12 +102,15 @@ mod tests {
     use crate::sbom_generation::domain::vulnerability::Severity;
 
     #[test]
-    fn test_map_severity_all_levels() {
-        assert_eq!(map_severity(&Severity::Critical), SeverityView::Critical);
-        assert_eq!(map_severity(&Severity::High), SeverityView::High);
-        assert_eq!(map_severity(&Severity::Medium), SeverityView::Medium);
-        assert_eq!(map_severity(&Severity::Low), SeverityView::Low);
-        assert_eq!(map_severity(&Severity::None), SeverityView::None);
+    fn test_severity_view_from_severity_all_levels() {
+        assert_eq!(
+            SeverityView::from(Severity::Critical),
+            SeverityView::Critical
+        );
+        assert_eq!(SeverityView::from(Severity::High), SeverityView::High);
+        assert_eq!(SeverityView::from(Severity::Medium), SeverityView::Medium);
+        assert_eq!(SeverityView::from(Severity::Low), SeverityView::Low);
+        assert_eq!(SeverityView::from(Severity::None), SeverityView::None);
     }
 
     #[test]

--- a/src/application/read_models/vulnerability_view.rs
+++ b/src/application/read_models/vulnerability_view.rs
@@ -3,6 +3,8 @@
 //! These structs provide a query-optimized view of vulnerability data
 //! with pre-computed categorization and summary information.
 
+use crate::sbom_generation::domain::vulnerability::Severity;
+
 /// View representation of a vulnerability report
 ///
 /// Provides pre-categorized vulnerabilities with summary statistics
@@ -102,6 +104,18 @@ impl SeverityView {
             SeverityView::Medium => "MEDIUM",
             SeverityView::Low => "LOW",
             SeverityView::None => "NONE",
+        }
+    }
+}
+
+impl From<Severity> for SeverityView {
+    fn from(sev: Severity) -> Self {
+        match sev {
+            Severity::Critical => SeverityView::Critical,
+            Severity::High => SeverityView::High,
+            Severity::Medium => SeverityView::Medium,
+            Severity::Low => SeverityView::Low,
+            Severity::None => SeverityView::None,
         }
     }
 }

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -1,40 +1,62 @@
-use crate::application::dto::DiffRequest;
-use crate::ports::outbound::{DiffLockfileReader, DiffSource, LockfileReader};
-use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
+use crate::application::dto::{DiffRequest, DiffResult};
+use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
+use crate::application::read_models::vulnerability_view::SeverityView;
+use crate::ports::outbound::{
+    DiffLockfileReader, DiffSource, LockfileReader, VulnerabilityRepository,
+};
 use crate::sbom_generation::domain::services::DependencyDiffAnalyzer;
+use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
+use crate::sbom_generation::domain::Package;
 use crate::shared::Result;
+use std::collections::{HashMap, HashSet};
 
-pub struct GenerateDiffUseCase<LR, DLR>
+/// Orchestrates dependency diff generation between two lockfile snapshots.
+///
+/// `LR` reads the current `uv.lock`, `DLR` reads the base lockfile (git ref or
+/// file path), and `VR` fetches OSV vulnerability data. `VR` defaults to `()`
+/// (the Null Object implementation) when CVE checking is not needed.
+pub struct GenerateDiffUseCase<LR, DLR, VR = ()>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
+    VR: VulnerabilityRepository,
 {
     lockfile_reader: LR,
     diff_reader: DLR,
+    vulnerability_repository: Option<VR>,
 }
 
-impl<LR, DLR> GenerateDiffUseCase<LR, DLR>
+impl<LR, DLR, VR> GenerateDiffUseCase<LR, DLR, VR>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
+    VR: VulnerabilityRepository,
 {
-    pub fn new(lockfile_reader: LR, diff_reader: DLR) -> Self {
+    /// Creates a new [`GenerateDiffUseCase`] with the given readers and optional vulnerability repository.
+    pub fn new(
+        lockfile_reader: LR,
+        diff_reader: DLR,
+        vulnerability_repository: Option<VR>,
+    ) -> Self {
         Self {
             lockfile_reader,
             diff_reader,
+            vulnerability_repository,
         }
     }
 
     /// Execute the diff use case.
     ///
     /// Reads the current `uv.lock` via `lockfile_reader`, reads the base packages
-    /// via `diff_reader`, and returns a `DependencyDiff` with `base_ref` set to
+    /// via `diff_reader`, and returns a `DiffResult` with `diff.base_ref` set to
     /// the string representation of the source. Non-UTF-8 path bytes are replaced
     /// with U+FFFD (display use only — the string is never round-tripped to the FS).
     ///
-    /// CVE enrichment (`check_cve`) is accepted but currently a no-op; it will be
-    /// wired in a follow-up issue.
-    pub fn execute(&self, request: DiffRequest) -> Result<DependencyDiff> {
+    /// When `request.check_cve` is true and a `VulnerabilityRepository` was supplied,
+    /// runs OSV checks on both the base and current package sets and populates
+    /// `cve_delta` with newly introduced and resolved CVEs. When `check_cve` is false
+    /// or no repository was supplied, `cve_delta` is `None`.
+    pub async fn execute(&self, request: DiffRequest) -> Result<DiffResult> {
         let (current, _deps) = self
             .lockfile_reader
             .read_and_parse_lockfile(&request.project_path)?;
@@ -50,24 +72,102 @@ where
             DiffSource::FilePath(p) => p.to_string_lossy().into_owned(),
         };
 
-        // CVE enrichment deferred to a follow-up issue.
-        let _ = request.check_cve;
+        let cve_delta = if request.check_cve {
+            match &self.vulnerability_repository {
+                Some(repo) => Some(compute_cve_delta(repo, &base, &current).await?),
+                None => None,
+            }
+        } else {
+            None
+        };
 
-        Ok(diff)
+        Ok(DiffResult { diff, cve_delta })
     }
+}
+
+/// Fetches OSV vulnerability data for `base` and `current` package sets sequentially,
+/// then computes the set difference keyed on `(package_name, version, cve_id)`.
+/// Sequential fetching is intentional: OSV API rate limits make parallel calls
+/// counter-productive, and it simplifies mock ordering in tests.
+async fn compute_cve_delta<VR: VulnerabilityRepository>(
+    repo: &VR,
+    base: &[Package],
+    current: &[Package],
+) -> Result<CveDeltaView> {
+    let base_vulns = repo.fetch_vulnerabilities(base.to_vec()).await?;
+    let current_vulns = repo.fetch_vulnerabilities(current.to_vec()).await?;
+
+    let base_map = flatten_to_entries(&base_vulns);
+    let current_map = flatten_to_entries(&current_vulns);
+
+    let base_keys: HashSet<_> = base_map.keys().cloned().collect();
+    let current_keys: HashSet<_> = current_map.keys().cloned().collect();
+
+    let new: Vec<CveDeltaEntry> = current_keys
+        .difference(&base_keys)
+        .filter_map(|k| current_map.get(k).cloned())
+        .collect();
+
+    let resolved: Vec<CveDeltaEntry> = base_keys
+        .difference(&current_keys)
+        .filter_map(|k| base_map.get(k).cloned())
+        .collect();
+
+    Ok(CveDeltaView { new, resolved })
+}
+
+/// Converts a flat list of `PackageVulnerabilities` into a map keyed by
+/// `(package_name, version, cve_id)`. This three-part key ensures that the same
+/// CVE ID on different package versions is treated as distinct entries.
+fn flatten_to_entries(
+    pkg_vulns: &[PackageVulnerabilities],
+) -> HashMap<(String, String, String), CveDeltaEntry> {
+    let mut map = HashMap::new();
+    for pv in pkg_vulns {
+        for vuln in pv.vulnerabilities() {
+            let key = (
+                pv.package_name().to_string(),
+                pv.current_version().to_string(),
+                vuln.id().to_string(),
+            );
+            let entry = CveDeltaEntry::new(
+                pv.package_name().to_string(),
+                pv.current_version().to_string(),
+                vuln.id().to_string(),
+                Some(SeverityView::from(vuln.severity())),
+                vuln.summary().unwrap_or("").to_string(),
+            );
+            map.insert(key, entry);
+        }
+    }
+    map
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::use_cases::test_doubles::PairedMockVulnerabilityRepository;
     use crate::ports::outbound::lockfile_reader::LockfileParseResult;
     use crate::sbom_generation::domain::dependency_diff::ChangeType;
+    use crate::sbom_generation::domain::vulnerability::{Severity, Vulnerability};
     use crate::sbom_generation::domain::Package;
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
     fn pkg(name: &str, version: &str) -> Package {
         Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    fn make_vuln(id: &str, severity: Severity) -> Vulnerability {
+        Vulnerability::new(id.to_string(), None, severity, None, None).unwrap()
+    }
+
+    fn make_pkg_vulns(
+        name: &str,
+        version: &str,
+        vulns: Vec<Vulnerability>,
+    ) -> PackageVulnerabilities {
+        PackageVulnerabilities::new(name.to_string(), version.to_string(), vulns)
     }
 
     struct StubLockfileReader {
@@ -109,10 +209,27 @@ mod tests {
     fn make_use_case(
         current: Vec<Package>,
         base: Vec<Package>,
-    ) -> GenerateDiffUseCase<StubLockfileReader, StubDiffLockfileReader> {
+    ) -> GenerateDiffUseCase<StubLockfileReader, StubDiffLockfileReader, ()> {
         GenerateDiffUseCase::new(
             StubLockfileReader { packages: current },
             StubDiffLockfileReader { packages: base },
+            None,
+        )
+    }
+
+    fn make_use_case_with_vuln_repo(
+        current: Vec<Package>,
+        base: Vec<Package>,
+        repo: PairedMockVulnerabilityRepository,
+    ) -> GenerateDiffUseCase<
+        StubLockfileReader,
+        StubDiffLockfileReader,
+        PairedMockVulnerabilityRepository,
+    > {
+        GenerateDiffUseCase::new(
+            StubLockfileReader { packages: current },
+            StubDiffLockfileReader { packages: base },
+            Some(repo),
         )
     }
 
@@ -124,81 +241,187 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_execute_detects_added_package() {
+    fn git_ref_request_with_cve(ref_name: &str) -> DiffRequest {
+        DiffRequest {
+            source: DiffSource::GitRef(ref_name.to_string()),
+            project_path: PathBuf::from("/project"),
+            check_cve: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_detects_added_package() {
         let uc = make_use_case(vec![pkg("requests", "2.31.0")], vec![]);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.changes.len(), 1);
-        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
-        assert_eq!(diff.changes[0].package_name, "requests");
-        assert_eq!(diff.summary.added, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.changes.len(), 1);
+        assert_eq!(result.diff.changes[0].change_type, ChangeType::Added);
+        assert_eq!(result.diff.changes[0].package_name, "requests");
+        assert_eq!(result.diff.summary.added, 1);
     }
 
-    #[test]
-    fn test_execute_detects_removed_package() {
+    #[tokio::test]
+    async fn test_execute_detects_removed_package() {
         let uc = make_use_case(vec![], vec![pkg("requests", "2.31.0")]);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.changes.len(), 1);
-        assert_eq!(diff.changes[0].change_type, ChangeType::Removed);
-        assert_eq!(diff.summary.removed, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.changes.len(), 1);
+        assert_eq!(result.diff.changes[0].change_type, ChangeType::Removed);
+        assert_eq!(result.diff.summary.removed, 1);
     }
 
-    #[test]
-    fn test_execute_detects_updated_package() {
+    #[tokio::test]
+    async fn test_execute_detects_updated_package() {
         let uc = make_use_case(
             vec![pkg("urllib3", "2.0.7")],
             vec![pkg("urllib3", "1.26.5")],
         );
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.changes.len(), 1);
-        assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
-        assert_eq!(diff.changes[0].old_version, Some("1.26.5".to_string()));
-        assert_eq!(diff.changes[0].new_version, Some("2.0.7".to_string()));
-        assert_eq!(diff.summary.updated, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.changes.len(), 1);
+        assert_eq!(result.diff.changes[0].change_type, ChangeType::Updated);
+        assert_eq!(
+            result.diff.changes[0].old_version,
+            Some("1.26.5".to_string())
+        );
+        assert_eq!(
+            result.diff.changes[0].new_version,
+            Some("2.0.7".to_string())
+        );
+        assert_eq!(result.diff.summary.updated, 1);
     }
 
-    #[test]
-    fn test_execute_mixed_changes() {
+    #[tokio::test]
+    async fn test_execute_mixed_changes() {
         let base = vec![pkg("a", "1.0"), pkg("b", "1.0"), pkg("c", "1.0")];
         let current = vec![pkg("a", "1.0"), pkg("b", "2.0"), pkg("d", "1.0")];
         let uc = make_use_case(current, base);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.summary.added, 1);
-        assert_eq!(diff.summary.updated, 1);
-        assert_eq!(diff.summary.removed, 1);
-        assert_eq!(diff.summary.unchanged, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.summary.added, 1);
+        assert_eq!(result.diff.summary.updated, 1);
+        assert_eq!(result.diff.summary.removed, 1);
+        assert_eq!(result.diff.summary.unchanged, 1);
     }
 
-    #[test]
-    fn test_execute_base_ref_uses_git_ref_string() {
+    #[tokio::test]
+    async fn test_execute_base_ref_uses_git_ref_string() {
         let uc = make_use_case(vec![], vec![]);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.base_ref, "main");
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.base_ref, "main");
     }
 
-    #[test]
-    fn test_execute_base_ref_uses_file_path_string() {
+    #[tokio::test]
+    async fn test_execute_base_ref_uses_file_path_string() {
         let uc = make_use_case(vec![], vec![]);
         let req = DiffRequest {
             source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
             project_path: PathBuf::from("/project"),
             check_cve: false,
         };
-        let diff = uc.execute(req).unwrap();
-        assert_eq!(diff.base_ref, "/tmp/uv.lock");
+        let result = uc.execute(req).await.unwrap();
+        assert_eq!(result.diff.base_ref, "/tmp/uv.lock");
     }
 
-    #[test]
-    fn test_execute_check_cve_flag_is_currently_a_noop() {
-        let base = vec![pkg("a", "1.0")];
-        let current = vec![pkg("a", "2.0")];
-        let uc_false = make_use_case(current.clone(), base.clone());
-        let uc_true = make_use_case(current, base);
-        let diff_false = uc_false.execute(git_ref_request("main")).unwrap();
-        let mut req_cve = git_ref_request("main");
-        req_cve.check_cve = true;
-        let diff_true = uc_true.execute(req_cve).unwrap();
-        assert_eq!(diff_false.changes, diff_true.changes);
-        assert_eq!(diff_false.summary, diff_true.summary);
+    #[tokio::test]
+    async fn test_execute_check_cve_false_skips_osv_and_cve_delta_is_none() {
+        let uc = make_use_case(vec![pkg("a", "1.0")], vec![pkg("a", "2.0")]);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert!(result.cve_delta.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_check_cve_true_no_repo_returns_none() {
+        let uc = make_use_case(vec![pkg("a", "1.0")], vec![]);
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        assert!(result.cve_delta.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_new_cve_appears_in_current() {
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![make_vuln("CVE-2024-1234", Severity::High)],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.30.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert_eq!(delta.new.len(), 1);
+        assert_eq!(delta.new[0].cve_id, "CVE-2024-1234");
+        assert!(delta.resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_resolved_cve_absent_in_current() {
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![make_pkg_vulns(
+                "requests",
+                "2.30.0",
+                vec![make_vuln("CVE-2023-9999", Severity::Medium)],
+            )],
+            vec![],
+        );
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.30.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert!(delta.new.is_empty());
+        assert_eq!(delta.resolved.len(), 1);
+        assert_eq!(delta.resolved[0].cve_id, "CVE-2023-9999");
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_no_change_produces_empty_lists() {
+        let shared_vuln = make_pkg_vulns(
+            "requests",
+            "2.31.0",
+            vec![make_vuln("CVE-2024-0001", Severity::Low)],
+        );
+        let repo =
+            PairedMockVulnerabilityRepository::new(vec![shared_vuln.clone()], vec![shared_vuln]);
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.31.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert!(delta.new.is_empty());
+        assert!(delta.resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_same_cve_id_different_version_counts_separately() {
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![make_pkg_vulns(
+                "requests",
+                "2.30.0",
+                vec![make_vuln("CVE-2024-0001", Severity::High)],
+            )],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![make_vuln("CVE-2024-0001", Severity::High)],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.30.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        // (requests, 2.30.0, CVE-2024-0001) resolved; (requests, 2.31.0, CVE-2024-0001) is new
+        assert_eq!(delta.new.len(), 1);
+        assert_eq!(delta.resolved.len(), 1);
+        assert_eq!(delta.new[0].version, "2.31.0");
+        assert_eq!(delta.resolved[0].version, "2.30.0");
     }
 }

--- a/src/application/use_cases/test_doubles.rs
+++ b/src/application/use_cases/test_doubles.rs
@@ -7,6 +7,43 @@ use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+/// Mock VulnerabilityRepository that returns pre-configured responses in order.
+///
+/// Each call to `fetch_vulnerabilities` pops the next response from the queue.
+/// Designed for testing `GenerateDiffUseCase`'s CVE delta computation, where the
+/// use case calls `fetch_vulnerabilities` twice — once for base packages and once
+/// for current packages — in sequential order.
+#[derive(Clone, Default)]
+pub(crate) struct PairedMockVulnerabilityRepository {
+    queue: Arc<Mutex<VecDeque<Vec<PackageVulnerabilities>>>>,
+}
+
+impl PairedMockVulnerabilityRepository {
+    /// Creates a mock that returns `base_response` on the first call and
+    /// `current_response` on the second call.
+    pub fn new(
+        base_response: Vec<PackageVulnerabilities>,
+        current_response: Vec<PackageVulnerabilities>,
+    ) -> Self {
+        let mut queue = VecDeque::new();
+        queue.push_back(base_response);
+        queue.push_back(current_response);
+        Self {
+            queue: Arc::new(Mutex::new(queue)),
+        }
+    }
+}
+
+#[async_trait]
+impl VulnerabilityRepository for PairedMockVulnerabilityRepository {
+    async fn fetch_vulnerabilities(
+        &self,
+        _packages: Vec<Package>,
+    ) -> Result<Vec<PackageVulnerabilities>> {
+        Ok(self.queue.lock().unwrap().pop_front().unwrap_or_default())
+    }
+}
+
 /// Configurable in-memory mock implementing `MaintenanceRepository`.
 ///
 /// Each call to `fetch_maintenance_info` pops the next response from the queue.

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,9 +504,6 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
 ///
 /// Returns `Ok(true)` if vulnerabilities were detected in new/updated packages
 /// and CVE checking is enabled, `Ok(false)` otherwise.
-///
-/// Note: CVE enrichment is currently a no-op in `GenerateDiffUseCase::execute`,
-/// so this will always return `Ok(false)` until a follow-up issue wires it in.
 async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     display_banner();
 
@@ -525,13 +522,22 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         check_cve,
     };
 
-    // execute() is synchronous — call directly without .await
-    let use_case = GenerateDiffUseCase::new(FileSystemReader::new(), GitLockfileReader::new());
-    let diff = use_case.execute(request)?;
+    let vulnerability_repository = if check_cve {
+        Some(OsvClient::new()?)
+    } else {
+        None
+    };
+    let use_case = GenerateDiffUseCase::new(
+        FileSystemReader::new(),
+        GitLockfileReader::new(),
+        vulnerability_repository,
+    );
+    let result = use_case.execute(request).await?;
+    let diff = &result.diff;
 
     let formatted = match merged.format {
-        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(&diff),
-        OutputFormat::Json => DiffJsonFormatter::new().format(&diff)?,
+        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(diff),
+        OutputFormat::Json => DiffJsonFormatter::new().format(diff)?,
     };
 
     let presenter_type = if let Some(output_path) = args.output {
@@ -542,5 +548,6 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted)?;
 
+    // TODO(#600): incorporate result.cve_delta into exit-code logic once formatter wires it in
     Ok(diff.changes.iter().any(|c| c.vulnerability_count > 0) && check_cve)
 }

--- a/src/sbom_generation/domain/vulnerability.rs
+++ b/src/sbom_generation/domain/vulnerability.rs
@@ -111,6 +111,11 @@ impl Vulnerability {
     pub fn fixed_version(&self) -> Option<&str> {
         self.fixed_version.as_deref()
     }
+
+    /// Returns the summary if available
+    pub fn summary(&self) -> Option<&str> {
+        self.summary.as_deref()
+    }
 }
 
 /// Severity levels based on CVSS scores


### PR DESCRIPTION
## Summary

- Add a third generic parameter `VR: VulnerabilityRepository` (default `()`) to `GenerateDiffUseCase`, converting `execute()` to `async`
- When `check_cve` is true and a `VulnerabilityRepository` is supplied, run OSV checks on both base and current package sets and compute CVE delta via set-difference keyed on `(package_name, version, cve_id)`
- Introduce `DiffResult` application-layer wrapper (domain `DependencyDiff` + `Option<CveDeltaView>`) to preserve the hex-arch invariant that the domain layer must not depend on application read-model types

## Related Issue

Closes #599
Part of #596

## Changes Made

- **`src/application/use_cases/generate_diff.rs`**: Add `VR` generic param, async `execute()`, `compute_cve_delta()`, `flatten_to_entries()`, convert all tests to `#[tokio::test]`, add 5 new CVE delta tests
- **`src/application/dto/diff_result.rs`** (new): `DiffResult { diff: DependencyDiff, cve_delta: Option<CveDeltaView> }` application-layer result wrapper
- **`src/application/read_models/vulnerability_view.rs`**: Add `From<Severity> for SeverityView` as the single canonical severity-mapping conversion
- **`src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs`**: Remove duplicated `map_severity`; use `SeverityView::from()` instead
- **`src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs`**: Use `SeverityView::from()` instead of `map_severity`
- **`src/application/use_cases/test_doubles.rs`**: Add `PairedMockVulnerabilityRepository` for sequential OSV call testing
- **`src/application/read_models/cve_delta_view.rs`**: Remove `WIRE(#599)` annotations; retain `WIRE(#600)` until diff formatters consume `cve_delta`
- **`src/main.rs`**: Wire `Option<OsvClient>` into `GenerateDiffUseCase::new()`, `.await` the `execute()` call
- **`src/sbom_generation/domain/vulnerability.rs`**: Add `summary()` getter

## Architectural Note

`DependencyDiff` (domain) was NOT given a `cve_delta` field to avoid a domain → application read-model dependency. `DiffResult` at the application layer wraps both, consistent with the existing `SbomResponse` pattern.

## WIRE Annotations

This PR retains `#[allow(dead_code)] // WIRE(#600)` on `CveDeltaView` and `CveDeltaEntry` fields because diff formatters do not yet consume `cve_delta`. Issue #600 will remove these annotations via the Step 4.0 cleanup gate.

> ⚠️ CHANGELOG not updated — this PR is an internal stepping stone. `CveDeltaView` is computed but not yet rendered. CHANGELOG will be updated in #600 when the feature becomes user-visible.

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo test --all-targets --all-features` passes
- [x] 5 new CVE delta tests: new CVE, resolved CVE, no-change, version-keyed, check_cve=false skip

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)