### PR TITLE
fix(application): add indicatif progress bar during CVE lookup in diff mode (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Progress indicator in `--diff` CVE lookup**: Running `uv-sbom --diff <ref>` now prints a progress message (`🔍 Fetching vulnerability information...`) to stderr before the OSV API calls begin, consistent with the UX in SBOM mode. No message is printed when `--no-check-cve` is passed (#611).
+- **indicatif progress bar during CVE lookup in `--diff` mode**: The OSV vulnerability lookup in `--diff` mode now displays an indicatif spinner and per-package progress bar (identical to SBOM mode) for both the base and current lockfile phases. Previously the lookup silently waited with no progress feedback after the initial message (#613).
 
 ## [2.4.0] - 2026-05-21
 

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -125,7 +125,9 @@ async fn compute_cve_delta<VR: VulnerabilityRepository + Clone>(
 
     eprintln!("{}", msgs.progress_diff_checking_current);
     let current_use_case = CheckVulnerabilitiesUseCase::new(repo.clone());
-    let current_vulns = current_use_case.check_with_progress(current.to_vec()).await?;
+    let current_vulns = current_use_case
+        .check_with_progress(current.to_vec())
+        .await?;
     eprintln!();
 
     let base_map = flatten_to_entries(&base_vulns, threshold);

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -1,6 +1,8 @@
 use crate::application::dto::{DiffRequest, DiffResult};
 use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
 use crate::application::read_models::vulnerability_view::SeverityView;
+use crate::application::use_cases::CheckVulnerabilitiesUseCase;
+use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::{
     DiffLockfileReader, DiffSource, LockfileReader, VulnerabilityRepository,
 };
@@ -15,33 +17,38 @@ use std::collections::{HashMap, HashSet};
 /// `LR` reads the current `uv.lock`, `DLR` reads the base lockfile (git ref or
 /// file path), and `VR` fetches OSV vulnerability data. `VR` defaults to `()`
 /// (the Null Object implementation) when CVE checking is not needed.
+/// `VR` must be `Clone` because `compute_cve_delta` creates two
+/// `CheckVulnerabilitiesUseCase` instances (one for base, one for current).
 pub struct GenerateDiffUseCase<LR, DLR, VR = ()>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
-    VR: VulnerabilityRepository,
+    VR: VulnerabilityRepository + Clone,
 {
     lockfile_reader: LR,
     diff_reader: DLR,
     vulnerability_repository: Option<VR>,
+    locale: Locale,
 }
 
 impl<LR, DLR, VR> GenerateDiffUseCase<LR, DLR, VR>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
-    VR: VulnerabilityRepository,
+    VR: VulnerabilityRepository + Clone,
 {
-    /// Creates a new [`GenerateDiffUseCase`] with the given readers and optional vulnerability repository.
+    /// Creates a new [`GenerateDiffUseCase`] with the given readers, optional vulnerability repository, and locale.
     pub fn new(
         lockfile_reader: LR,
         diff_reader: DLR,
         vulnerability_repository: Option<VR>,
+        locale: Locale,
     ) -> Self {
         Self {
             lockfile_reader,
             diff_reader,
             vulnerability_repository,
+            locale,
         }
     }
 
@@ -81,7 +88,9 @@ where
 
         let cve_delta = if request.check_cve {
             match &self.vulnerability_repository {
-                Some(repo) => Some(compute_cve_delta(repo, &base, &current, &threshold).await?),
+                Some(repo) => {
+                    Some(compute_cve_delta(repo, &base, &current, &threshold, self.locale).await?)
+                }
                 None => None,
             }
         } else {
@@ -92,21 +101,32 @@ where
     }
 }
 
-/// Fetches OSV vulnerability data for `base` and `current` package sets sequentially,
-/// then computes the set difference keyed on `(package_name, version, cve_id)`.
-/// Sequential fetching is intentional: OSV API rate limits make parallel calls
-/// counter-productive, and it simplifies mock ordering in tests.
+/// Fetches OSV vulnerability data for `base` and `current` package sets sequentially
+/// using `CheckVulnerabilitiesUseCase::check_with_progress`, which displays an indicatif
+/// spinner/progress bar identical to SBOM mode. Sequential fetching is intentional:
+/// OSV API rate limits make parallel calls counter-productive, and it simplifies mock
+/// ordering in tests.
 ///
 /// Both base and current maps are filtered by `threshold` before the set difference
 /// is computed, so below-threshold CVEs never appear in either `new` or `resolved`.
-async fn compute_cve_delta<VR: VulnerabilityRepository>(
+async fn compute_cve_delta<VR: VulnerabilityRepository + Clone>(
     repo: &VR,
     base: &[Package],
     current: &[Package],
     threshold: &ThresholdConfig,
+    locale: Locale,
 ) -> Result<CveDeltaView> {
-    let base_vulns = repo.fetch_vulnerabilities(base.to_vec()).await?;
-    let current_vulns = repo.fetch_vulnerabilities(current.to_vec()).await?;
+    let msgs = Messages::for_locale(locale);
+
+    eprintln!("{}", msgs.progress_diff_checking_base);
+    let base_use_case = CheckVulnerabilitiesUseCase::new(repo.clone());
+    let base_vulns = base_use_case.check_with_progress(base.to_vec()).await?;
+    eprintln!();
+
+    eprintln!("{}", msgs.progress_diff_checking_current);
+    let current_use_case = CheckVulnerabilitiesUseCase::new(repo.clone());
+    let current_vulns = current_use_case.check_with_progress(current.to_vec()).await?;
+    eprintln!();
 
     let base_map = flatten_to_entries(&base_vulns, threshold);
     let current_map = flatten_to_entries(&current_vulns, threshold);
@@ -165,6 +185,7 @@ fn flatten_to_entries(
 mod tests {
     use super::*;
     use crate::application::use_cases::test_doubles::PairedMockVulnerabilityRepository;
+    use crate::i18n::Locale;
     use crate::ports::outbound::lockfile_reader::LockfileParseResult;
     use crate::sbom_generation::domain::dependency_diff::ChangeType;
     use crate::sbom_generation::domain::vulnerability::{Severity, Vulnerability};
@@ -232,6 +253,7 @@ mod tests {
             StubLockfileReader { packages: current },
             StubDiffLockfileReader { packages: base },
             None,
+            Locale::En,
         )
     }
 
@@ -248,6 +270,7 @@ mod tests {
             StubLockfileReader { packages: current },
             StubDiffLockfileReader { packages: base },
             Some(repo),
+            Locale::En,
         )
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -58,6 +58,8 @@ pub struct Messages {
     pub progress_verifying_links: &'static str,
     pub progress_fetching_license: &'static str,
     pub progress_fetching_vulns: &'static str,
+    pub progress_diff_checking_base: &'static str,
+    pub progress_diff_checking_current: &'static str,
 
     // Progress messages (use case layer)
     pub progress_loading_lockfile: &'static str,
@@ -241,6 +243,8 @@ static EN_MESSAGES: Messages = Messages {
     progress_verifying_links: "🔗 Verifying PyPI links...",
     progress_fetching_license: "🔍 Fetching license information...",
     progress_fetching_vulns: "🔍 Fetching vulnerability information...",
+    progress_diff_checking_base: "🔍 Checking vulnerabilities in base lockfile...",
+    progress_diff_checking_current: "🔍 Checking vulnerabilities in current lockfile...",
 
     // Progress messages (use case layer)
     progress_loading_lockfile: "📖 Loading uv.lock file from: {}",
@@ -393,6 +397,8 @@ static JA_MESSAGES: Messages = Messages {
     progress_verifying_links: "🔗 PyPIリンクを検証中...",
     progress_fetching_license: "🔍 ライセンス情報を取得中...",
     progress_fetching_vulns: "🔍 脆弱性情報を取得中...",
+    progress_diff_checking_base: "🔍 ベースロックファイルの脆弱性をチェック中...",
+    progress_diff_checking_current: "🔍 現在のロックファイルの脆弱性をチェック中...",
 
     // Progress messages (use case layer)
     progress_loading_lockfile: "📖 uv.lockファイルを読み込み中: {}",
@@ -645,6 +651,32 @@ mod tests {
         assert_eq!(
             msgs.progress_license_unknown_packages,
             "⚠️  ライセンスコンプライアンス: ライセンス不明のパッケージが{}件あります"
+        );
+    }
+
+    #[test]
+    fn test_diff_progress_messages_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(
+            msgs.progress_diff_checking_base,
+            "🔍 Checking vulnerabilities in base lockfile..."
+        );
+        assert_eq!(
+            msgs.progress_diff_checking_current,
+            "🔍 Checking vulnerabilities in current lockfile..."
+        );
+    }
+
+    #[test]
+    fn test_diff_progress_messages_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(
+            msgs.progress_diff_checking_base,
+            "🔍 ベースロックファイルの脆弱性をチェック中..."
+        );
+        assert_eq!(
+            msgs.progress_diff_checking_current,
+            "🔍 現在のロックファイルの脆弱性をチェック中..."
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,11 +533,8 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         FileSystemReader::new(),
         GitLockfileReader::new(),
         vulnerability_repository,
+        locale,
     );
-    if check_cve {
-        let msgs = Messages::for_locale(locale);
-        eprintln!("{}", msgs.progress_fetching_vulns);
-    }
     let result = use_case.execute(request).await?;
     let diff = &result.diff;
     let cve_delta = result.cve_delta.as_ref();


### PR DESCRIPTION
## Summary

- Replace bare `fetch_vulnerabilities` calls in `compute_cve_delta` with `CheckVulnerabilitiesUseCase::check_with_progress`, displaying an indicatif spinner identical to SBOM mode for both base and current lockfile OSV lookup phases
- Add `locale: Locale` field to `GenerateDiffUseCase` and thread it through to `compute_cve_delta` so progress messages are emitted via the i18n system
- Add `progress_diff_checking_base` and `progress_diff_checking_current` message keys to `EN_MESSAGES` and `JA_MESSAGES` with unit tests

## Related Issue

Closes #613

## Changes Made

- `src/application/use_cases/generate_diff.rs`: Store `locale: Locale` in struct; rewrite `compute_cve_delta` to use `CheckVulnerabilitiesUseCase::check_with_progress` with i18n phase labels; add `Clone` bound to `VR`
- `src/i18n/mod.rs`: Add `progress_diff_checking_base` and `progress_diff_checking_current` to `Messages`, `EN_MESSAGES`, `JA_MESSAGES`, and test module
- `src/main.rs`: Pass `locale` to `GenerateDiffUseCase::new`; remove now-redundant pre-call `eprintln!`
- `CHANGELOG.md`: Add `### Fixed` entry for #613

## Test Plan

- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)