### PR TITLE
fix(cli): show progress indicator during CVE lookup in diff mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CVE Delta section in `--diff` output**: When `--diff` is used with CVE checking enabled, the Markdown output now includes a `## CVE Delta` section with separate tables for newly introduced and resolved vulnerabilities. The JSON output gains a top-level `cve_delta` key with `new` and `resolved` arrays. Both formatters omit the section when `--no-check-cve` is passed, preserving backward-compatible output (#600).
 - **Severity and CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries in `--diff` output. Only entries at or above the threshold appear in the `new` and `resolved` tables. A non-zero exit code is returned when new CVEs above threshold are introduced (#601).
 
+### Fixed
+- **Progress indicator in `--diff` CVE lookup**: Running `uv-sbom --diff <ref>` now prints a progress message (`🔍 Fetching vulnerability information...`) to stderr before the OSV API calls begin, consistent with the UX in SBOM mode. No message is printed when `--no-check-cve` is passed (#611).
+
 ## [2.4.0] - 2026-05-21
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,6 +534,10 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         GitLockfileReader::new(),
         vulnerability_repository,
     );
+    if check_cve {
+        let msgs = Messages::for_locale(locale);
+        eprintln!("{}", msgs.progress_fetching_vulns);
+    }
     let result = use_case.execute(request).await?;
     let diff = &result.diff;
     let cve_delta = result.cve_delta.as_ref();


### PR DESCRIPTION
## Summary

- Add a progress message (`🔍 Fetching vulnerability information...`) to stderr in `--diff` mode before OSV API calls begin
- Message is guarded by `check_cve`; suppressed when `--no-check-cve` is passed
- Locale-aware via the existing `msgs.progress_fetching_vulns` i18n key (EN + JA)

## Related Issue

Closes #611

This was the sole unmet acceptance criterion for Issue #596 (CVE Delta in `--diff` mode), identified during post-implementation evaluation.

## Changes Made

- `src/main.rs`: 4-line block added in `run_diff` between use-case construction and `execute()` call
- `CHANGELOG.md`: `### Fixed` entry added under `[Unreleased]`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (765 tests, 0 failed)

---
Generated with [Claude Code](https://claude.com/claude-code)