### PR TITLE
fix(adapters): apply --lang flag to --diff Markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Severity and CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries in `--diff` output. Only entries at or above the threshold appear in the `new` and `resolved` tables. A non-zero exit code is returned when new CVEs above threshold are introduced (#601).
 
 ### Fixed
+- **`--lang` flag now applies to `--diff -f markdown` output**: Section headings, column headers, change-type labels, and CVE Delta labels are now rendered in the selected locale. Previously all strings were hardcoded English regardless of `--lang ja` (#615).
 - **Progress indicator in `--diff` CVE lookup**: Running `uv-sbom --diff <ref>` now prints a progress message (`🔍 Fetching vulnerability information...`) to stderr before the OSV API calls begin, consistent with the UX in SBOM mode. No message is printed when `--no-check-cve` is passed (#611).
 - **indicatif progress bar during CVE lookup in `--diff` mode**: The OSV vulnerability lookup in `--diff` mode now displays an indicatif spinner and per-package progress bar (identical to SBOM mode) for both the base and current lockfile phases. Previously the lookup silently waited with no progress feedback after the initial message (#613).
 

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -43,9 +43,19 @@ impl DiffMarkdownFormatter {
 
         writeln!(out, "{}", msgs.diff_section_summary).unwrap();
         writeln!(out).unwrap();
-        writeln!(out, "| {} | {} |", msgs.diff_col_metric, msgs.diff_col_count).unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_col_metric, msgs.diff_col_count
+        )
+        .unwrap();
         writeln!(out, "|--------|-------|").unwrap();
-        writeln!(out, "| {} | {} |", msgs.diff_label_added, diff.summary.added).unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_added, diff.summary.added
+        )
+        .unwrap();
         writeln!(
             out,
             "| {} | {} |",
@@ -593,14 +603,7 @@ mod tests {
     fn test_ja_change_type_labels() {
         let diff = make_diff(vec![
             make_change("pkg-a", ChangeType::Added, None, Some("1.0.0"), None, 0),
-            make_change(
-                "pkg-b",
-                ChangeType::Removed,
-                Some("1.0.0"),
-                None,
-                None,
-                0,
-            ),
+            make_change("pkg-b", ChangeType::Removed, Some("1.0.0"), None, None, 0),
             make_change(
                 "pkg-c",
                 ChangeType::Updated,

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -2,6 +2,7 @@ use std::fmt::Write;
 
 use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
 use crate::application::read_models::vulnerability_view::SeverityView;
+use crate::i18n::{Locale, Messages};
 use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff, PackageChange};
 
 /// Formats a `DependencyDiff` as a human-readable Markdown report.
@@ -9,42 +10,73 @@ use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff
 /// Produces a two-section report: a summary table with aggregate counts, and a
 /// changes table listing every package with its change type, versions, license,
 /// and vulnerability count.
-pub struct DiffMarkdownFormatter;
+pub struct DiffMarkdownFormatter {
+    messages: &'static Messages,
+}
 
 impl DiffMarkdownFormatter {
-    /// Creates a new `DiffMarkdownFormatter`.
-    pub fn new() -> Self {
-        Self
+    /// Creates a new `DiffMarkdownFormatter` for the given locale.
+    pub fn new(locale: Locale) -> Self {
+        Self {
+            messages: Messages::for_locale(locale),
+        }
     }
 
     /// Formats `diff` as a Markdown string. This operation is infallible.
     ///
-    /// When `cve_delta` is `Some`, a `## CVE Delta` section is appended with tables
+    /// When `cve_delta` is `Some`, a CVE Delta section is appended with tables
     /// for newly introduced and resolved vulnerabilities. When `None`, the section
     /// is omitted entirely (e.g., when `--no-check-cve` was passed).
     pub fn format(&self, diff: &DependencyDiff, cve_delta: Option<&CveDeltaView>) -> String {
+        let msgs = self.messages;
         let mut out = String::new();
 
-        writeln!(out, "## Dependency Diff Report").unwrap();
-        writeln!(out).unwrap();
-        writeln!(out, "Compared: `{}` vs current `uv.lock`", diff.base_ref).unwrap();
-        writeln!(out).unwrap();
-
-        writeln!(out, "### Summary").unwrap();
-        writeln!(out).unwrap();
-        writeln!(out, "| Metric | Count |").unwrap();
-        writeln!(out, "|--------|-------|").unwrap();
-        writeln!(out, "| Added | {} |", diff.summary.added).unwrap();
-        writeln!(out, "| Removed | {} |", diff.summary.removed).unwrap();
-        writeln!(out, "| Updated | {} |", diff.summary.updated).unwrap();
-        writeln!(out, "| Unchanged | {} |", diff.summary.unchanged).unwrap();
-        writeln!(out).unwrap();
-
-        writeln!(out, "### Changes").unwrap();
+        writeln!(out, "{}", msgs.diff_section_title).unwrap();
         writeln!(out).unwrap();
         writeln!(
             out,
-            "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
+            "{}",
+            Messages::format(msgs.diff_compared_line, &[&diff.base_ref])
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "{}", msgs.diff_section_summary).unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "| {} | {} |", msgs.diff_col_metric, msgs.diff_col_count).unwrap();
+        writeln!(out, "|--------|-------|").unwrap();
+        writeln!(out, "| {} | {} |", msgs.diff_label_added, diff.summary.added).unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_removed, diff.summary.removed
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_updated, diff.summary.updated
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_unchanged, diff.summary.unchanged
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "{}", msgs.diff_section_changes).unwrap();
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "| {} | {} | {} | {} | {} | {} |",
+            msgs.col_package,
+            msgs.diff_col_change,
+            msgs.diff_col_old_version,
+            msgs.diff_col_new_version,
+            msgs.col_license,
+            msgs.diff_col_vulnerabilities,
         )
         .unwrap();
         writeln!(
@@ -54,44 +86,34 @@ impl DiffMarkdownFormatter {
         .unwrap();
 
         for change in &diff.changes {
-            writeln!(out, "{}", format_change_row(change)).unwrap();
+            writeln!(out, "{}", format_change_row(change, msgs)).unwrap();
         }
 
         if let Some(delta) = cve_delta {
             writeln!(out).unwrap();
-            writeln!(out, "## CVE Delta").unwrap();
+            writeln!(out, "{}", msgs.diff_section_cve_delta).unwrap();
             writeln!(out).unwrap();
 
-            writeln!(out, "### 🔴 New Vulnerabilities ({})", delta.new.len()).unwrap();
-            writeln!(out).unwrap();
-            writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
-            writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
-            if delta.new.is_empty() {
-                writeln!(out, "| — | — | — | — | No new vulnerabilities |").unwrap();
-            } else {
-                for entry in &delta.new {
-                    writeln!(out, "{}", format_cve_row(entry)).unwrap();
-                }
-            }
+            writeln!(
+                out,
+                "{}",
+                Messages::format(msgs.diff_new_vulns_header, &[&delta.new.len().to_string()])
+            )
+            .unwrap();
+            write_cve_subsection(&mut out, &delta.new, msgs.diff_no_new_vulns);
 
             writeln!(out).unwrap();
 
             writeln!(
                 out,
-                "### ✅ Resolved Vulnerabilities ({})",
-                delta.resolved.len()
+                "{}",
+                Messages::format(
+                    msgs.diff_resolved_vulns_header,
+                    &[&delta.resolved.len().to_string()]
+                )
             )
             .unwrap();
-            writeln!(out).unwrap();
-            writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
-            writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
-            if delta.resolved.is_empty() {
-                writeln!(out, "| — | — | — | — | No resolved vulnerabilities |").unwrap();
-            } else {
-                for entry in &delta.resolved {
-                    writeln!(out, "{}", format_cve_row(entry)).unwrap();
-                }
-            }
+            write_cve_subsection(&mut out, &delta.resolved, msgs.diff_no_resolved_vulns);
         }
 
         out
@@ -100,21 +122,34 @@ impl DiffMarkdownFormatter {
 
 impl Default for DiffMarkdownFormatter {
     fn default() -> Self {
-        Self::new()
+        Self::new(Locale::En)
     }
 }
 
-fn format_change_row(change: &PackageChange) -> String {
+fn write_cve_subsection(out: &mut String, entries: &[CveDeltaEntry], empty_label: &str) {
+    writeln!(out).unwrap();
+    writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
+    writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
+    if entries.is_empty() {
+        writeln!(out, "| — | — | — | — | {} |", empty_label).unwrap();
+    } else {
+        for entry in entries {
+            writeln!(out, "{}", format_cve_row(entry)).unwrap();
+        }
+    }
+}
+
+fn format_change_row(change: &PackageChange, msgs: &Messages) -> String {
     let change_label = match change.change_type {
-        ChangeType::Added => "Added",
-        ChangeType::Removed => "Removed",
-        ChangeType::Updated => "Updated",
-        ChangeType::Unchanged => "Unchanged",
+        ChangeType::Added => msgs.diff_label_added,
+        ChangeType::Removed => msgs.diff_label_removed,
+        ChangeType::Updated => msgs.diff_label_updated,
+        ChangeType::Unchanged => msgs.diff_label_unchanged,
     };
     let old = version_cell(&change.old_version);
     let new = version_cell(&change.new_version);
     let license = version_cell(&change.license);
-    let vulns = vuln_cell(&change.change_type, change.vulnerability_count);
+    let vulns = vuln_cell(&change.change_type, change.vulnerability_count, msgs);
     format!(
         "| {} | {} | {} | {} | {} | {} |",
         change.package_name, change_label, old, new, license, vulns
@@ -143,12 +178,12 @@ fn version_cell(opt: &Option<String>) -> &str {
     opt.as_deref().unwrap_or("-")
 }
 
-fn vuln_cell(change_type: &ChangeType, count: usize) -> String {
+fn vuln_cell(change_type: &ChangeType, count: usize, msgs: &Messages) -> String {
     if matches!(change_type, ChangeType::Removed) {
         return "-".to_string();
     }
     if count == 0 {
-        "None".to_string()
+        msgs.diff_vuln_none.to_string()
     } else {
         count.to_string()
     }
@@ -159,6 +194,7 @@ mod tests {
     use super::*;
     use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
     use crate::application::read_models::vulnerability_view::SeverityView;
+    use crate::i18n::Locale;
     use crate::sbom_generation::domain::dependency_diff::{
         ChangeType, DependencyDiff, DiffSummary, PackageChange,
     };
@@ -226,7 +262,7 @@ mod tests {
     #[test]
     fn test_header_and_compared_line() {
         let diff = make_diff(vec![]);
-        let formatter = DiffMarkdownFormatter::new();
+        let formatter = DiffMarkdownFormatter::new(Locale::En);
         let md = formatter.format(&diff, None);
 
         assert!(md.contains("## Dependency Diff Report"));
@@ -245,7 +281,7 @@ mod tests {
                 unchanged: 45,
             },
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| Added | 2 |"));
         assert!(md.contains("| Removed | 1 |"));
@@ -256,7 +292,7 @@ mod tests {
     #[test]
     fn test_changes_table_header_always_present() {
         let diff = make_diff(vec![]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains(
             "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
@@ -276,7 +312,7 @@ mod tests {
             Some("MIT"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| pydantic | Added | - | 2.9.0 | MIT | None |"));
     }
@@ -291,7 +327,7 @@ mod tests {
             Some("BSD-3-Clause"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| flask | Removed | 3.0.0 | - | BSD-3-Clause | - |"));
     }
@@ -306,7 +342,7 @@ mod tests {
             Some("Apache-2.0"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| requests | Updated | 2.31.0 | 2.32.0 | Apache-2.0 | None |"));
     }
@@ -321,7 +357,7 @@ mod tests {
             Some("MIT"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| urllib3 | Unchanged | 1.26.0 | 1.26.0 | MIT | None |"));
     }
@@ -336,7 +372,7 @@ mod tests {
             None,
             3,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| vuln-pkg | Updated | 1.0.0 | 1.1.0 | - | 3 |"));
     }
@@ -351,7 +387,7 @@ mod tests {
             None,
             5,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| gone | Removed | 1.0.0 | - | - | - |"));
     }
@@ -366,7 +402,7 @@ mod tests {
             None,
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| nolic | Added | - | 0.1.0 | - | None |"));
     }
@@ -383,7 +419,7 @@ mod tests {
                 unchanged: 0,
             },
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
         let summary_pos = md.find("### Summary").unwrap();
         let changes_pos = md.find("### Changes").unwrap();
         assert!(summary_pos < changes_pos);
@@ -392,7 +428,7 @@ mod tests {
     #[test]
     fn test_cve_delta_section_absent_when_none() {
         let diff = make_diff(vec![]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(!md.contains("## CVE Delta"));
     }
@@ -401,7 +437,7 @@ mod tests {
     fn test_cve_delta_section_present_with_empty_lists() {
         let diff = make_diff(vec![]);
         let delta = CveDeltaView::default();
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("## CVE Delta"));
         assert!(md.contains("### 🔴 New Vulnerabilities (0)"));
@@ -423,7 +459,7 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("### 🔴 New Vulnerabilities (1)"));
         assert!(md.contains(
@@ -444,7 +480,7 @@ mod tests {
                 "Fixed in 2.31.0",
             )],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("### ✅ Resolved Vulnerabilities (1)"));
         assert!(md.contains("| requests | 2.28.0 | CVE-2023-32681 | MEDIUM | Fixed in 2.31.0 |"));
@@ -457,7 +493,7 @@ mod tests {
             new: vec![make_entry("pkg", "1.0.0", "CVE-2024-0001", None, "desc")],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("| pkg | 1.0.0 | CVE-2024-0001 | UNKNOWN | desc |"));
     }
@@ -475,7 +511,7 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("| pkg | 1.0.0 | CVE-2024-0002 | NONE | desc |"));
     }
@@ -493,7 +529,7 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("see CVE \\| NVD"));
     }
@@ -502,10 +538,148 @@ mod tests {
     fn test_cve_delta_section_after_changes_section() {
         let diff = make_diff(vec![]);
         let delta = CveDeltaView::default();
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         let changes_pos = md.find("### Changes").unwrap();
         let cve_pos = md.find("## CVE Delta").unwrap();
         assert!(changes_pos < cve_pos);
+    }
+
+    // Japanese locale tests
+
+    #[test]
+    fn test_ja_section_titles() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("## 依存関係差分レポート"));
+        assert!(md.contains("比較: `main` と現在の `uv.lock`"));
+        assert!(md.contains("### サマリー"));
+        assert!(md.contains("### 変更一覧"));
+    }
+
+    #[test]
+    fn test_ja_summary_table_labels() {
+        let diff = DependencyDiff {
+            base_ref: "v0.1.0".to_string(),
+            changes: vec![],
+            summary: DiffSummary {
+                added: 3,
+                removed: 1,
+                updated: 2,
+                unchanged: 10,
+            },
+        };
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("| 指標 | 件数 |"));
+        assert!(md.contains("| 追加 | 3 |"));
+        assert!(md.contains("| 削除 | 1 |"));
+        assert!(md.contains("| 更新 | 2 |"));
+        assert!(md.contains("| 変更なし | 10 |"));
+    }
+
+    #[test]
+    fn test_ja_changes_table_column_headers() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains(
+            "| パッケージ | 変更種別 | 旧バージョン | 新バージョン | ライセンス | 脆弱性 |"
+        ));
+    }
+
+    #[test]
+    fn test_ja_change_type_labels() {
+        let diff = make_diff(vec![
+            make_change("pkg-a", ChangeType::Added, None, Some("1.0.0"), None, 0),
+            make_change(
+                "pkg-b",
+                ChangeType::Removed,
+                Some("1.0.0"),
+                None,
+                None,
+                0,
+            ),
+            make_change(
+                "pkg-c",
+                ChangeType::Updated,
+                Some("1.0.0"),
+                Some("2.0.0"),
+                None,
+                0,
+            ),
+            make_change(
+                "pkg-d",
+                ChangeType::Unchanged,
+                Some("1.0.0"),
+                Some("1.0.0"),
+                None,
+                0,
+            ),
+        ]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("| pkg-a | 追加 |"));
+        assert!(md.contains("| pkg-b | 削除 |"));
+        assert!(md.contains("| pkg-c | 更新 |"));
+        assert!(md.contains("| pkg-d | 変更なし |"));
+    }
+
+    #[test]
+    fn test_ja_vuln_none_label() {
+        let diff = make_diff(vec![make_change(
+            "pkg",
+            ChangeType::Added,
+            None,
+            Some("1.0.0"),
+            None,
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("| pkg | 追加 | - | 1.0.0 | - | なし |"));
+    }
+
+    #[test]
+    fn test_ja_cve_delta_section() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView::default();
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, Some(&delta));
+
+        assert!(md.contains("## CVE デルタ"));
+        assert!(md.contains("### 🔴 新たな脆弱性 (0)"));
+        assert!(md.contains("### ✅ 解消された脆弱性 (0)"));
+        assert!(md.contains("新たな脆弱性はありません"));
+        assert!(md.contains("解消された脆弱性はありません"));
+    }
+
+    #[test]
+    fn test_ja_cve_delta_with_entries() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "cryptography",
+                "41.0.0",
+                "CVE-2024-0727",
+                Some(SeverityView::High),
+                "Null pointer dereference",
+            )],
+            resolved: vec![make_entry(
+                "requests",
+                "2.28.0",
+                "CVE-2023-32681",
+                Some(SeverityView::Medium),
+                "Fixed in 2.31.0",
+            )],
+        };
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, Some(&delta));
+
+        assert!(md.contains("### 🔴 新たな脆弱性 (1)"));
+        assert!(md.contains("### ✅ 解消された脆弱性 (1)"));
+        assert!(md.contains(
+            "| cryptography | 41.0.0 | CVE-2024-0727 | HIGH | Null pointer dereference |"
+        ));
+        assert!(md.contains("| requests | 2.28.0 | CVE-2023-32681 | MEDIUM | Fixed in 2.31.0 |"));
     }
 }

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -182,6 +182,28 @@ pub struct Messages {
     pub col_last_release: &'static str,
     pub col_days_inactive: &'static str,
     pub col_type: &'static str,
+
+    // Diff Markdown formatter strings
+    pub diff_section_title: &'static str,
+    pub diff_compared_line: &'static str,
+    pub diff_section_summary: &'static str,
+    pub diff_col_metric: &'static str,
+    pub diff_col_count: &'static str,
+    pub diff_label_added: &'static str,
+    pub diff_label_removed: &'static str,
+    pub diff_label_updated: &'static str,
+    pub diff_label_unchanged: &'static str,
+    pub diff_section_changes: &'static str,
+    pub diff_col_change: &'static str,
+    pub diff_col_old_version: &'static str,
+    pub diff_col_new_version: &'static str,
+    pub diff_col_vulnerabilities: &'static str,
+    pub diff_vuln_none: &'static str,
+    pub diff_section_cve_delta: &'static str,
+    pub diff_new_vulns_header: &'static str,
+    pub diff_resolved_vulns_header: &'static str,
+    pub diff_no_new_vulns: &'static str,
+    pub diff_no_resolved_vulns: &'static str,
 }
 
 impl Messages {
@@ -367,6 +389,28 @@ static EN_MESSAGES: Messages = Messages {
     col_last_release: "Last Release",
     col_days_inactive: "Days Inactive",
     col_type: "Type",
+
+    // Diff Markdown formatter strings
+    diff_section_title: "## Dependency Diff Report",
+    diff_compared_line: "Compared: `{}` vs current `uv.lock`",
+    diff_section_summary: "### Summary",
+    diff_col_metric: "Metric",
+    diff_col_count: "Count",
+    diff_label_added: "Added",
+    diff_label_removed: "Removed",
+    diff_label_updated: "Updated",
+    diff_label_unchanged: "Unchanged",
+    diff_section_changes: "### Changes",
+    diff_col_change: "Change",
+    diff_col_old_version: "Old Version",
+    diff_col_new_version: "New Version",
+    diff_col_vulnerabilities: "Vulnerabilities",
+    diff_vuln_none: "None",
+    diff_section_cve_delta: "## CVE Delta",
+    diff_new_vulns_header: "### 🔴 New Vulnerabilities ({})",
+    diff_resolved_vulns_header: "### ✅ Resolved Vulnerabilities ({})",
+    diff_no_new_vulns: "No new vulnerabilities",
+    diff_no_resolved_vulns: "No resolved vulnerabilities",
 };
 
 static JA_MESSAGES: Messages = Messages {
@@ -523,6 +567,28 @@ static JA_MESSAGES: Messages = Messages {
     col_last_release: "最終リリース",
     col_days_inactive: "非アクティブ日数",
     col_type: "種別",
+
+    // Diff Markdown formatter strings
+    diff_section_title: "## 依存関係差分レポート",
+    diff_compared_line: "比較: `{}` と現在の `uv.lock`",
+    diff_section_summary: "### サマリー",
+    diff_col_metric: "指標",
+    diff_col_count: "件数",
+    diff_label_added: "追加",
+    diff_label_removed: "削除",
+    diff_label_updated: "更新",
+    diff_label_unchanged: "変更なし",
+    diff_section_changes: "### 変更一覧",
+    diff_col_change: "変更種別",
+    diff_col_old_version: "旧バージョン",
+    diff_col_new_version: "新バージョン",
+    diff_col_vulnerabilities: "脆弱性",
+    diff_vuln_none: "なし",
+    diff_section_cve_delta: "## CVE デルタ",
+    diff_new_vulns_header: "### 🔴 新たな脆弱性 ({})",
+    diff_resolved_vulns_header: "### ✅ 解消された脆弱性 ({})",
+    diff_no_new_vulns: "新たな脆弱性はありません",
+    diff_no_resolved_vulns: "解消された脆弱性はありません",
 };
 
 #[cfg(test)]
@@ -1024,5 +1090,73 @@ mod tests {
         assert_eq!(msgs.col_last_release, "最終リリース");
         assert_eq!(msgs.col_days_inactive, "非アクティブ日数");
         assert_eq!(msgs.col_type, "種別");
+    }
+
+    #[test]
+    fn test_messages_diff_fields_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(msgs.diff_section_title, "## Dependency Diff Report");
+        assert_eq!(
+            msgs.diff_compared_line,
+            "Compared: `{}` vs current `uv.lock`"
+        );
+        assert_eq!(msgs.diff_section_summary, "### Summary");
+        assert_eq!(msgs.diff_col_metric, "Metric");
+        assert_eq!(msgs.diff_col_count, "Count");
+        assert_eq!(msgs.diff_label_added, "Added");
+        assert_eq!(msgs.diff_label_removed, "Removed");
+        assert_eq!(msgs.diff_label_updated, "Updated");
+        assert_eq!(msgs.diff_label_unchanged, "Unchanged");
+        assert_eq!(msgs.diff_section_changes, "### Changes");
+        assert_eq!(msgs.diff_col_change, "Change");
+        assert_eq!(msgs.diff_col_old_version, "Old Version");
+        assert_eq!(msgs.diff_col_new_version, "New Version");
+        assert_eq!(msgs.diff_col_vulnerabilities, "Vulnerabilities");
+        assert_eq!(msgs.diff_vuln_none, "None");
+        assert_eq!(msgs.diff_section_cve_delta, "## CVE Delta");
+        assert_eq!(
+            msgs.diff_new_vulns_header,
+            "### 🔴 New Vulnerabilities ({})"
+        );
+        assert_eq!(
+            msgs.diff_resolved_vulns_header,
+            "### ✅ Resolved Vulnerabilities ({})"
+        );
+        assert_eq!(msgs.diff_no_new_vulns, "No new vulnerabilities");
+        assert_eq!(msgs.diff_no_resolved_vulns, "No resolved vulnerabilities");
+    }
+
+    #[test]
+    fn test_messages_diff_fields_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(msgs.diff_section_title, "## 依存関係差分レポート");
+        assert_eq!(
+            msgs.diff_compared_line,
+            "比較: `{}` と現在の `uv.lock`"
+        );
+        assert_eq!(msgs.diff_section_summary, "### サマリー");
+        assert_eq!(msgs.diff_col_metric, "指標");
+        assert_eq!(msgs.diff_col_count, "件数");
+        assert_eq!(msgs.diff_label_added, "追加");
+        assert_eq!(msgs.diff_label_removed, "削除");
+        assert_eq!(msgs.diff_label_updated, "更新");
+        assert_eq!(msgs.diff_label_unchanged, "変更なし");
+        assert_eq!(msgs.diff_section_changes, "### 変更一覧");
+        assert_eq!(msgs.diff_col_change, "変更種別");
+        assert_eq!(msgs.diff_col_old_version, "旧バージョン");
+        assert_eq!(msgs.diff_col_new_version, "新バージョン");
+        assert_eq!(msgs.diff_col_vulnerabilities, "脆弱性");
+        assert_eq!(msgs.diff_vuln_none, "なし");
+        assert_eq!(msgs.diff_section_cve_delta, "## CVE デルタ");
+        assert_eq!(
+            msgs.diff_new_vulns_header,
+            "### 🔴 新たな脆弱性 ({})"
+        );
+        assert_eq!(
+            msgs.diff_resolved_vulns_header,
+            "### ✅ 解消された脆弱性 ({})"
+        );
+        assert_eq!(msgs.diff_no_new_vulns, "新たな脆弱性はありません");
+        assert_eq!(msgs.diff_no_resolved_vulns, "解消された脆弱性はありません");
     }
 }

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -1130,10 +1130,7 @@ mod tests {
     fn test_messages_diff_fields_ja() {
         let msgs = Messages::for_locale(Locale::Ja);
         assert_eq!(msgs.diff_section_title, "## 依存関係差分レポート");
-        assert_eq!(
-            msgs.diff_compared_line,
-            "比較: `{}` と現在の `uv.lock`"
-        );
+        assert_eq!(msgs.diff_compared_line, "比較: `{}` と現在の `uv.lock`");
         assert_eq!(msgs.diff_section_summary, "### サマリー");
         assert_eq!(msgs.diff_col_metric, "指標");
         assert_eq!(msgs.diff_col_count, "件数");
@@ -1148,10 +1145,7 @@ mod tests {
         assert_eq!(msgs.diff_col_vulnerabilities, "脆弱性");
         assert_eq!(msgs.diff_vuln_none, "なし");
         assert_eq!(msgs.diff_section_cve_delta, "## CVE デルタ");
-        assert_eq!(
-            msgs.diff_new_vulns_header,
-            "### 🔴 新たな脆弱性 ({})"
-        );
+        assert_eq!(msgs.diff_new_vulns_header, "### 🔴 新たな脆弱性 ({})");
         assert_eq!(
             msgs.diff_resolved_vulns_header,
             "### ✅ 解消された脆弱性 ({})"

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,7 +540,7 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     let cve_delta = result.cve_delta.as_ref();
 
     let formatted = match merged.format {
-        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(diff, cve_delta),
+        OutputFormat::Markdown => DiffMarkdownFormatter::new(locale).format(diff, cve_delta),
         OutputFormat::Json => DiffJsonFormatter::new().format(diff, cve_delta)?,
     };
 


### PR DESCRIPTION
## Summary

- `DiffMarkdownFormatter` was a unit struct with all strings hardcoded in English, so `--lang ja` had no effect on `--diff -f markdown` output
- Refactored `DiffMarkdownFormatter` to hold `messages: &'static Messages`, mirroring the existing `MarkdownFormatter` locale pattern
- Added 20 `diff_*` i18n keys to `Messages`, `EN_MESSAGES`, and `JA_MESSAGES`

## Related Issue

Closes #615

## Changes Made

- `src/i18n/mod.rs`: Add 20 `diff_*` fields to `Messages` struct, populate `EN_MESSAGES` and `JA_MESSAGES`, add unit tests for all new fields
- `src/adapters/outbound/formatters/diff_markdown_formatter.rs`: Refactor to locale-aware struct; accept `Locale` in `new()`; extract `write_cve_subsection()` helper to eliminate duplicate CVE table header code; update all existing tests to pass `Locale::En`; add 7 new Japanese locale tests
- `src/main.rs:543`: Pass `locale` to `DiffMarkdownFormatter::new(locale)`
- `CHANGELOG.md`: Add `### Fixed` entry under `[Unreleased]`

## Test Plan

- [x] `cargo test --all` passes (741 + 776 + 12 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] 7 new Japanese locale tests cover all three major sections (summary table, changes table, CVE Delta section)
- [x] All 20 existing English locale tests updated and passing

---
Generated with [Claude Code](https://claude.com/claude-code)