### PR TITLE
docs: document CVE delta section for --diff mode in README

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -522,12 +522,37 @@ uv-sbom --diff main --format json
 
 **排他制約:** `--diff` は `--workspace` または `--init` と同時に使用できません。
 
-**CVEチェック:** デフォルトでは追加・更新されたパッケージのCVEチェックが有効です（`--no-check-cve` で無効化）。脆弱性が見つかった場合、プロセスはコード `1` で終了します。
+#### CVEデルタ
+
+デフォルトでは、`--diff` はベースおよび現在のロックファイル両方に対して脆弱性チェックも実行し、導入または解消された脆弱性を示す **CVEデルタ** セクションをレポートに追加します：
+
+- **新規脆弱性** — 現在のロックファイルのパッケージに影響するが、ベースには存在しなかったCVE。
+- **解消済み脆弱性** — ベースのロックファイルのパッケージに影響していたが、現在は適用されなくなったCVE。
+
+```bash
+# CVEデルタ付きのDiff（デフォルト — CVEチェックは有効）
+uv-sbom --diff main
+
+# diffモードでCVEチェックを無効化
+uv-sbom --diff main --no-check-cve
+```
+
+JSON出力にはトップレベルの `cve_delta` キーが `new` と `resolved` 配列とともに追加されます。`--no-check-cve` を指定した場合、このキーは出力から省略されます。
+
+**重大度およびCVSSフィルタリング:** `--severity-threshold` と `--cvss-threshold` はCVEデルタにも適用されます。しきい値以上のエントリのみがテーブルに表示されます。設定したしきい値を超える新規CVEが導入された場合、プロセスはコード `1` で終了します。
+
+```bash
+# HIGH以上のCVEデルタエントリのみ表示
+uv-sbom --diff main --severity-threshold high
+
+# CVSS ≥ 7.0 のCVEデルタエントリのみ表示
+uv-sbom --diff main --cvss-threshold 7.0
+```
 
 **CI例:**
 ```bash
-# このPRで新規追加された依存関係に既知のCVEがある場合にビルドを失敗させる
-uv-sbom --diff origin/main --format markdown --output diff.md
+# このPRで新規追加された依存関係にHIGH以上の既知のCVEがある場合にビルドを失敗させる
+uv-sbom --diff origin/main --format markdown --output diff.md --severity-threshold high
 ```
 
 ### CI統合

--- a/README.md
+++ b/README.md
@@ -526,12 +526,37 @@ uv-sbom --diff main --format json
 
 **Mutual exclusion:** `--diff` cannot be combined with `--workspace` or `--init`.
 
-**CVE check:** By default CVE checking is enabled for added and updated packages (use `--no-check-cve` to disable). When a vulnerability is found, the process exits with code `1`.
+#### CVE Delta
+
+By default, `--diff` also runs vulnerability checks on both the base and current lock files and appends a **CVE Delta** section to the report showing which vulnerabilities were introduced or resolved:
+
+- **New vulnerabilities** — CVEs that affect packages in the current lock but were not present in the base.
+- **Resolved vulnerabilities** — CVEs that affected packages in the base lock but no longer apply.
+
+```bash
+# Diff with CVE delta (default — CVE checking is on)
+uv-sbom --diff main
+
+# Disable CVE checking in diff mode
+uv-sbom --diff main --no-check-cve
+```
+
+JSON output includes a top-level `cve_delta` key with `new` and `resolved` arrays. The key is omitted entirely when `--no-check-cve` is passed.
+
+**Severity and CVSS filtering:** `--severity-threshold` and `--cvss-threshold` apply to the CVE delta. Only entries at or above the threshold appear in the tables. The process exits with code `1` when new CVEs above the configured threshold are introduced.
+
+```bash
+# Show only HIGH and above CVE delta entries
+uv-sbom --diff main --severity-threshold high
+
+# Show only CVE delta entries with CVSS ≥ 7.0
+uv-sbom --diff main --cvss-threshold 7.0
+```
 
 **CI example:**
 ```bash
-# Fail the build if new dependencies introduced by this PR have known CVEs
-uv-sbom --diff origin/main --format markdown --output diff.md
+# Fail the build if new dependencies introduced by this PR have known HIGH+ CVEs
+uv-sbom --diff origin/main --format markdown --output diff.md --severity-threshold high
 ```
 
 ### CI Integration


### PR DESCRIPTION
## Summary
- Replace the one-line `**CVE check:**` note in the Dependency Diff section with a full `#### CVE Delta` subsection in both `README.md` and `README-JP.md`
- Documents the new CVE delta output, how to disable it with `--no-check-cve`, and how `--severity-threshold`/`--cvss-threshold` filter the delta entries
- Updates the CI example to show a threshold-aware command

## Related Issue
Closes #602
Part of #596

## Changes Made
- `README.md` — new `#### CVE Delta` subsection under `### Dependency Diff` covering: default-on behavior, `--no-check-cve`, JSON `cve_delta` key omission, severity/CVSS filtering, exit code semantics, and updated CI example
- `README-JP.md` — full Japanese translation of the above changes (`#### CVEデルタ` subsection)

## Test Plan
- [x] `cargo fmt --all -- --check` passes (documentation-only change)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib` passes (758 tests, all green)

---
Generated with [Claude Code](https://claude.com/claude-code)