### PR TITLE
chore(release): v2.5.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -217,8 +217,9 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555 |
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
 | `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, check_cve) |
-| `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; wired to CLI via `--diff` flag (#581) |
-| `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; `#[allow(dead_code)]` until wired by #599/#600 |
+| `DiffResult` | `src/application/dto/diff_result.rs` | Output of `GenerateDiffUseCase::execute`; wraps domain `DependencyDiff` with `Option<CveDeltaView>` to keep domain layer free of read-model dependencies |
+| `GenerateDiffUseCase<LR,DLR,VR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer, optionally fetches CVE delta via VulnerabilityRepository; 3rd param `VR` (default `()`) added in #599 |
+| `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; wired into `GenerateDiffUseCase` in #599; consumed by diff formatters (Markdown/JSON) in #600 |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -78,6 +78,18 @@ When a user requests any operation listed above (even in Japanese), Claude MUST:
 When the user proposes, discusses, or asks Claude to evaluate a new feature idea,
 Claude MUST follow this process before responding with implementation suggestions.
 
+### Step 0: Check current implementation state (MANDATORY — run before Step 1)
+
+Before proposing or evaluating any feature, read these two files to build an exhaustive
+list of already-implemented capabilities:
+
+1. `src/cli/mod.rs` — all current CLI flags (e.g., `--severity-threshold`, `--license-allow`)
+2. `src/config.rs` — all current config keys (e.g., `severity_threshold`, `license_policy`)
+
+For each feature idea (your own or the user's), check whether it is already covered by an
+existing CLI flag or config key. If it is, do NOT propose it as a new feature — instead,
+state explicitly: "This is already implemented as `--flag-name` / config key `key_name`."
+
 ### Step 1: Read vision and triage files (MANDATORY)
 
 Before responding to any feature proposal, read these two files:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -218,6 +218,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
 | `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, check_cve) |
 | `GenerateDiffUseCase<LR,DLR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer; wired to CLI via `--diff` flag (#581) |
+| `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; `#[allow(dead_code)]` until wired by #599/#600 |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 
 ### Important Invariants
@@ -257,13 +258,16 @@ Bulk removal is error-prone when multiple structs share field names.
 
 `#[allow(dead_code)]` is allowed ONLY for:
 
-| Use Case | Example |
-|----------|---------|
+| Use Case | Required Format |
+|----------|-----------------|
 | serde wire-format fields that are deserialized but not yet processed in Rust | `#[allow(dead_code)] pub experimental_flag: Option<bool>` on a `#[derive(Deserialize)]` struct |
 | `#[cfg(test)]`-bounded test helpers defined in a test module | Inside `#[cfg(test)] mod tests { ... }` only |
+| Foundational type/function in a sequential PR split whose consumer is a concrete tracked issue, not yet reachable from the binary | Must use the standardized format: `#[allow(dead_code)] // WIRE(#N): remove when <description>`. The attribute MUST be removed in Issue #N via the Step 4.0 cleanup gate. |
 
-In both cases, add a comment explaining WHY the field is intentionally unused in
-production code.
+In all cases, add a comment explaining WHY the field is intentionally unused in
+production code. For the WIRE case, the consuming issue number (#N) MUST exist as
+an open GitHub Issue, and the description after the colon MUST state the removal
+condition clearly.
 
 ### YAGNI Workflow
 
@@ -288,3 +292,10 @@ cargo clippy --lib -- -D warnings
 
 This is already enforced in `.claude/skills/commit/SKILL.md` and
 `.claude/skills/pr/SKILL.md`. Do not weaken this to `--lib` only.
+
+### Recent Incidents
+
+- **2026-05-24 (Issue #598)**: Added `CveDeltaView` and `CveDeltaEntry` read model
+  types with `#[allow(dead_code)]` in a standalone foundational PR. Free-form comment
+  was not machine-scannable, so removal in #599 was not enforced. Fixed by Issue #604
+  with the WIRE convention and the Step 4.0 cleanup gate.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -95,6 +95,28 @@ Accepted responses:
 - "Adjust X" → revise plan, re-present
 - "Cancel" → halt
 
+### Step 4.0: WIRE Annotation Cleanup Gate (MANDATORY)
+
+Scan the entire codebase for WIRE annotations that reference the current issue number:
+
+```bash
+git grep -rn "WIRE(#<issue-number>)" src/
+```
+
+**If matches are found**, each matched item MUST be cleaned up as part of this
+implementation:
+
+- [ ] Remove the `#[allow(dead_code)]` attribute
+- [ ] Remove the `// WIRE(#N): ...` comment line
+- [ ] Verify the item is now actually referenced in the production code added by
+  this issue (not just in `#[cfg(test)]`)
+- [ ] If the item is NOT yet referenced after your implementation, this is a scope
+  gap — pause and report to the user before proceeding
+
+**Do NOT proceed to Step 4 until every matched annotation has been addressed.**
+
+If no matches are found, continue to Step 4 without interruption.
+
 ### Step 4: Implement Changes
 
 - **Follow the confirmed plan from Step 3.5 exactly**

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -53,6 +53,20 @@ Execute all three checks above. If any fail:
 2. Commit the fixes using `/commit` skill
 3. Re-run the checks until all pass
 
+#### WIRE Annotation Notice (informational — does not block)
+
+```bash
+git diff origin/develop...HEAD | grep -E '^\+.*WIRE\(#[0-9]+\)' | grep -v '^+++'
+```
+
+If the output is non-empty, print:
+
+> ⚠️ This PR introduces WIRE(#N) annotation(s). Verify that Issue #N is open and
+> will consume these items. The annotation will be auto-detected by /implement Step 4.0
+> when Issue #N is implemented.
+
+This check is informational only and does not block PR creation.
+
 ### Step 2: Verify Branch Status
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         rust: [stable]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -70,7 +70,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -84,7 +84,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -102,7 +102,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Extract tag version
         id: tag
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CVE Delta section in `--diff` output**: When `--diff` is used with CVE checking enabled, the Markdown output now includes a `## CVE Delta` section with separate tables for newly introduced and resolved vulnerabilities. The JSON output gains a top-level `cve_delta` key with `new` and `resolved` arrays. Both formatters omit the section when `--no-check-cve` is passed, preserving backward-compatible output (#600).
 - **Severity and CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries in `--diff` output. Only entries at or above the threshold appear in the `new` and `resolved` tables. A non-zero exit code is returned when new CVEs above threshold are introduced (#601).
 
+### Fixed
+- **Progress indicator in `--diff` CVE lookup**: Running `uv-sbom --diff <ref>` now prints a progress message (`🔍 Fetching vulnerability information...`) to stderr before the OSV API calls begin, consistent with the UX in SBOM mode. No message is printed when `--no-check-cve` is passed (#611).
+
 ## [2.4.0] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CVE Delta section in `--diff` output**: When `--diff` is used with CVE checking enabled, the Markdown output now includes a `## CVE Delta` section with separate tables for newly introduced and resolved vulnerabilities. The JSON output gains a top-level `cve_delta` key with `new` and `resolved` arrays. Both formatters omit the section when `--no-check-cve` is passed, preserving backward-compatible output (#600).
+
 ## [2.4.0] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Progress indicator in `--diff` CVE lookup**: Running `uv-sbom --diff <ref>` now prints a progress message (`🔍 Fetching vulnerability information...`) to stderr before the OSV API calls begin, consistent with the UX in SBOM mode. No message is printed when `--no-check-cve` is passed (#611).
+- **indicatif progress bar during CVE lookup in `--diff` mode**: The OSV vulnerability lookup in `--diff` mode now displays an indicatif spinner and per-package progress bar (identical to SBOM mode) for both the base and current lockfile phases. Previously the lookup silently waited with no progress feedback after the initial message (#613).
 
 ## [2.4.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Severity and CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries in `--diff` output. Only entries at or above the threshold appear in the `new` and `resolved` tables. A non-zero exit code is returned when new CVEs above threshold are introduced (#601).
 
 ### Fixed
+- **`--lang` flag now applies to `--diff -f markdown` output**: Section headings, column headers, change-type labels, and CVE Delta labels are now rendered in the selected locale. Previously all strings were hardcoded English regardless of `--lang ja` (#615).
 - **Progress indicator in `--diff` CVE lookup**: Running `uv-sbom --diff <ref>` now prints a progress message (`🔍 Fetching vulnerability information...`) to stderr before the OSV API calls begin, consistent with the UX in SBOM mode. No message is printed when `--no-check-cve` is passed (#611).
 - **indicatif progress bar during CVE lookup in `--diff` mode**: The OSV vulnerability lookup in `--diff` mode now displays an indicatif spinner and per-package progress bar (identical to SBOM mode) for both the base and current lockfile phases. Previously the lookup silently waited with no progress feedback after the initial message (#613).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-06-08
+
 ### Added
 - **CVE Delta section in `--diff` output**: When `--diff` is used with CVE checking enabled, the Markdown output now includes a `## CVE Delta` section with separate tables for newly introduced and resolved vulnerabilities. The JSON output gains a top-level `cve_delta` key with `new` and `resolved` arrays. Both formatters omit the section when `--no-check-cve` is passed, preserving backward-compatible output (#600).
 - **Severity and CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries in `--diff` output. Only entries at or above the threshold appear in the `new` and `resolved` tables. A non-zero exit code is returned when new CVEs above threshold are introduced (#601).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **CVE Delta section in `--diff` output**: When `--diff` is used with CVE checking enabled, the Markdown output now includes a `## CVE Delta` section with separate tables for newly introduced and resolved vulnerabilities. The JSON output gains a top-level `cve_delta` key with `new` and `resolved` arrays. Both formatters omit the section when `--no-check-cve` is passed, preserving backward-compatible output (#600).
+- **Severity and CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries in `--diff` output. Only entries at or above the threshold appear in the `new` and `resolved` tables. A non-zero exit code is returned when new CVEs above threshold are introduced (#601).
 
 ## [2.4.0] - 2026-05-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1030,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1296,9 +1296,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,9 +1993,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/README-JP.md
+++ b/README-JP.md
@@ -522,12 +522,37 @@ uv-sbom --diff main --format json
 
 **排他制約:** `--diff` は `--workspace` または `--init` と同時に使用できません。
 
-**CVEチェック:** デフォルトでは追加・更新されたパッケージのCVEチェックが有効です（`--no-check-cve` で無効化）。脆弱性が見つかった場合、プロセスはコード `1` で終了します。
+#### CVEデルタ
+
+デフォルトでは、`--diff` はベースおよび現在のロックファイル両方に対して脆弱性チェックも実行し、導入または解消された脆弱性を示す **CVEデルタ** セクションをレポートに追加します：
+
+- **新規脆弱性** — 現在のロックファイルのパッケージに影響するが、ベースには存在しなかったCVE。
+- **解消済み脆弱性** — ベースのロックファイルのパッケージに影響していたが、現在は適用されなくなったCVE。
+
+```bash
+# CVEデルタ付きのDiff（デフォルト — CVEチェックは有効）
+uv-sbom --diff main
+
+# diffモードでCVEチェックを無効化
+uv-sbom --diff main --no-check-cve
+```
+
+JSON出力にはトップレベルの `cve_delta` キーが `new` と `resolved` 配列とともに追加されます。`--no-check-cve` を指定した場合、このキーは出力から省略されます。
+
+**重大度およびCVSSフィルタリング:** `--severity-threshold` と `--cvss-threshold` はCVEデルタにも適用されます。しきい値以上のエントリのみがテーブルに表示されます。設定したしきい値を超える新規CVEが導入された場合、プロセスはコード `1` で終了します。
+
+```bash
+# HIGH以上のCVEデルタエントリのみ表示
+uv-sbom --diff main --severity-threshold high
+
+# CVSS ≥ 7.0 のCVEデルタエントリのみ表示
+uv-sbom --diff main --cvss-threshold 7.0
+```
 
 **CI例:**
 ```bash
-# このPRで新規追加された依存関係に既知のCVEがある場合にビルドを失敗させる
-uv-sbom --diff origin/main --format markdown --output diff.md
+# このPRで新規追加された依存関係にHIGH以上の既知のCVEがある場合にビルドを失敗させる
+uv-sbom --diff origin/main --format markdown --output diff.md --severity-threshold high
 ```
 
 ### CI統合

--- a/README.md
+++ b/README.md
@@ -526,12 +526,37 @@ uv-sbom --diff main --format json
 
 **Mutual exclusion:** `--diff` cannot be combined with `--workspace` or `--init`.
 
-**CVE check:** By default CVE checking is enabled for added and updated packages (use `--no-check-cve` to disable). When a vulnerability is found, the process exits with code `1`.
+#### CVE Delta
+
+By default, `--diff` also runs vulnerability checks on both the base and current lock files and appends a **CVE Delta** section to the report showing which vulnerabilities were introduced or resolved:
+
+- **New vulnerabilities** — CVEs that affect packages in the current lock but were not present in the base.
+- **Resolved vulnerabilities** — CVEs that affected packages in the base lock but no longer apply.
+
+```bash
+# Diff with CVE delta (default — CVE checking is on)
+uv-sbom --diff main
+
+# Disable CVE checking in diff mode
+uv-sbom --diff main --no-check-cve
+```
+
+JSON output includes a top-level `cve_delta` key with `new` and `resolved` arrays. The key is omitted entirely when `--no-check-cve` is passed.
+
+**Severity and CVSS filtering:** `--severity-threshold` and `--cvss-threshold` apply to the CVE delta. Only entries at or above the threshold appear in the tables. The process exits with code `1` when new CVEs above the configured threshold are introduced.
+
+```bash
+# Show only HIGH and above CVE delta entries
+uv-sbom --diff main --severity-threshold high
+
+# Show only CVE delta entries with CVSS ≥ 7.0
+uv-sbom --diff main --cvss-threshold 7.0
+```
 
 **CI example:**
 ```bash
-# Fail the build if new dependencies introduced by this PR have known CVEs
-uv-sbom --diff origin/main --format markdown --output diff.md
+# Fail the build if new dependencies introduced by this PR have known HIGH+ CVEs
+uv-sbom --diff origin/main --format markdown --output diff.md --severity-threshold high
 ```
 
 ### CI Integration

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.4.0"
+version = "2.5.0"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.4.0"
+UV_SBOM_VERSION = "2.5.0"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (

--- a/src/adapters/outbound/formatters/diff_json_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_json_formatter.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
+use crate::application::read_models::vulnerability_view::SeverityView;
 use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff};
 use crate::shared::Result;
 
@@ -9,6 +11,7 @@ use crate::shared::Result;
 /// ```json
 /// { "diff": { "base": "<ref>", "summary": {...}, "changes": [...] } }
 /// ```
+/// When `cve_delta` is `Some`, a top-level `"cve_delta"` key is added alongside `"diff"`.
 /// Version fields are omitted when not applicable (e.g. `old_version` for Added packages).
 pub struct DiffJsonFormatter;
 
@@ -20,10 +23,13 @@ impl DiffJsonFormatter {
 
     /// Serializes `diff` to a pretty-printed JSON string.
     ///
+    /// When `cve_delta` is `Some`, includes a top-level `"cve_delta"` object with `"new"` and
+    /// `"resolved"` arrays. When `None`, the key is omitted entirely (backward-compatible output).
+    ///
     /// # Errors
     /// Returns an error if JSON serialization fails (in practice this cannot happen
     /// because all field types are serializable).
-    pub fn format(&self, diff: &DependencyDiff) -> Result<String> {
+    pub fn format(&self, diff: &DependencyDiff, cve_delta: Option<&CveDeltaView>) -> Result<String> {
         let changes: Vec<ChangeDto> = diff
             .changes
             .iter()
@@ -45,6 +51,8 @@ impl DiffJsonFormatter {
             })
             .collect();
 
+        let cve_delta_dto = cve_delta.map(map_cve_delta);
+
         let envelope = DiffEnvelope {
             diff: DiffBody {
                 base: &diff.base_ref,
@@ -56,6 +64,7 @@ impl DiffJsonFormatter {
                 },
                 changes,
             },
+            cve_delta: cve_delta_dto,
         };
 
         serde_json::to_string_pretty(&envelope).map_err(Into::into)
@@ -77,9 +86,28 @@ fn change_label(change_type: &ChangeType) -> &'static str {
     }
 }
 
+fn map_cve_delta(delta: &CveDeltaView) -> CveDeltaDto<'_> {
+    CveDeltaDto {
+        new: delta.new.iter().map(map_cve_entry).collect(),
+        resolved: delta.resolved.iter().map(map_cve_entry).collect(),
+    }
+}
+
+fn map_cve_entry(entry: &CveDeltaEntry) -> CveDeltaEntryDto<'_> {
+    CveDeltaEntryDto {
+        package: &entry.package_name,
+        version: &entry.version,
+        cve_id: &entry.cve_id,
+        severity: entry.severity.as_ref().map(SeverityView::as_str),
+        summary: &entry.summary,
+    }
+}
+
 #[derive(Serialize)]
 struct DiffEnvelope<'a> {
     diff: DiffBody<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cve_delta: Option<CveDeltaDto<'a>>,
 }
 
 #[derive(Serialize)]
@@ -109,9 +137,27 @@ struct ChangeDto<'a> {
     license: Option<&'a str>,
 }
 
+#[derive(Serialize)]
+struct CveDeltaDto<'a> {
+    new: Vec<CveDeltaEntryDto<'a>>,
+    resolved: Vec<CveDeltaEntryDto<'a>>,
+}
+
+#[derive(Serialize)]
+struct CveDeltaEntryDto<'a> {
+    package: &'a str,
+    version: &'a str,
+    cve_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    severity: Option<&'static str>,
+    summary: &'a str,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
+    use crate::application::read_models::vulnerability_view::SeverityView;
     use crate::sbom_generation::domain::dependency_diff::{
         ChangeType, DependencyDiff, DiffSummary, PackageChange,
     };
@@ -161,11 +207,27 @@ mod tests {
         }
     }
 
+    fn make_entry(
+        package: &str,
+        version: &str,
+        cve_id: &str,
+        severity: Option<SeverityView>,
+        summary: &str,
+    ) -> CveDeltaEntry {
+        CveDeltaEntry::new(
+            package.to_string(),
+            version.to_string(),
+            cve_id.to_string(),
+            severity,
+            summary.to_string(),
+        )
+    }
+
     #[test]
     fn test_top_level_shape_and_base_ref() {
         let diff = make_diff(vec![]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
 
         assert!(json["diff"].is_object());
         assert_eq!(json["diff"]["base"], "main");
@@ -177,7 +239,7 @@ mod tests {
     fn test_empty_diff() {
         let diff = make_diff(vec![]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
 
         assert_eq!(json["diff"]["summary"]["added"], 0);
         assert_eq!(json["diff"]["summary"]["removed"], 0);
@@ -197,7 +259,7 @@ mod tests {
             0,
         )]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
         let change = &json["diff"]["changes"][0];
 
         assert_eq!(change["change"], "added");
@@ -217,7 +279,7 @@ mod tests {
             0,
         )]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
         let change = &json["diff"]["changes"][0];
 
         assert_eq!(change["change"], "removed");
@@ -236,7 +298,7 @@ mod tests {
             0,
         )]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
         let change = &json["diff"]["changes"][0];
 
         assert_eq!(change["change"], "updated");
@@ -255,7 +317,7 @@ mod tests {
             0,
         )]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
         let change = &json["diff"]["changes"][0];
 
         assert_eq!(change["change"], "unchanged");
@@ -274,7 +336,7 @@ mod tests {
             0,
         )]);
         let formatter = DiffJsonFormatter::new();
-        let json_str = formatter.format(&diff).unwrap();
+        let json_str = formatter.format(&diff, None).unwrap();
         let json: Value = serde_json::from_str(&json_str).unwrap();
 
         assert!(json["diff"]["changes"][0]["license"].is_null());
@@ -311,12 +373,122 @@ mod tests {
             ),
         ]);
         let formatter = DiffJsonFormatter::new();
-        let json: Value = serde_json::from_str(&formatter.format(&diff).unwrap()).unwrap();
+        let json: Value = serde_json::from_str(&formatter.format(&diff, None).unwrap()).unwrap();
 
         assert_eq!(json["diff"]["summary"]["added"], 1);
         assert_eq!(json["diff"]["summary"]["removed"], 1);
         assert_eq!(json["diff"]["summary"]["updated"], 1);
         assert_eq!(json["diff"]["summary"]["unchanged"], 1);
         assert_eq!(json["diff"]["changes"].as_array().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn test_cve_delta_key_absent_when_none() {
+        let diff = make_diff(vec![]);
+        let json_str = DiffJsonFormatter::new().format(&diff, None).unwrap();
+        let json: Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(json["cve_delta"].is_null());
+        assert!(!json_str.contains("\"cve_delta\""));
+    }
+
+    #[test]
+    fn test_cve_delta_key_present_with_empty_lists() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView::default();
+        let json: Value =
+            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
+                .unwrap();
+
+        assert!(json["cve_delta"].is_object());
+        assert_eq!(json["cve_delta"]["new"].as_array().unwrap().len(), 0);
+        assert_eq!(json["cve_delta"]["resolved"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_cve_delta_new_entry_serialized() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "cryptography",
+                "41.0.0",
+                "CVE-2024-0727",
+                Some(SeverityView::High),
+                "Null pointer dereference",
+            )],
+            resolved: vec![],
+        };
+        let json: Value =
+            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
+                .unwrap();
+        let entry = &json["cve_delta"]["new"][0];
+
+        assert_eq!(entry["package"], "cryptography");
+        assert_eq!(entry["version"], "41.0.0");
+        assert_eq!(entry["cve_id"], "CVE-2024-0727");
+        assert_eq!(entry["severity"], "HIGH");
+        assert_eq!(entry["summary"], "Null pointer dereference");
+    }
+
+    #[test]
+    fn test_cve_delta_resolved_entry_serialized() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![],
+            resolved: vec![make_entry(
+                "requests",
+                "2.28.0",
+                "CVE-2023-32681",
+                Some(SeverityView::Medium),
+                "Fixed in 2.31.0",
+            )],
+        };
+        let json: Value =
+            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
+                .unwrap();
+        let entry = &json["cve_delta"]["resolved"][0];
+
+        assert_eq!(entry["package"], "requests");
+        assert_eq!(entry["cve_id"], "CVE-2023-32681");
+        assert_eq!(entry["severity"], "MEDIUM");
+    }
+
+    #[test]
+    fn test_cve_delta_severity_omitted_when_option_none() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry("pkg", "1.0.0", "CVE-2024-0001", None, "desc")],
+            resolved: vec![],
+        };
+        let json_str = DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap();
+        let json: Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(json["cve_delta"]["new"][0]["severity"].is_null());
+        // severity key itself is omitted when None
+        assert!(
+            !json_str
+                .lines()
+                .any(|l| l.contains("\"severity\"") && !l.contains("HIGH") && !l.contains("MEDIUM") && !l.contains("LOW") && !l.contains("CRITICAL") && !l.contains("NONE"))
+        );
+    }
+
+    #[test]
+    fn test_cve_delta_severity_none_variant_renders_as_none_string() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "pkg",
+                "1.0.0",
+                "CVE-2024-0002",
+                Some(SeverityView::None),
+                "desc",
+            )],
+            resolved: vec![],
+        };
+        let json: Value =
+            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
+                .unwrap();
+
+        assert_eq!(json["cve_delta"]["new"][0]["severity"], "NONE");
     }
 }

--- a/src/adapters/outbound/formatters/diff_json_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_json_formatter.rs
@@ -29,7 +29,11 @@ impl DiffJsonFormatter {
     /// # Errors
     /// Returns an error if JSON serialization fails (in practice this cannot happen
     /// because all field types are serializable).
-    pub fn format(&self, diff: &DependencyDiff, cve_delta: Option<&CveDeltaView>) -> Result<String> {
+    pub fn format(
+        &self,
+        diff: &DependencyDiff,
+        cve_delta: Option<&CveDeltaView>,
+    ) -> Result<String> {
         let changes: Vec<ChangeDto> = diff
             .changes
             .iter()
@@ -396,9 +400,12 @@ mod tests {
     fn test_cve_delta_key_present_with_empty_lists() {
         let diff = make_diff(vec![]);
         let delta = CveDeltaView::default();
-        let json: Value =
-            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
-                .unwrap();
+        let json: Value = serde_json::from_str(
+            &DiffJsonFormatter::new()
+                .format(&diff, Some(&delta))
+                .unwrap(),
+        )
+        .unwrap();
 
         assert!(json["cve_delta"].is_object());
         assert_eq!(json["cve_delta"]["new"].as_array().unwrap().len(), 0);
@@ -418,9 +425,12 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let json: Value =
-            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
-                .unwrap();
+        let json: Value = serde_json::from_str(
+            &DiffJsonFormatter::new()
+                .format(&diff, Some(&delta))
+                .unwrap(),
+        )
+        .unwrap();
         let entry = &json["cve_delta"]["new"][0];
 
         assert_eq!(entry["package"], "cryptography");
@@ -443,9 +453,12 @@ mod tests {
                 "Fixed in 2.31.0",
             )],
         };
-        let json: Value =
-            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
-                .unwrap();
+        let json: Value = serde_json::from_str(
+            &DiffJsonFormatter::new()
+                .format(&diff, Some(&delta))
+                .unwrap(),
+        )
+        .unwrap();
         let entry = &json["cve_delta"]["resolved"][0];
 
         assert_eq!(entry["package"], "requests");
@@ -460,16 +473,19 @@ mod tests {
             new: vec![make_entry("pkg", "1.0.0", "CVE-2024-0001", None, "desc")],
             resolved: vec![],
         };
-        let json_str = DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap();
+        let json_str = DiffJsonFormatter::new()
+            .format(&diff, Some(&delta))
+            .unwrap();
         let json: Value = serde_json::from_str(&json_str).unwrap();
 
         assert!(json["cve_delta"]["new"][0]["severity"].is_null());
         // severity key itself is omitted when None
-        assert!(
-            !json_str
-                .lines()
-                .any(|l| l.contains("\"severity\"") && !l.contains("HIGH") && !l.contains("MEDIUM") && !l.contains("LOW") && !l.contains("CRITICAL") && !l.contains("NONE"))
-        );
+        assert!(!json_str.lines().any(|l| l.contains("\"severity\"")
+            && !l.contains("HIGH")
+            && !l.contains("MEDIUM")
+            && !l.contains("LOW")
+            && !l.contains("CRITICAL")
+            && !l.contains("NONE")));
     }
 
     #[test]
@@ -485,9 +501,12 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let json: Value =
-            serde_json::from_str(&DiffJsonFormatter::new().format(&diff, Some(&delta)).unwrap())
-                .unwrap();
+        let json: Value = serde_json::from_str(
+            &DiffJsonFormatter::new()
+                .format(&diff, Some(&delta))
+                .unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(json["cve_delta"]["new"][0]["severity"], "NONE");
     }

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -43,9 +43,19 @@ impl DiffMarkdownFormatter {
 
         writeln!(out, "{}", msgs.diff_section_summary).unwrap();
         writeln!(out).unwrap();
-        writeln!(out, "| {} | {} |", msgs.diff_col_metric, msgs.diff_col_count).unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_col_metric, msgs.diff_col_count
+        )
+        .unwrap();
         writeln!(out, "|--------|-------|").unwrap();
-        writeln!(out, "| {} | {} |", msgs.diff_label_added, diff.summary.added).unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_added, diff.summary.added
+        )
+        .unwrap();
         writeln!(
             out,
             "| {} | {} |",
@@ -593,14 +603,7 @@ mod tests {
     fn test_ja_change_type_labels() {
         let diff = make_diff(vec![
             make_change("pkg-a", ChangeType::Added, None, Some("1.0.0"), None, 0),
-            make_change(
-                "pkg-b",
-                ChangeType::Removed,
-                Some("1.0.0"),
-                None,
-                None,
-                0,
-            ),
+            make_change("pkg-b", ChangeType::Removed, Some("1.0.0"), None, None, 0),
             make_change(
                 "pkg-c",
                 ChangeType::Updated,

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -2,6 +2,7 @@ use std::fmt::Write;
 
 use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
 use crate::application::read_models::vulnerability_view::SeverityView;
+use crate::i18n::{Locale, Messages};
 use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff, PackageChange};
 
 /// Formats a `DependencyDiff` as a human-readable Markdown report.
@@ -9,42 +10,73 @@ use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff
 /// Produces a two-section report: a summary table with aggregate counts, and a
 /// changes table listing every package with its change type, versions, license,
 /// and vulnerability count.
-pub struct DiffMarkdownFormatter;
+pub struct DiffMarkdownFormatter {
+    messages: &'static Messages,
+}
 
 impl DiffMarkdownFormatter {
-    /// Creates a new `DiffMarkdownFormatter`.
-    pub fn new() -> Self {
-        Self
+    /// Creates a new `DiffMarkdownFormatter` for the given locale.
+    pub fn new(locale: Locale) -> Self {
+        Self {
+            messages: Messages::for_locale(locale),
+        }
     }
 
     /// Formats `diff` as a Markdown string. This operation is infallible.
     ///
-    /// When `cve_delta` is `Some`, a `## CVE Delta` section is appended with tables
+    /// When `cve_delta` is `Some`, a CVE Delta section is appended with tables
     /// for newly introduced and resolved vulnerabilities. When `None`, the section
     /// is omitted entirely (e.g., when `--no-check-cve` was passed).
     pub fn format(&self, diff: &DependencyDiff, cve_delta: Option<&CveDeltaView>) -> String {
+        let msgs = self.messages;
         let mut out = String::new();
 
-        writeln!(out, "## Dependency Diff Report").unwrap();
-        writeln!(out).unwrap();
-        writeln!(out, "Compared: `{}` vs current `uv.lock`", diff.base_ref).unwrap();
-        writeln!(out).unwrap();
-
-        writeln!(out, "### Summary").unwrap();
-        writeln!(out).unwrap();
-        writeln!(out, "| Metric | Count |").unwrap();
-        writeln!(out, "|--------|-------|").unwrap();
-        writeln!(out, "| Added | {} |", diff.summary.added).unwrap();
-        writeln!(out, "| Removed | {} |", diff.summary.removed).unwrap();
-        writeln!(out, "| Updated | {} |", diff.summary.updated).unwrap();
-        writeln!(out, "| Unchanged | {} |", diff.summary.unchanged).unwrap();
-        writeln!(out).unwrap();
-
-        writeln!(out, "### Changes").unwrap();
+        writeln!(out, "{}", msgs.diff_section_title).unwrap();
         writeln!(out).unwrap();
         writeln!(
             out,
-            "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
+            "{}",
+            Messages::format(msgs.diff_compared_line, &[&diff.base_ref])
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "{}", msgs.diff_section_summary).unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "| {} | {} |", msgs.diff_col_metric, msgs.diff_col_count).unwrap();
+        writeln!(out, "|--------|-------|").unwrap();
+        writeln!(out, "| {} | {} |", msgs.diff_label_added, diff.summary.added).unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_removed, diff.summary.removed
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_updated, diff.summary.updated
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "| {} | {} |",
+            msgs.diff_label_unchanged, diff.summary.unchanged
+        )
+        .unwrap();
+        writeln!(out).unwrap();
+
+        writeln!(out, "{}", msgs.diff_section_changes).unwrap();
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "| {} | {} | {} | {} | {} | {} |",
+            msgs.col_package,
+            msgs.diff_col_change,
+            msgs.diff_col_old_version,
+            msgs.diff_col_new_version,
+            msgs.col_license,
+            msgs.diff_col_vulnerabilities,
         )
         .unwrap();
         writeln!(
@@ -54,44 +86,34 @@ impl DiffMarkdownFormatter {
         .unwrap();
 
         for change in &diff.changes {
-            writeln!(out, "{}", format_change_row(change)).unwrap();
+            writeln!(out, "{}", format_change_row(change, msgs)).unwrap();
         }
 
         if let Some(delta) = cve_delta {
             writeln!(out).unwrap();
-            writeln!(out, "## CVE Delta").unwrap();
+            writeln!(out, "{}", msgs.diff_section_cve_delta).unwrap();
             writeln!(out).unwrap();
 
-            writeln!(out, "### 🔴 New Vulnerabilities ({})", delta.new.len()).unwrap();
-            writeln!(out).unwrap();
-            writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
-            writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
-            if delta.new.is_empty() {
-                writeln!(out, "| — | — | — | — | No new vulnerabilities |").unwrap();
-            } else {
-                for entry in &delta.new {
-                    writeln!(out, "{}", format_cve_row(entry)).unwrap();
-                }
-            }
+            writeln!(
+                out,
+                "{}",
+                Messages::format(msgs.diff_new_vulns_header, &[&delta.new.len().to_string()])
+            )
+            .unwrap();
+            write_cve_subsection(&mut out, &delta.new, msgs.diff_no_new_vulns);
 
             writeln!(out).unwrap();
 
             writeln!(
                 out,
-                "### ✅ Resolved Vulnerabilities ({})",
-                delta.resolved.len()
+                "{}",
+                Messages::format(
+                    msgs.diff_resolved_vulns_header,
+                    &[&delta.resolved.len().to_string()]
+                )
             )
             .unwrap();
-            writeln!(out).unwrap();
-            writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
-            writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
-            if delta.resolved.is_empty() {
-                writeln!(out, "| — | — | — | — | No resolved vulnerabilities |").unwrap();
-            } else {
-                for entry in &delta.resolved {
-                    writeln!(out, "{}", format_cve_row(entry)).unwrap();
-                }
-            }
+            write_cve_subsection(&mut out, &delta.resolved, msgs.diff_no_resolved_vulns);
         }
 
         out
@@ -100,21 +122,34 @@ impl DiffMarkdownFormatter {
 
 impl Default for DiffMarkdownFormatter {
     fn default() -> Self {
-        Self::new()
+        Self::new(Locale::En)
     }
 }
 
-fn format_change_row(change: &PackageChange) -> String {
+fn write_cve_subsection(out: &mut String, entries: &[CveDeltaEntry], empty_label: &str) {
+    writeln!(out).unwrap();
+    writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
+    writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
+    if entries.is_empty() {
+        writeln!(out, "| — | — | — | — | {} |", empty_label).unwrap();
+    } else {
+        for entry in entries {
+            writeln!(out, "{}", format_cve_row(entry)).unwrap();
+        }
+    }
+}
+
+fn format_change_row(change: &PackageChange, msgs: &Messages) -> String {
     let change_label = match change.change_type {
-        ChangeType::Added => "Added",
-        ChangeType::Removed => "Removed",
-        ChangeType::Updated => "Updated",
-        ChangeType::Unchanged => "Unchanged",
+        ChangeType::Added => msgs.diff_label_added,
+        ChangeType::Removed => msgs.diff_label_removed,
+        ChangeType::Updated => msgs.diff_label_updated,
+        ChangeType::Unchanged => msgs.diff_label_unchanged,
     };
     let old = version_cell(&change.old_version);
     let new = version_cell(&change.new_version);
     let license = version_cell(&change.license);
-    let vulns = vuln_cell(&change.change_type, change.vulnerability_count);
+    let vulns = vuln_cell(&change.change_type, change.vulnerability_count, msgs);
     format!(
         "| {} | {} | {} | {} | {} | {} |",
         change.package_name, change_label, old, new, license, vulns
@@ -143,12 +178,12 @@ fn version_cell(opt: &Option<String>) -> &str {
     opt.as_deref().unwrap_or("-")
 }
 
-fn vuln_cell(change_type: &ChangeType, count: usize) -> String {
+fn vuln_cell(change_type: &ChangeType, count: usize, msgs: &Messages) -> String {
     if matches!(change_type, ChangeType::Removed) {
         return "-".to_string();
     }
     if count == 0 {
-        "None".to_string()
+        msgs.diff_vuln_none.to_string()
     } else {
         count.to_string()
     }
@@ -159,6 +194,7 @@ mod tests {
     use super::*;
     use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
     use crate::application::read_models::vulnerability_view::SeverityView;
+    use crate::i18n::Locale;
     use crate::sbom_generation::domain::dependency_diff::{
         ChangeType, DependencyDiff, DiffSummary, PackageChange,
     };
@@ -226,7 +262,7 @@ mod tests {
     #[test]
     fn test_header_and_compared_line() {
         let diff = make_diff(vec![]);
-        let formatter = DiffMarkdownFormatter::new();
+        let formatter = DiffMarkdownFormatter::new(Locale::En);
         let md = formatter.format(&diff, None);
 
         assert!(md.contains("## Dependency Diff Report"));
@@ -245,7 +281,7 @@ mod tests {
                 unchanged: 45,
             },
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| Added | 2 |"));
         assert!(md.contains("| Removed | 1 |"));
@@ -256,7 +292,7 @@ mod tests {
     #[test]
     fn test_changes_table_header_always_present() {
         let diff = make_diff(vec![]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains(
             "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
@@ -276,7 +312,7 @@ mod tests {
             Some("MIT"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| pydantic | Added | - | 2.9.0 | MIT | None |"));
     }
@@ -291,7 +327,7 @@ mod tests {
             Some("BSD-3-Clause"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| flask | Removed | 3.0.0 | - | BSD-3-Clause | - |"));
     }
@@ -306,7 +342,7 @@ mod tests {
             Some("Apache-2.0"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| requests | Updated | 2.31.0 | 2.32.0 | Apache-2.0 | None |"));
     }
@@ -321,7 +357,7 @@ mod tests {
             Some("MIT"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| urllib3 | Unchanged | 1.26.0 | 1.26.0 | MIT | None |"));
     }
@@ -336,7 +372,7 @@ mod tests {
             None,
             3,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| vuln-pkg | Updated | 1.0.0 | 1.1.0 | - | 3 |"));
     }
@@ -351,7 +387,7 @@ mod tests {
             None,
             5,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| gone | Removed | 1.0.0 | - | - | - |"));
     }
@@ -366,7 +402,7 @@ mod tests {
             None,
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(md.contains("| nolic | Added | - | 0.1.0 | - | None |"));
     }
@@ -383,7 +419,7 @@ mod tests {
                 unchanged: 0,
             },
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
         let summary_pos = md.find("### Summary").unwrap();
         let changes_pos = md.find("### Changes").unwrap();
         assert!(summary_pos < changes_pos);
@@ -392,7 +428,7 @@ mod tests {
     #[test]
     fn test_cve_delta_section_absent_when_none() {
         let diff = make_diff(vec![]);
-        let md = DiffMarkdownFormatter::new().format(&diff, None);
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, None);
 
         assert!(!md.contains("## CVE Delta"));
     }
@@ -401,7 +437,7 @@ mod tests {
     fn test_cve_delta_section_present_with_empty_lists() {
         let diff = make_diff(vec![]);
         let delta = CveDeltaView::default();
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("## CVE Delta"));
         assert!(md.contains("### 🔴 New Vulnerabilities (0)"));
@@ -423,7 +459,7 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("### 🔴 New Vulnerabilities (1)"));
         assert!(md.contains(
@@ -444,7 +480,7 @@ mod tests {
                 "Fixed in 2.31.0",
             )],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("### ✅ Resolved Vulnerabilities (1)"));
         assert!(md.contains("| requests | 2.28.0 | CVE-2023-32681 | MEDIUM | Fixed in 2.31.0 |"));
@@ -457,7 +493,7 @@ mod tests {
             new: vec![make_entry("pkg", "1.0.0", "CVE-2024-0001", None, "desc")],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("| pkg | 1.0.0 | CVE-2024-0001 | UNKNOWN | desc |"));
     }
@@ -475,7 +511,7 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("| pkg | 1.0.0 | CVE-2024-0002 | NONE | desc |"));
     }
@@ -493,7 +529,7 @@ mod tests {
             )],
             resolved: vec![],
         };
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         assert!(md.contains("see CVE \\| NVD"));
     }
@@ -502,10 +538,148 @@ mod tests {
     fn test_cve_delta_section_after_changes_section() {
         let diff = make_diff(vec![]);
         let delta = CveDeltaView::default();
-        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+        let md = DiffMarkdownFormatter::new(Locale::En).format(&diff, Some(&delta));
 
         let changes_pos = md.find("### Changes").unwrap();
         let cve_pos = md.find("## CVE Delta").unwrap();
         assert!(changes_pos < cve_pos);
+    }
+
+    // Japanese locale tests
+
+    #[test]
+    fn test_ja_section_titles() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("## 依存関係差分レポート"));
+        assert!(md.contains("比較: `main` と現在の `uv.lock`"));
+        assert!(md.contains("### サマリー"));
+        assert!(md.contains("### 変更一覧"));
+    }
+
+    #[test]
+    fn test_ja_summary_table_labels() {
+        let diff = DependencyDiff {
+            base_ref: "v0.1.0".to_string(),
+            changes: vec![],
+            summary: DiffSummary {
+                added: 3,
+                removed: 1,
+                updated: 2,
+                unchanged: 10,
+            },
+        };
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("| 指標 | 件数 |"));
+        assert!(md.contains("| 追加 | 3 |"));
+        assert!(md.contains("| 削除 | 1 |"));
+        assert!(md.contains("| 更新 | 2 |"));
+        assert!(md.contains("| 変更なし | 10 |"));
+    }
+
+    #[test]
+    fn test_ja_changes_table_column_headers() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains(
+            "| パッケージ | 変更種別 | 旧バージョン | 新バージョン | ライセンス | 脆弱性 |"
+        ));
+    }
+
+    #[test]
+    fn test_ja_change_type_labels() {
+        let diff = make_diff(vec![
+            make_change("pkg-a", ChangeType::Added, None, Some("1.0.0"), None, 0),
+            make_change(
+                "pkg-b",
+                ChangeType::Removed,
+                Some("1.0.0"),
+                None,
+                None,
+                0,
+            ),
+            make_change(
+                "pkg-c",
+                ChangeType::Updated,
+                Some("1.0.0"),
+                Some("2.0.0"),
+                None,
+                0,
+            ),
+            make_change(
+                "pkg-d",
+                ChangeType::Unchanged,
+                Some("1.0.0"),
+                Some("1.0.0"),
+                None,
+                0,
+            ),
+        ]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("| pkg-a | 追加 |"));
+        assert!(md.contains("| pkg-b | 削除 |"));
+        assert!(md.contains("| pkg-c | 更新 |"));
+        assert!(md.contains("| pkg-d | 変更なし |"));
+    }
+
+    #[test]
+    fn test_ja_vuln_none_label() {
+        let diff = make_diff(vec![make_change(
+            "pkg",
+            ChangeType::Added,
+            None,
+            Some("1.0.0"),
+            None,
+            0,
+        )]);
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, None);
+
+        assert!(md.contains("| pkg | 追加 | - | 1.0.0 | - | なし |"));
+    }
+
+    #[test]
+    fn test_ja_cve_delta_section() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView::default();
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, Some(&delta));
+
+        assert!(md.contains("## CVE デルタ"));
+        assert!(md.contains("### 🔴 新たな脆弱性 (0)"));
+        assert!(md.contains("### ✅ 解消された脆弱性 (0)"));
+        assert!(md.contains("新たな脆弱性はありません"));
+        assert!(md.contains("解消された脆弱性はありません"));
+    }
+
+    #[test]
+    fn test_ja_cve_delta_with_entries() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "cryptography",
+                "41.0.0",
+                "CVE-2024-0727",
+                Some(SeverityView::High),
+                "Null pointer dereference",
+            )],
+            resolved: vec![make_entry(
+                "requests",
+                "2.28.0",
+                "CVE-2023-32681",
+                Some(SeverityView::Medium),
+                "Fixed in 2.31.0",
+            )],
+        };
+        let md = DiffMarkdownFormatter::new(Locale::Ja).format(&diff, Some(&delta));
+
+        assert!(md.contains("### 🔴 新たな脆弱性 (1)"));
+        assert!(md.contains("### ✅ 解消された脆弱性 (1)"));
+        assert!(md.contains(
+            "| cryptography | 41.0.0 | CVE-2024-0727 | HIGH | Null pointer dereference |"
+        ));
+        assert!(md.contains("| requests | 2.28.0 | CVE-2023-32681 | MEDIUM | Fixed in 2.31.0 |"));
     }
 }

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -426,7 +426,9 @@ mod tests {
         let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
 
         assert!(md.contains("### 🔴 New Vulnerabilities (1)"));
-        assert!(md.contains("| cryptography | 41.0.0 | CVE-2024-0727 | HIGH | Null pointer dereference |"));
+        assert!(md.contains(
+            "| cryptography | 41.0.0 | CVE-2024-0727 | HIGH | Null pointer dereference |"
+        ));
     }
 
     #[test]

--- a/src/adapters/outbound/formatters/diff_markdown_formatter.rs
+++ b/src/adapters/outbound/formatters/diff_markdown_formatter.rs
@@ -1,5 +1,7 @@
 use std::fmt::Write;
 
+use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
+use crate::application::read_models::vulnerability_view::SeverityView;
 use crate::sbom_generation::domain::dependency_diff::{ChangeType, DependencyDiff, PackageChange};
 
 /// Formats a `DependencyDiff` as a human-readable Markdown report.
@@ -16,7 +18,11 @@ impl DiffMarkdownFormatter {
     }
 
     /// Formats `diff` as a Markdown string. This operation is infallible.
-    pub fn format(&self, diff: &DependencyDiff) -> String {
+    ///
+    /// When `cve_delta` is `Some`, a `## CVE Delta` section is appended with tables
+    /// for newly introduced and resolved vulnerabilities. When `None`, the section
+    /// is omitted entirely (e.g., when `--no-check-cve` was passed).
+    pub fn format(&self, diff: &DependencyDiff, cve_delta: Option<&CveDeltaView>) -> String {
         let mut out = String::new();
 
         writeln!(out, "## Dependency Diff Report").unwrap();
@@ -51,6 +57,43 @@ impl DiffMarkdownFormatter {
             writeln!(out, "{}", format_change_row(change)).unwrap();
         }
 
+        if let Some(delta) = cve_delta {
+            writeln!(out).unwrap();
+            writeln!(out, "## CVE Delta").unwrap();
+            writeln!(out).unwrap();
+
+            writeln!(out, "### 🔴 New Vulnerabilities ({})", delta.new.len()).unwrap();
+            writeln!(out).unwrap();
+            writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
+            writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
+            if delta.new.is_empty() {
+                writeln!(out, "| — | — | — | — | No new vulnerabilities |").unwrap();
+            } else {
+                for entry in &delta.new {
+                    writeln!(out, "{}", format_cve_row(entry)).unwrap();
+                }
+            }
+
+            writeln!(out).unwrap();
+
+            writeln!(
+                out,
+                "### ✅ Resolved Vulnerabilities ({})",
+                delta.resolved.len()
+            )
+            .unwrap();
+            writeln!(out).unwrap();
+            writeln!(out, "| Package | Version | CVE | Severity | Summary |").unwrap();
+            writeln!(out, "|---------|---------|-----|----------|---------|").unwrap();
+            if delta.resolved.is_empty() {
+                writeln!(out, "| — | — | — | — | No resolved vulnerabilities |").unwrap();
+            } else {
+                for entry in &delta.resolved {
+                    writeln!(out, "{}", format_cve_row(entry)).unwrap();
+                }
+            }
+        }
+
         out
     }
 }
@@ -78,6 +121,24 @@ fn format_change_row(change: &PackageChange) -> String {
     )
 }
 
+/// Formats a single `CveDeltaEntry` as a Markdown table row.
+///
+/// Column order: `Package | Version | CVE | Severity | Summary`.
+/// `Option::None` severity renders as `"UNKNOWN"`; `Some(SeverityView::None)` renders as `"NONE"`.
+/// Literal `|` characters in `summary` are escaped as `\|` to avoid breaking the table.
+fn format_cve_row(entry: &CveDeltaEntry) -> String {
+    let severity = entry
+        .severity
+        .as_ref()
+        .map(SeverityView::as_str)
+        .unwrap_or("UNKNOWN");
+    let summary = entry.summary.replace('|', "\\|");
+    format!(
+        "| {} | {} | {} | {} | {} |",
+        entry.package_name, entry.version, entry.cve_id, severity, summary
+    )
+}
+
 fn version_cell(opt: &Option<String>) -> &str {
     opt.as_deref().unwrap_or("-")
 }
@@ -96,6 +157,8 @@ fn vuln_cell(change_type: &ChangeType, count: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
+    use crate::application::read_models::vulnerability_view::SeverityView;
     use crate::sbom_generation::domain::dependency_diff::{
         ChangeType, DependencyDiff, DiffSummary, PackageChange,
     };
@@ -144,11 +207,27 @@ mod tests {
         }
     }
 
+    fn make_entry(
+        package: &str,
+        version: &str,
+        cve_id: &str,
+        severity: Option<SeverityView>,
+        summary: &str,
+    ) -> CveDeltaEntry {
+        CveDeltaEntry::new(
+            package.to_string(),
+            version.to_string(),
+            cve_id.to_string(),
+            severity,
+            summary.to_string(),
+        )
+    }
+
     #[test]
     fn test_header_and_compared_line() {
         let diff = make_diff(vec![]);
         let formatter = DiffMarkdownFormatter::new();
-        let md = formatter.format(&diff);
+        let md = formatter.format(&diff, None);
 
         assert!(md.contains("## Dependency Diff Report"));
         assert!(md.contains("Compared: `main` vs current `uv.lock`"));
@@ -166,7 +245,7 @@ mod tests {
                 unchanged: 45,
             },
         };
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| Added | 2 |"));
         assert!(md.contains("| Removed | 1 |"));
@@ -177,7 +256,7 @@ mod tests {
     #[test]
     fn test_changes_table_header_always_present() {
         let diff = make_diff(vec![]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains(
             "| Package | Change | Old Version | New Version | License | Vulnerabilities |"
@@ -197,7 +276,7 @@ mod tests {
             Some("MIT"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| pydantic | Added | - | 2.9.0 | MIT | None |"));
     }
@@ -212,7 +291,7 @@ mod tests {
             Some("BSD-3-Clause"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| flask | Removed | 3.0.0 | - | BSD-3-Clause | - |"));
     }
@@ -227,7 +306,7 @@ mod tests {
             Some("Apache-2.0"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| requests | Updated | 2.31.0 | 2.32.0 | Apache-2.0 | None |"));
     }
@@ -242,7 +321,7 @@ mod tests {
             Some("MIT"),
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| urllib3 | Unchanged | 1.26.0 | 1.26.0 | MIT | None |"));
     }
@@ -257,7 +336,7 @@ mod tests {
             None,
             3,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| vuln-pkg | Updated | 1.0.0 | 1.1.0 | - | 3 |"));
     }
@@ -272,7 +351,7 @@ mod tests {
             None,
             5,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| gone | Removed | 1.0.0 | - | - | - |"));
     }
@@ -287,7 +366,7 @@ mod tests {
             None,
             0,
         )]);
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
 
         assert!(md.contains("| nolic | Added | - | 0.1.0 | - | None |"));
     }
@@ -304,9 +383,127 @@ mod tests {
                 unchanged: 0,
             },
         };
-        let md = DiffMarkdownFormatter::new().format(&diff);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
         let summary_pos = md.find("### Summary").unwrap();
         let changes_pos = md.find("### Changes").unwrap();
         assert!(summary_pos < changes_pos);
+    }
+
+    #[test]
+    fn test_cve_delta_section_absent_when_none() {
+        let diff = make_diff(vec![]);
+        let md = DiffMarkdownFormatter::new().format(&diff, None);
+
+        assert!(!md.contains("## CVE Delta"));
+    }
+
+    #[test]
+    fn test_cve_delta_section_present_with_empty_lists() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView::default();
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        assert!(md.contains("## CVE Delta"));
+        assert!(md.contains("### 🔴 New Vulnerabilities (0)"));
+        assert!(md.contains("### ✅ Resolved Vulnerabilities (0)"));
+        assert!(md.contains("No new vulnerabilities"));
+        assert!(md.contains("No resolved vulnerabilities"));
+    }
+
+    #[test]
+    fn test_cve_delta_new_row_renders_with_severity() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "cryptography",
+                "41.0.0",
+                "CVE-2024-0727",
+                Some(SeverityView::High),
+                "Null pointer dereference",
+            )],
+            resolved: vec![],
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        assert!(md.contains("### 🔴 New Vulnerabilities (1)"));
+        assert!(md.contains("| cryptography | 41.0.0 | CVE-2024-0727 | HIGH | Null pointer dereference |"));
+    }
+
+    #[test]
+    fn test_cve_delta_resolved_row_renders() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![],
+            resolved: vec![make_entry(
+                "requests",
+                "2.28.0",
+                "CVE-2023-32681",
+                Some(SeverityView::Medium),
+                "Fixed in 2.31.0",
+            )],
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        assert!(md.contains("### ✅ Resolved Vulnerabilities (1)"));
+        assert!(md.contains("| requests | 2.28.0 | CVE-2023-32681 | MEDIUM | Fixed in 2.31.0 |"));
+    }
+
+    #[test]
+    fn test_cve_delta_unknown_severity_when_option_none() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry("pkg", "1.0.0", "CVE-2024-0001", None, "desc")],
+            resolved: vec![],
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        assert!(md.contains("| pkg | 1.0.0 | CVE-2024-0001 | UNKNOWN | desc |"));
+    }
+
+    #[test]
+    fn test_cve_delta_severity_none_variant_renders_as_none_string() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "pkg",
+                "1.0.0",
+                "CVE-2024-0002",
+                Some(SeverityView::None),
+                "desc",
+            )],
+            resolved: vec![],
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        assert!(md.contains("| pkg | 1.0.0 | CVE-2024-0002 | NONE | desc |"));
+    }
+
+    #[test]
+    fn test_cve_delta_pipe_in_summary_is_escaped() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView {
+            new: vec![make_entry(
+                "pkg",
+                "1.0.0",
+                "CVE-2024-0003",
+                Some(SeverityView::Low),
+                "see CVE | NVD",
+            )],
+            resolved: vec![],
+        };
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        assert!(md.contains("see CVE \\| NVD"));
+    }
+
+    #[test]
+    fn test_cve_delta_section_after_changes_section() {
+        let diff = make_diff(vec![]);
+        let delta = CveDeltaView::default();
+        let md = DiffMarkdownFormatter::new().format(&diff, Some(&delta));
+
+        let changes_pos = md.find("### Changes").unwrap();
+        let cve_pos = md.find("## CVE Delta").unwrap();
+        assert!(changes_pos < cve_pos);
     }
 }

--- a/src/application/dto/diff_request.rs
+++ b/src/application/dto/diff_request.rs
@@ -1,18 +1,22 @@
 use crate::ports::outbound::DiffSource;
+use crate::sbom_generation::domain::vulnerability::Severity;
 use std::path::PathBuf;
 
 /// DiffRequest - Internal request DTO for dependency diff generation use case.
 ///
 /// Carries everything `GenerateDiffUseCase::execute` needs: where to read the
 /// "base" lockfile from, the project root holding the "current" `uv.lock`,
-/// and whether to enrich with CVE data.
+/// whether to enrich with CVE data, and optional threshold configuration.
 #[derive(Debug, Clone)]
 pub struct DiffRequest {
     pub source: DiffSource,
     pub project_path: PathBuf,
-    /// Whether to enrich results with CVE data. Currently a no-op; enrichment
-    /// will be implemented in a follow-up issue.
+    /// Whether to enrich results with CVE data.
     pub check_cve: bool,
+    /// Minimum severity level for CVE delta entries; entries below this are omitted.
+    pub severity_threshold: Option<Severity>,
+    /// Minimum CVSS score for CVE delta entries; entries below this are omitted.
+    pub cvss_threshold: Option<f32>,
 }
 
 #[cfg(test)]
@@ -25,10 +29,14 @@ mod tests {
             source: DiffSource::GitRef("main".to_string()),
             project_path: PathBuf::from("/project"),
             check_cve: false,
+            severity_threshold: None,
+            cvss_threshold: None,
         };
         assert_eq!(req.source, DiffSource::GitRef("main".to_string()));
         assert_eq!(req.project_path, PathBuf::from("/project"));
         assert!(!req.check_cve);
+        assert!(req.severity_threshold.is_none());
+        assert!(req.cvss_threshold.is_none());
     }
 
     #[test]
@@ -37,11 +45,40 @@ mod tests {
             source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
             project_path: PathBuf::from("/project"),
             check_cve: true,
+            severity_threshold: None,
+            cvss_threshold: None,
         };
         assert_eq!(
             req.source,
             DiffSource::FilePath(PathBuf::from("/tmp/uv.lock"))
         );
         assert!(req.check_cve);
+    }
+
+    #[test]
+    fn test_diff_request_with_severity_threshold() {
+        use crate::sbom_generation::domain::vulnerability::Severity;
+        let req = DiffRequest {
+            source: DiffSource::GitRef("main".to_string()),
+            project_path: PathBuf::from("/project"),
+            check_cve: true,
+            severity_threshold: Some(Severity::High),
+            cvss_threshold: None,
+        };
+        assert_eq!(req.severity_threshold, Some(Severity::High));
+        assert!(req.cvss_threshold.is_none());
+    }
+
+    #[test]
+    fn test_diff_request_with_cvss_threshold() {
+        let req = DiffRequest {
+            source: DiffSource::GitRef("main".to_string()),
+            project_path: PathBuf::from("/project"),
+            check_cve: true,
+            severity_threshold: None,
+            cvss_threshold: Some(7.0),
+        };
+        assert!(req.severity_threshold.is_none());
+        assert_eq!(req.cvss_threshold, Some(7.0));
     }
 }

--- a/src/application/dto/diff_result.rs
+++ b/src/application/dto/diff_result.rs
@@ -1,0 +1,34 @@
+use crate::application::read_models::cve_delta_view::CveDeltaView;
+use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
+
+/// Application-layer result of running the diff use case.
+///
+/// Bundles the pure domain `DependencyDiff` with the optional application
+/// read model `CveDeltaView`, keeping the domain layer free of read-model
+/// dependencies.
+#[derive(Debug, Clone)]
+pub struct DiffResult {
+    pub diff: DependencyDiff,
+    #[allow(dead_code)] // WIRE(#600): remove when cve_delta is consumed by diff formatters
+    pub cve_delta: Option<CveDeltaView>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sbom_generation::domain::dependency_diff::{DependencyDiff, DiffSummary};
+
+    #[test]
+    fn test_diff_result_cve_delta_defaults_to_none() {
+        let diff = DependencyDiff {
+            base_ref: "main".to_string(),
+            changes: vec![],
+            summary: DiffSummary::default(),
+        };
+        let result = DiffResult {
+            diff,
+            cve_delta: None,
+        };
+        assert!(result.cve_delta.is_none());
+    }
+}

--- a/src/application/dto/diff_result.rs
+++ b/src/application/dto/diff_result.rs
@@ -9,7 +9,6 @@ use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
 #[derive(Debug, Clone)]
 pub struct DiffResult {
     pub diff: DependencyDiff,
-    #[allow(dead_code)] // WIRE(#600): remove when cve_delta is consumed by diff formatters
     pub cve_delta: Option<CveDeltaView>,
 }
 

--- a/src/application/dto/mod.rs
+++ b/src/application/dto/mod.rs
@@ -3,11 +3,13 @@
 /// DTOs are used to transfer data between the application layer
 /// and adapters, keeping the domain layer isolated.
 mod diff_request;
+mod diff_result;
 mod output_format;
 mod sbom_request;
 mod sbom_response;
 
 pub use diff_request::DiffRequest;
+pub use diff_result::DiffResult;
 pub use output_format::OutputFormat;
 pub use sbom_request::SbomRequest;
 #[allow(unused_imports)]

--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -7,7 +7,7 @@ use super::vulnerability_view::SeverityView;
 
 /// Container describing the change in CVE exposure between two SBOM snapshots.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaView is wired into GenerateDiffUseCase
 pub struct CveDeltaView {
     /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
     pub new: Vec<CveDeltaEntry>,
@@ -17,7 +17,7 @@ pub struct CveDeltaView {
 
 /// Single CVE change entry for a specific package/version.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry is wired into GenerateDiffUseCase
 pub struct CveDeltaEntry {
     /// Name of the affected package.
     pub package_name: String,
@@ -32,7 +32,7 @@ pub struct CveDeltaEntry {
     pub summary: String,
 }
 
-#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry::new is used in use case or formatter
 impl CveDeltaEntry {
     /// Creates a new [`CveDeltaEntry`].
     pub fn new(

--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -7,7 +7,7 @@ use super::vulnerability_view::SeverityView;
 
 /// Container describing the change in CVE exposure between two SBOM snapshots.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaView is wired into GenerateDiffUseCase
+#[allow(dead_code)] // WIRE(#600): remove when CveDeltaView fields are consumed by diff formatters
 pub struct CveDeltaView {
     /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
     pub new: Vec<CveDeltaEntry>,
@@ -17,7 +17,7 @@ pub struct CveDeltaView {
 
 /// Single CVE change entry for a specific package/version.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry is wired into GenerateDiffUseCase
+#[allow(dead_code)] // WIRE(#600): remove when CveDeltaEntry fields are consumed by diff formatters
 pub struct CveDeltaEntry {
     /// Name of the affected package.
     pub package_name: String,
@@ -32,7 +32,6 @@ pub struct CveDeltaEntry {
     pub summary: String,
 }
 
-#[allow(dead_code)] // WIRE(#599) WIRE(#600): remove when CveDeltaEntry::new is used in use case or formatter
 impl CveDeltaEntry {
     /// Creates a new [`CveDeltaEntry`].
     pub fn new(

--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -1,0 +1,127 @@
+//! CVE delta view model for read-side queries
+//!
+//! Captures the difference in CVE exposure between two SBOM snapshots:
+//! which CVEs are newly introduced and which have been resolved.
+
+use super::vulnerability_view::SeverityView;
+
+/// Container describing the change in CVE exposure between two SBOM snapshots.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+pub struct CveDeltaView {
+    /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
+    pub new: Vec<CveDeltaEntry>,
+    /// Resolved CVEs (present in the baseline, absent from the newer snapshot).
+    pub resolved: Vec<CveDeltaEntry>,
+}
+
+/// Single CVE change entry for a specific package/version.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+pub struct CveDeltaEntry {
+    /// Name of the affected package.
+    pub package_name: String,
+    /// Version of the affected package.
+    pub version: String,
+    /// CVE identifier (e.g., "CVE-2024-1234").
+    pub cve_id: String,
+    /// Severity level. `None` means the CVE has not yet been scored;
+    /// `Some(SeverityView::None)` means it was explicitly scored as no severity.
+    pub severity: Option<SeverityView>,
+    /// Short description of the vulnerability.
+    pub summary: String,
+}
+
+#[allow(dead_code)] // Consumed by #599 (use case) and #600 (formatters); remove when wired
+impl CveDeltaEntry {
+    /// Creates a new [`CveDeltaEntry`].
+    pub fn new(
+        package_name: String,
+        version: String,
+        cve_id: String,
+        severity: Option<SeverityView>,
+        summary: String,
+    ) -> Self {
+        CveDeltaEntry {
+            package_name,
+            version,
+            cve_id,
+            severity,
+            summary,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(cve: &str, severity: Option<SeverityView>) -> CveDeltaEntry {
+        CveDeltaEntry::new(
+            "requests".to_string(),
+            "2.28.0".to_string(),
+            cve.to_string(),
+            severity,
+            "Test summary".to_string(),
+        )
+    }
+
+    #[test]
+    fn test_cve_delta_entry_new_all_fields_are_stored() {
+        let entry = make_entry("CVE-2024-1234", Some(SeverityView::High));
+        assert_eq!(entry.package_name, "requests");
+        assert_eq!(entry.version, "2.28.0");
+        assert_eq!(entry.cve_id, "CVE-2024-1234");
+        assert_eq!(entry.severity, Some(SeverityView::High));
+        assert_eq!(entry.summary, "Test summary");
+    }
+
+    #[test]
+    fn test_cve_delta_entry_severity_some_as_str_returns_variant_name() {
+        let entry = make_entry("CVE-2024-0001", Some(SeverityView::Critical));
+        assert_eq!(entry.severity, Some(SeverityView::Critical));
+        assert_eq!(entry.severity.unwrap().as_str(), "CRITICAL");
+    }
+
+    #[test]
+    fn test_cve_delta_entry_severity_none_differs_from_explicit_none_variant() {
+        let unscored = make_entry("CVE-2024-0002", None);
+        let explicit_none = make_entry("CVE-2024-0002", Some(SeverityView::None));
+        assert!(unscored.severity.is_none());
+        assert!(explicit_none.severity.is_some());
+        assert_ne!(unscored.severity, explicit_none.severity);
+    }
+
+    #[test]
+    fn test_cve_delta_view_default_produces_empty_lists() {
+        let view = CveDeltaView::default();
+        assert!(view.new.is_empty());
+        assert!(view.resolved.is_empty());
+    }
+
+    #[test]
+    fn test_cve_delta_view_new_and_resolved_are_independent() {
+        let view = CveDeltaView {
+            new: vec![make_entry("CVE-2024-0001", Some(SeverityView::High))],
+            resolved: vec![
+                make_entry("CVE-2023-9999", Some(SeverityView::Medium)),
+                make_entry("CVE-2023-8888", None),
+            ],
+        };
+        assert_eq!(view.new.len(), 1);
+        assert_eq!(view.resolved.len(), 2);
+        assert_eq!(view.new[0].cve_id, "CVE-2024-0001");
+        assert_eq!(view.resolved[0].cve_id, "CVE-2023-9999");
+    }
+
+    #[test]
+    fn test_cve_delta_entry_clone_produces_equal_fields() {
+        let original = make_entry("CVE-2024-0003", Some(SeverityView::Low));
+        let cloned = original.clone();
+        assert_eq!(cloned.package_name, original.package_name);
+        assert_eq!(cloned.version, original.version);
+        assert_eq!(cloned.cve_id, original.cve_id);
+        assert_eq!(cloned.severity, original.severity);
+        assert_eq!(cloned.summary, original.summary);
+    }
+}

--- a/src/application/read_models/cve_delta_view.rs
+++ b/src/application/read_models/cve_delta_view.rs
@@ -7,7 +7,6 @@ use super::vulnerability_view::SeverityView;
 
 /// Container describing the change in CVE exposure between two SBOM snapshots.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)] // WIRE(#600): remove when CveDeltaView fields are consumed by diff formatters
 pub struct CveDeltaView {
     /// Newly introduced CVEs (present in the newer snapshot, absent from the baseline).
     pub new: Vec<CveDeltaEntry>,
@@ -17,7 +16,6 @@ pub struct CveDeltaView {
 
 /// Single CVE change entry for a specific package/version.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // WIRE(#600): remove when CveDeltaEntry fields are consumed by diff formatters
 pub struct CveDeltaEntry {
     /// Name of the affected package.
     pub package_name: String,

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod abandoned_package;
 pub mod component_view;
+pub mod cve_delta_view;
 pub mod dependency_view;
 pub mod license_compliance_view;
 pub mod resolution_guide_view;
@@ -17,6 +18,8 @@ pub mod vulnerability_view;
 pub use abandoned_package::{AbandonedPackageView, AbandonedPackagesReport};
 #[allow(unused_imports)]
 pub use component_view::{ComponentView, LicenseView};
+#[allow(unused_imports)]
+pub use cve_delta_view::{CveDeltaEntry, CveDeltaView};
 #[allow(unused_imports)]
 pub use dependency_view::DependencyView;
 #[allow(unused_imports)]

--- a/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/resolution_guide_builder.rs
@@ -1,6 +1,7 @@
 use super::super::resolution_guide_view::{
     IntroducedByView, ResolutionEntryView, ResolutionGuideView,
 };
+use crate::application::read_models::vulnerability_view::SeverityView;
 use crate::sbom_generation::domain::resolution_guide::ResolutionEntry;
 
 /// Builds resolution guide view from domain resolution entries
@@ -33,7 +34,7 @@ fn build_resolution_entry_view(entry: &ResolutionEntry) -> ResolutionEntryView {
         vulnerable_package: entry.vulnerable_package().to_string(),
         current_version: entry.current_version().to_string(),
         fixed_version: entry.fixed_version().map(|v| v.to_string()),
-        severity: super::vulnerability_builder::map_severity(&entry.severity()),
+        severity: SeverityView::from(entry.severity()),
         vulnerability_id: entry.vulnerability_id().to_string(),
         introduced_by,
         dependency_chains,

--- a/src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/vulnerability_builder.rs
@@ -3,9 +3,7 @@ use super::super::vulnerability_view::{
     SeverityView, VulnerabilityReportView, VulnerabilitySummary, VulnerabilityView,
 };
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
-use crate::sbom_generation::domain::vulnerability::{
-    PackageVulnerabilities, Severity, Vulnerability,
-};
+use crate::sbom_generation::domain::vulnerability::{PackageVulnerabilities, Vulnerability};
 use std::collections::HashSet;
 
 /// Builds vulnerability report view from vulnerability check result
@@ -88,21 +86,10 @@ pub(super) fn build_vulnerability_view(
         affected_version: package.current_version().to_string(),
         cvss_score: vuln.cvss_score().map(|s| s.value()),
         cvss_vector: None, // OSV API doesn't provide vector in our current implementation
-        severity: map_severity(&vuln.severity()),
+        severity: SeverityView::from(vuln.severity()),
         fixed_version: vuln.fixed_version().map(|s| s.to_string()),
         description: None, // Summary is not exposed in Vulnerability, could be added later
         source_url: None,  // Not available in current domain model
-    }
-}
-
-/// Converts domain Severity to SeverityView
-pub(super) fn map_severity(severity: &Severity) -> SeverityView {
-    match severity {
-        Severity::Critical => SeverityView::Critical,
-        Severity::High => SeverityView::High,
-        Severity::Medium => SeverityView::Medium,
-        Severity::Low => SeverityView::Low,
-        Severity::None => SeverityView::None,
     }
 }
 
@@ -115,12 +102,15 @@ mod tests {
     use crate::sbom_generation::domain::vulnerability::Severity;
 
     #[test]
-    fn test_map_severity_all_levels() {
-        assert_eq!(map_severity(&Severity::Critical), SeverityView::Critical);
-        assert_eq!(map_severity(&Severity::High), SeverityView::High);
-        assert_eq!(map_severity(&Severity::Medium), SeverityView::Medium);
-        assert_eq!(map_severity(&Severity::Low), SeverityView::Low);
-        assert_eq!(map_severity(&Severity::None), SeverityView::None);
+    fn test_severity_view_from_severity_all_levels() {
+        assert_eq!(
+            SeverityView::from(Severity::Critical),
+            SeverityView::Critical
+        );
+        assert_eq!(SeverityView::from(Severity::High), SeverityView::High);
+        assert_eq!(SeverityView::from(Severity::Medium), SeverityView::Medium);
+        assert_eq!(SeverityView::from(Severity::Low), SeverityView::Low);
+        assert_eq!(SeverityView::from(Severity::None), SeverityView::None);
     }
 
     #[test]

--- a/src/application/read_models/vulnerability_view.rs
+++ b/src/application/read_models/vulnerability_view.rs
@@ -3,6 +3,8 @@
 //! These structs provide a query-optimized view of vulnerability data
 //! with pre-computed categorization and summary information.
 
+use crate::sbom_generation::domain::vulnerability::Severity;
+
 /// View representation of a vulnerability report
 ///
 /// Provides pre-categorized vulnerabilities with summary statistics
@@ -102,6 +104,18 @@ impl SeverityView {
             SeverityView::Medium => "MEDIUM",
             SeverityView::Low => "LOW",
             SeverityView::None => "NONE",
+        }
+    }
+}
+
+impl From<Severity> for SeverityView {
+    fn from(sev: Severity) -> Self {
+        match sev {
+            Severity::Critical => SeverityView::Critical,
+            Severity::High => SeverityView::High,
+            Severity::Medium => SeverityView::Medium,
+            Severity::Low => SeverityView::Low,
+            Severity::None => SeverityView::None,
         }
     }
 }

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -125,7 +125,9 @@ async fn compute_cve_delta<VR: VulnerabilityRepository + Clone>(
 
     eprintln!("{}", msgs.progress_diff_checking_current);
     let current_use_case = CheckVulnerabilitiesUseCase::new(repo.clone());
-    let current_vulns = current_use_case.check_with_progress(current.to_vec()).await?;
+    let current_vulns = current_use_case
+        .check_with_progress(current.to_vec())
+        .await?;
     eprintln!();
 
     let base_map = flatten_to_entries(&base_vulns, threshold);

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -1,6 +1,8 @@
 use crate::application::dto::{DiffRequest, DiffResult};
 use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
 use crate::application::read_models::vulnerability_view::SeverityView;
+use crate::application::use_cases::CheckVulnerabilitiesUseCase;
+use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::{
     DiffLockfileReader, DiffSource, LockfileReader, VulnerabilityRepository,
 };
@@ -15,33 +17,38 @@ use std::collections::{HashMap, HashSet};
 /// `LR` reads the current `uv.lock`, `DLR` reads the base lockfile (git ref or
 /// file path), and `VR` fetches OSV vulnerability data. `VR` defaults to `()`
 /// (the Null Object implementation) when CVE checking is not needed.
+/// `VR` must be `Clone` because `compute_cve_delta` creates two
+/// `CheckVulnerabilitiesUseCase` instances (one for base, one for current).
 pub struct GenerateDiffUseCase<LR, DLR, VR = ()>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
-    VR: VulnerabilityRepository,
+    VR: VulnerabilityRepository + Clone,
 {
     lockfile_reader: LR,
     diff_reader: DLR,
     vulnerability_repository: Option<VR>,
+    locale: Locale,
 }
 
 impl<LR, DLR, VR> GenerateDiffUseCase<LR, DLR, VR>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
-    VR: VulnerabilityRepository,
+    VR: VulnerabilityRepository + Clone,
 {
-    /// Creates a new [`GenerateDiffUseCase`] with the given readers and optional vulnerability repository.
+    /// Creates a new [`GenerateDiffUseCase`] with the given readers, optional vulnerability repository, and locale.
     pub fn new(
         lockfile_reader: LR,
         diff_reader: DLR,
         vulnerability_repository: Option<VR>,
+        locale: Locale,
     ) -> Self {
         Self {
             lockfile_reader,
             diff_reader,
             vulnerability_repository,
+            locale,
         }
     }
 
@@ -81,7 +88,9 @@ where
 
         let cve_delta = if request.check_cve {
             match &self.vulnerability_repository {
-                Some(repo) => Some(compute_cve_delta(repo, &base, &current, &threshold).await?),
+                Some(repo) => {
+                    Some(compute_cve_delta(repo, &base, &current, &threshold, self.locale).await?)
+                }
                 None => None,
             }
         } else {
@@ -92,21 +101,32 @@ where
     }
 }
 
-/// Fetches OSV vulnerability data for `base` and `current` package sets sequentially,
-/// then computes the set difference keyed on `(package_name, version, cve_id)`.
-/// Sequential fetching is intentional: OSV API rate limits make parallel calls
-/// counter-productive, and it simplifies mock ordering in tests.
+/// Fetches OSV vulnerability data for `base` and `current` package sets sequentially
+/// using `CheckVulnerabilitiesUseCase::check_with_progress`, which displays an indicatif
+/// spinner/progress bar identical to SBOM mode. Sequential fetching is intentional:
+/// OSV API rate limits make parallel calls counter-productive, and it simplifies mock
+/// ordering in tests.
 ///
 /// Both base and current maps are filtered by `threshold` before the set difference
 /// is computed, so below-threshold CVEs never appear in either `new` or `resolved`.
-async fn compute_cve_delta<VR: VulnerabilityRepository>(
+async fn compute_cve_delta<VR: VulnerabilityRepository + Clone>(
     repo: &VR,
     base: &[Package],
     current: &[Package],
     threshold: &ThresholdConfig,
+    locale: Locale,
 ) -> Result<CveDeltaView> {
-    let base_vulns = repo.fetch_vulnerabilities(base.to_vec()).await?;
-    let current_vulns = repo.fetch_vulnerabilities(current.to_vec()).await?;
+    let msgs = Messages::for_locale(locale);
+
+    eprintln!("{}", msgs.progress_diff_checking_base);
+    let base_use_case = CheckVulnerabilitiesUseCase::new(repo.clone());
+    let base_vulns = base_use_case.check_with_progress(base.to_vec()).await?;
+    eprintln!();
+
+    eprintln!("{}", msgs.progress_diff_checking_current);
+    let current_use_case = CheckVulnerabilitiesUseCase::new(repo.clone());
+    let current_vulns = current_use_case.check_with_progress(current.to_vec()).await?;
+    eprintln!();
 
     let base_map = flatten_to_entries(&base_vulns, threshold);
     let current_map = flatten_to_entries(&current_vulns, threshold);
@@ -165,6 +185,7 @@ fn flatten_to_entries(
 mod tests {
     use super::*;
     use crate::application::use_cases::test_doubles::PairedMockVulnerabilityRepository;
+    use crate::i18n::Locale;
     use crate::ports::outbound::lockfile_reader::LockfileParseResult;
     use crate::sbom_generation::domain::dependency_diff::ChangeType;
     use crate::sbom_generation::domain::vulnerability::{Severity, Vulnerability};
@@ -232,6 +253,7 @@ mod tests {
             StubLockfileReader { packages: current },
             StubDiffLockfileReader { packages: base },
             None,
+            Locale::En,
         )
     }
 
@@ -248,6 +270,7 @@ mod tests {
             StubLockfileReader { packages: current },
             StubDiffLockfileReader { packages: base },
             Some(repo),
+            Locale::En,
         )
     }
 

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -1,40 +1,62 @@
-use crate::application::dto::DiffRequest;
-use crate::ports::outbound::{DiffLockfileReader, DiffSource, LockfileReader};
-use crate::sbom_generation::domain::dependency_diff::DependencyDiff;
+use crate::application::dto::{DiffRequest, DiffResult};
+use crate::application::read_models::cve_delta_view::{CveDeltaEntry, CveDeltaView};
+use crate::application::read_models::vulnerability_view::SeverityView;
+use crate::ports::outbound::{
+    DiffLockfileReader, DiffSource, LockfileReader, VulnerabilityRepository,
+};
 use crate::sbom_generation::domain::services::DependencyDiffAnalyzer;
+use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
+use crate::sbom_generation::domain::Package;
 use crate::shared::Result;
+use std::collections::{HashMap, HashSet};
 
-pub struct GenerateDiffUseCase<LR, DLR>
+/// Orchestrates dependency diff generation between two lockfile snapshots.
+///
+/// `LR` reads the current `uv.lock`, `DLR` reads the base lockfile (git ref or
+/// file path), and `VR` fetches OSV vulnerability data. `VR` defaults to `()`
+/// (the Null Object implementation) when CVE checking is not needed.
+pub struct GenerateDiffUseCase<LR, DLR, VR = ()>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
+    VR: VulnerabilityRepository,
 {
     lockfile_reader: LR,
     diff_reader: DLR,
+    vulnerability_repository: Option<VR>,
 }
 
-impl<LR, DLR> GenerateDiffUseCase<LR, DLR>
+impl<LR, DLR, VR> GenerateDiffUseCase<LR, DLR, VR>
 where
     LR: LockfileReader,
     DLR: DiffLockfileReader,
+    VR: VulnerabilityRepository,
 {
-    pub fn new(lockfile_reader: LR, diff_reader: DLR) -> Self {
+    /// Creates a new [`GenerateDiffUseCase`] with the given readers and optional vulnerability repository.
+    pub fn new(
+        lockfile_reader: LR,
+        diff_reader: DLR,
+        vulnerability_repository: Option<VR>,
+    ) -> Self {
         Self {
             lockfile_reader,
             diff_reader,
+            vulnerability_repository,
         }
     }
 
     /// Execute the diff use case.
     ///
     /// Reads the current `uv.lock` via `lockfile_reader`, reads the base packages
-    /// via `diff_reader`, and returns a `DependencyDiff` with `base_ref` set to
+    /// via `diff_reader`, and returns a `DiffResult` with `diff.base_ref` set to
     /// the string representation of the source. Non-UTF-8 path bytes are replaced
     /// with U+FFFD (display use only — the string is never round-tripped to the FS).
     ///
-    /// CVE enrichment (`check_cve`) is accepted but currently a no-op; it will be
-    /// wired in a follow-up issue.
-    pub fn execute(&self, request: DiffRequest) -> Result<DependencyDiff> {
+    /// When `request.check_cve` is true and a `VulnerabilityRepository` was supplied,
+    /// runs OSV checks on both the base and current package sets and populates
+    /// `cve_delta` with newly introduced and resolved CVEs. When `check_cve` is false
+    /// or no repository was supplied, `cve_delta` is `None`.
+    pub async fn execute(&self, request: DiffRequest) -> Result<DiffResult> {
         let (current, _deps) = self
             .lockfile_reader
             .read_and_parse_lockfile(&request.project_path)?;
@@ -50,24 +72,102 @@ where
             DiffSource::FilePath(p) => p.to_string_lossy().into_owned(),
         };
 
-        // CVE enrichment deferred to a follow-up issue.
-        let _ = request.check_cve;
+        let cve_delta = if request.check_cve {
+            match &self.vulnerability_repository {
+                Some(repo) => Some(compute_cve_delta(repo, &base, &current).await?),
+                None => None,
+            }
+        } else {
+            None
+        };
 
-        Ok(diff)
+        Ok(DiffResult { diff, cve_delta })
     }
+}
+
+/// Fetches OSV vulnerability data for `base` and `current` package sets sequentially,
+/// then computes the set difference keyed on `(package_name, version, cve_id)`.
+/// Sequential fetching is intentional: OSV API rate limits make parallel calls
+/// counter-productive, and it simplifies mock ordering in tests.
+async fn compute_cve_delta<VR: VulnerabilityRepository>(
+    repo: &VR,
+    base: &[Package],
+    current: &[Package],
+) -> Result<CveDeltaView> {
+    let base_vulns = repo.fetch_vulnerabilities(base.to_vec()).await?;
+    let current_vulns = repo.fetch_vulnerabilities(current.to_vec()).await?;
+
+    let base_map = flatten_to_entries(&base_vulns);
+    let current_map = flatten_to_entries(&current_vulns);
+
+    let base_keys: HashSet<_> = base_map.keys().cloned().collect();
+    let current_keys: HashSet<_> = current_map.keys().cloned().collect();
+
+    let new: Vec<CveDeltaEntry> = current_keys
+        .difference(&base_keys)
+        .filter_map(|k| current_map.get(k).cloned())
+        .collect();
+
+    let resolved: Vec<CveDeltaEntry> = base_keys
+        .difference(&current_keys)
+        .filter_map(|k| base_map.get(k).cloned())
+        .collect();
+
+    Ok(CveDeltaView { new, resolved })
+}
+
+/// Converts a flat list of `PackageVulnerabilities` into a map keyed by
+/// `(package_name, version, cve_id)`. This three-part key ensures that the same
+/// CVE ID on different package versions is treated as distinct entries.
+fn flatten_to_entries(
+    pkg_vulns: &[PackageVulnerabilities],
+) -> HashMap<(String, String, String), CveDeltaEntry> {
+    let mut map = HashMap::new();
+    for pv in pkg_vulns {
+        for vuln in pv.vulnerabilities() {
+            let key = (
+                pv.package_name().to_string(),
+                pv.current_version().to_string(),
+                vuln.id().to_string(),
+            );
+            let entry = CveDeltaEntry::new(
+                pv.package_name().to_string(),
+                pv.current_version().to_string(),
+                vuln.id().to_string(),
+                Some(SeverityView::from(vuln.severity())),
+                vuln.summary().unwrap_or("").to_string(),
+            );
+            map.insert(key, entry);
+        }
+    }
+    map
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::use_cases::test_doubles::PairedMockVulnerabilityRepository;
     use crate::ports::outbound::lockfile_reader::LockfileParseResult;
     use crate::sbom_generation::domain::dependency_diff::ChangeType;
+    use crate::sbom_generation::domain::vulnerability::{Severity, Vulnerability};
     use crate::sbom_generation::domain::Package;
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
 
     fn pkg(name: &str, version: &str) -> Package {
         Package::new(name.to_string(), version.to_string()).unwrap()
+    }
+
+    fn make_vuln(id: &str, severity: Severity) -> Vulnerability {
+        Vulnerability::new(id.to_string(), None, severity, None, None).unwrap()
+    }
+
+    fn make_pkg_vulns(
+        name: &str,
+        version: &str,
+        vulns: Vec<Vulnerability>,
+    ) -> PackageVulnerabilities {
+        PackageVulnerabilities::new(name.to_string(), version.to_string(), vulns)
     }
 
     struct StubLockfileReader {
@@ -109,10 +209,27 @@ mod tests {
     fn make_use_case(
         current: Vec<Package>,
         base: Vec<Package>,
-    ) -> GenerateDiffUseCase<StubLockfileReader, StubDiffLockfileReader> {
+    ) -> GenerateDiffUseCase<StubLockfileReader, StubDiffLockfileReader, ()> {
         GenerateDiffUseCase::new(
             StubLockfileReader { packages: current },
             StubDiffLockfileReader { packages: base },
+            None,
+        )
+    }
+
+    fn make_use_case_with_vuln_repo(
+        current: Vec<Package>,
+        base: Vec<Package>,
+        repo: PairedMockVulnerabilityRepository,
+    ) -> GenerateDiffUseCase<
+        StubLockfileReader,
+        StubDiffLockfileReader,
+        PairedMockVulnerabilityRepository,
+    > {
+        GenerateDiffUseCase::new(
+            StubLockfileReader { packages: current },
+            StubDiffLockfileReader { packages: base },
+            Some(repo),
         )
     }
 
@@ -124,81 +241,187 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_execute_detects_added_package() {
+    fn git_ref_request_with_cve(ref_name: &str) -> DiffRequest {
+        DiffRequest {
+            source: DiffSource::GitRef(ref_name.to_string()),
+            project_path: PathBuf::from("/project"),
+            check_cve: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_detects_added_package() {
         let uc = make_use_case(vec![pkg("requests", "2.31.0")], vec![]);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.changes.len(), 1);
-        assert_eq!(diff.changes[0].change_type, ChangeType::Added);
-        assert_eq!(diff.changes[0].package_name, "requests");
-        assert_eq!(diff.summary.added, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.changes.len(), 1);
+        assert_eq!(result.diff.changes[0].change_type, ChangeType::Added);
+        assert_eq!(result.diff.changes[0].package_name, "requests");
+        assert_eq!(result.diff.summary.added, 1);
     }
 
-    #[test]
-    fn test_execute_detects_removed_package() {
+    #[tokio::test]
+    async fn test_execute_detects_removed_package() {
         let uc = make_use_case(vec![], vec![pkg("requests", "2.31.0")]);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.changes.len(), 1);
-        assert_eq!(diff.changes[0].change_type, ChangeType::Removed);
-        assert_eq!(diff.summary.removed, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.changes.len(), 1);
+        assert_eq!(result.diff.changes[0].change_type, ChangeType::Removed);
+        assert_eq!(result.diff.summary.removed, 1);
     }
 
-    #[test]
-    fn test_execute_detects_updated_package() {
+    #[tokio::test]
+    async fn test_execute_detects_updated_package() {
         let uc = make_use_case(
             vec![pkg("urllib3", "2.0.7")],
             vec![pkg("urllib3", "1.26.5")],
         );
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.changes.len(), 1);
-        assert_eq!(diff.changes[0].change_type, ChangeType::Updated);
-        assert_eq!(diff.changes[0].old_version, Some("1.26.5".to_string()));
-        assert_eq!(diff.changes[0].new_version, Some("2.0.7".to_string()));
-        assert_eq!(diff.summary.updated, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.changes.len(), 1);
+        assert_eq!(result.diff.changes[0].change_type, ChangeType::Updated);
+        assert_eq!(
+            result.diff.changes[0].old_version,
+            Some("1.26.5".to_string())
+        );
+        assert_eq!(
+            result.diff.changes[0].new_version,
+            Some("2.0.7".to_string())
+        );
+        assert_eq!(result.diff.summary.updated, 1);
     }
 
-    #[test]
-    fn test_execute_mixed_changes() {
+    #[tokio::test]
+    async fn test_execute_mixed_changes() {
         let base = vec![pkg("a", "1.0"), pkg("b", "1.0"), pkg("c", "1.0")];
         let current = vec![pkg("a", "1.0"), pkg("b", "2.0"), pkg("d", "1.0")];
         let uc = make_use_case(current, base);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.summary.added, 1);
-        assert_eq!(diff.summary.updated, 1);
-        assert_eq!(diff.summary.removed, 1);
-        assert_eq!(diff.summary.unchanged, 1);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.summary.added, 1);
+        assert_eq!(result.diff.summary.updated, 1);
+        assert_eq!(result.diff.summary.removed, 1);
+        assert_eq!(result.diff.summary.unchanged, 1);
     }
 
-    #[test]
-    fn test_execute_base_ref_uses_git_ref_string() {
+    #[tokio::test]
+    async fn test_execute_base_ref_uses_git_ref_string() {
         let uc = make_use_case(vec![], vec![]);
-        let diff = uc.execute(git_ref_request("main")).unwrap();
-        assert_eq!(diff.base_ref, "main");
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert_eq!(result.diff.base_ref, "main");
     }
 
-    #[test]
-    fn test_execute_base_ref_uses_file_path_string() {
+    #[tokio::test]
+    async fn test_execute_base_ref_uses_file_path_string() {
         let uc = make_use_case(vec![], vec![]);
         let req = DiffRequest {
             source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
             project_path: PathBuf::from("/project"),
             check_cve: false,
         };
-        let diff = uc.execute(req).unwrap();
-        assert_eq!(diff.base_ref, "/tmp/uv.lock");
+        let result = uc.execute(req).await.unwrap();
+        assert_eq!(result.diff.base_ref, "/tmp/uv.lock");
     }
 
-    #[test]
-    fn test_execute_check_cve_flag_is_currently_a_noop() {
-        let base = vec![pkg("a", "1.0")];
-        let current = vec![pkg("a", "2.0")];
-        let uc_false = make_use_case(current.clone(), base.clone());
-        let uc_true = make_use_case(current, base);
-        let diff_false = uc_false.execute(git_ref_request("main")).unwrap();
-        let mut req_cve = git_ref_request("main");
-        req_cve.check_cve = true;
-        let diff_true = uc_true.execute(req_cve).unwrap();
-        assert_eq!(diff_false.changes, diff_true.changes);
-        assert_eq!(diff_false.summary, diff_true.summary);
+    #[tokio::test]
+    async fn test_execute_check_cve_false_skips_osv_and_cve_delta_is_none() {
+        let uc = make_use_case(vec![pkg("a", "1.0")], vec![pkg("a", "2.0")]);
+        let result = uc.execute(git_ref_request("main")).await.unwrap();
+        assert!(result.cve_delta.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_check_cve_true_no_repo_returns_none() {
+        let uc = make_use_case(vec![pkg("a", "1.0")], vec![]);
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        assert!(result.cve_delta.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_new_cve_appears_in_current() {
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![make_vuln("CVE-2024-1234", Severity::High)],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.30.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert_eq!(delta.new.len(), 1);
+        assert_eq!(delta.new[0].cve_id, "CVE-2024-1234");
+        assert!(delta.resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_resolved_cve_absent_in_current() {
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![make_pkg_vulns(
+                "requests",
+                "2.30.0",
+                vec![make_vuln("CVE-2023-9999", Severity::Medium)],
+            )],
+            vec![],
+        );
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.30.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert!(delta.new.is_empty());
+        assert_eq!(delta.resolved.len(), 1);
+        assert_eq!(delta.resolved[0].cve_id, "CVE-2023-9999");
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_no_change_produces_empty_lists() {
+        let shared_vuln = make_pkg_vulns(
+            "requests",
+            "2.31.0",
+            vec![make_vuln("CVE-2024-0001", Severity::Low)],
+        );
+        let repo =
+            PairedMockVulnerabilityRepository::new(vec![shared_vuln.clone()], vec![shared_vuln]);
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.31.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert!(delta.new.is_empty());
+        assert!(delta.resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_execute_cve_delta_same_cve_id_different_version_counts_separately() {
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![make_pkg_vulns(
+                "requests",
+                "2.30.0",
+                vec![make_vuln("CVE-2024-0001", Severity::High)],
+            )],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![make_vuln("CVE-2024-0001", Severity::High)],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(
+            vec![pkg("requests", "2.31.0")],
+            vec![pkg("requests", "2.30.0")],
+            repo,
+        );
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        // (requests, 2.30.0, CVE-2024-0001) resolved; (requests, 2.31.0, CVE-2024-0001) is new
+        assert_eq!(delta.new.len(), 1);
+        assert_eq!(delta.resolved.len(), 1);
+        assert_eq!(delta.new[0].version, "2.31.0");
+        assert_eq!(delta.resolved[0].version, "2.30.0");
     }
 }

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -4,7 +4,7 @@ use crate::application::read_models::vulnerability_view::SeverityView;
 use crate::ports::outbound::{
     DiffLockfileReader, DiffSource, LockfileReader, VulnerabilityRepository,
 };
-use crate::sbom_generation::domain::services::DependencyDiffAnalyzer;
+use crate::sbom_generation::domain::services::{DependencyDiffAnalyzer, ThresholdConfig};
 use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
 use crate::sbom_generation::domain::Package;
 use crate::shared::Result;
@@ -72,9 +72,16 @@ where
             DiffSource::FilePath(p) => p.to_string_lossy().into_owned(),
         };
 
+        let threshold = match (request.severity_threshold, request.cvss_threshold) {
+            (Some(sev), None) => ThresholdConfig::Severity(sev),
+            (None, Some(cvss)) => ThresholdConfig::Cvss(cvss),
+            // Both None (no threshold) or unreachable (clap group prevents both being set)
+            _ => ThresholdConfig::None,
+        };
+
         let cve_delta = if request.check_cve {
             match &self.vulnerability_repository {
-                Some(repo) => Some(compute_cve_delta(repo, &base, &current).await?),
+                Some(repo) => Some(compute_cve_delta(repo, &base, &current, &threshold).await?),
                 None => None,
             }
         } else {
@@ -89,16 +96,20 @@ where
 /// then computes the set difference keyed on `(package_name, version, cve_id)`.
 /// Sequential fetching is intentional: OSV API rate limits make parallel calls
 /// counter-productive, and it simplifies mock ordering in tests.
+///
+/// Both base and current maps are filtered by `threshold` before the set difference
+/// is computed, so below-threshold CVEs never appear in either `new` or `resolved`.
 async fn compute_cve_delta<VR: VulnerabilityRepository>(
     repo: &VR,
     base: &[Package],
     current: &[Package],
+    threshold: &ThresholdConfig,
 ) -> Result<CveDeltaView> {
     let base_vulns = repo.fetch_vulnerabilities(base.to_vec()).await?;
     let current_vulns = repo.fetch_vulnerabilities(current.to_vec()).await?;
 
-    let base_map = flatten_to_entries(&base_vulns);
-    let current_map = flatten_to_entries(&current_vulns);
+    let base_map = flatten_to_entries(&base_vulns, threshold);
+    let current_map = flatten_to_entries(&current_vulns, threshold);
 
     let base_keys: HashSet<_> = base_map.keys().cloned().collect();
     let current_keys: HashSet<_> = current_map.keys().cloned().collect();
@@ -117,14 +128,21 @@ async fn compute_cve_delta<VR: VulnerabilityRepository>(
 }
 
 /// Converts a flat list of `PackageVulnerabilities` into a map keyed by
-/// `(package_name, version, cve_id)`. This three-part key ensures that the same
-/// CVE ID on different package versions is treated as distinct entries.
+/// `(package_name, version, cve_id)`, filtered by `threshold`.
+///
+/// Filtering happens here, at the `Vulnerability` level, because `CveDeltaEntry`
+/// does not store the raw CVSS score — filtering after entry construction would
+/// be unable to apply CVSS-based thresholds.
 fn flatten_to_entries(
     pkg_vulns: &[PackageVulnerabilities],
+    threshold: &ThresholdConfig,
 ) -> HashMap<(String, String, String), CveDeltaEntry> {
     let mut map = HashMap::new();
     for pv in pkg_vulns {
         for vuln in pv.vulnerabilities() {
+            if !threshold.is_above_threshold(vuln) {
+                continue;
+            }
             let key = (
                 pv.package_name().to_string(),
                 pv.current_version().to_string(),
@@ -238,6 +256,8 @@ mod tests {
             source: DiffSource::GitRef(ref_name.to_string()),
             project_path: PathBuf::from("/project"),
             check_cve: false,
+            severity_threshold: None,
+            cvss_threshold: None,
         }
     }
 
@@ -246,6 +266,8 @@ mod tests {
             source: DiffSource::GitRef(ref_name.to_string()),
             project_path: PathBuf::from("/project"),
             check_cve: true,
+            severity_threshold: None,
+            cvss_threshold: None,
         }
     }
 
@@ -314,6 +336,8 @@ mod tests {
             source: DiffSource::FilePath(PathBuf::from("/tmp/uv.lock")),
             project_path: PathBuf::from("/project"),
             check_cve: false,
+            severity_threshold: None,
+            cvss_threshold: None,
         };
         let result = uc.execute(req).await.unwrap();
         assert_eq!(result.diff.base_ref, "/tmp/uv.lock");
@@ -423,5 +447,151 @@ mod tests {
         assert_eq!(delta.resolved.len(), 1);
         assert_eq!(delta.new[0].version, "2.31.0");
         assert_eq!(delta.resolved[0].version, "2.30.0");
+    }
+
+    fn git_ref_request_with_severity(ref_name: &str, severity: Severity) -> DiffRequest {
+        DiffRequest {
+            source: DiffSource::GitRef(ref_name.to_string()),
+            project_path: PathBuf::from("/project"),
+            check_cve: true,
+            severity_threshold: Some(severity),
+            cvss_threshold: None,
+        }
+    }
+
+    fn git_ref_request_with_cvss(ref_name: &str, cvss: f32) -> DiffRequest {
+        DiffRequest {
+            source: DiffSource::GitRef(ref_name.to_string()),
+            project_path: PathBuf::from("/project"),
+            check_cve: true,
+            severity_threshold: None,
+            cvss_threshold: Some(cvss),
+        }
+    }
+
+    fn make_vuln_with_cvss(id: &str, severity: Severity, cvss: f32) -> Vulnerability {
+        use crate::sbom_generation::domain::vulnerability::CvssScore;
+        Vulnerability::new(
+            id.to_string(),
+            Some(CvssScore::new(cvss).unwrap()),
+            severity,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_severity_threshold_filters_below_threshold_new_entries() {
+        // base: empty; current: high + low CVE → only high should appear in new
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![
+                    make_vuln("CVE-2024-HIGH", Severity::High),
+                    make_vuln("CVE-2024-LOW", Severity::Low),
+                ],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(vec![pkg("requests", "2.31.0")], vec![], repo);
+        let result = uc
+            .execute(git_ref_request_with_severity("main", Severity::High))
+            .await
+            .unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert_eq!(delta.new.len(), 1);
+        assert_eq!(delta.new[0].cve_id, "CVE-2024-HIGH");
+        assert!(delta.resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cvss_threshold_filters_below_threshold_new_entries() {
+        // base: empty; current: 9.0 (above) + 3.0 (below) → only 9.0 appears
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![
+                    make_vuln_with_cvss("CVE-2024-CRITICAL", Severity::Critical, 9.0),
+                    make_vuln_with_cvss("CVE-2024-LOW", Severity::Low, 3.0),
+                ],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(vec![pkg("requests", "2.31.0")], vec![], repo);
+        let result = uc
+            .execute(git_ref_request_with_cvss("main", 7.0))
+            .await
+            .unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert_eq!(delta.new.len(), 1);
+        assert_eq!(delta.new[0].cve_id, "CVE-2024-CRITICAL");
+    }
+
+    #[tokio::test]
+    async fn test_cvss_threshold_excludes_cve_without_score() {
+        // A CVE with no CVSS score should be excluded when a CVSS threshold is set
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![make_vuln("CVE-2024-UNSCORED", Severity::High)],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(vec![pkg("requests", "2.31.0")], vec![], repo);
+        let result = uc
+            .execute(git_ref_request_with_cvss("main", 7.0))
+            .await
+            .unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert!(delta.new.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_no_threshold_passes_all_entries() {
+        // Without threshold, all CVEs should appear
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![],
+            vec![make_pkg_vulns(
+                "requests",
+                "2.31.0",
+                vec![
+                    make_vuln("CVE-2024-CRITICAL", Severity::Critical),
+                    make_vuln("CVE-2024-LOW", Severity::Low),
+                ],
+            )],
+        );
+        let uc = make_use_case_with_vuln_repo(vec![pkg("requests", "2.31.0")], vec![], repo);
+        let result = uc.execute(git_ref_request_with_cve("main")).await.unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert_eq!(delta.new.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_severity_threshold_filters_resolved_entries_symmetrically() {
+        // Below-threshold CVEs in base should not appear in resolved either
+        let repo = PairedMockVulnerabilityRepository::new(
+            vec![make_pkg_vulns(
+                "requests",
+                "2.30.0",
+                vec![
+                    make_vuln("CVE-2023-HIGH", Severity::High),
+                    make_vuln("CVE-2023-LOW", Severity::Low),
+                ],
+            )],
+            vec![],
+        );
+        let uc = make_use_case_with_vuln_repo(vec![], vec![pkg("requests", "2.30.0")], repo);
+        let result = uc
+            .execute(git_ref_request_with_severity("main", Severity::High))
+            .await
+            .unwrap();
+        let delta = result.cve_delta.unwrap();
+        assert!(delta.new.is_empty());
+        assert_eq!(delta.resolved.len(), 1);
+        assert_eq!(delta.resolved[0].cve_id, "CVE-2023-HIGH");
     }
 }

--- a/src/application/use_cases/test_doubles.rs
+++ b/src/application/use_cases/test_doubles.rs
@@ -7,6 +7,43 @@ use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+/// Mock VulnerabilityRepository that returns pre-configured responses in order.
+///
+/// Each call to `fetch_vulnerabilities` pops the next response from the queue.
+/// Designed for testing `GenerateDiffUseCase`'s CVE delta computation, where the
+/// use case calls `fetch_vulnerabilities` twice — once for base packages and once
+/// for current packages — in sequential order.
+#[derive(Clone, Default)]
+pub(crate) struct PairedMockVulnerabilityRepository {
+    queue: Arc<Mutex<VecDeque<Vec<PackageVulnerabilities>>>>,
+}
+
+impl PairedMockVulnerabilityRepository {
+    /// Creates a mock that returns `base_response` on the first call and
+    /// `current_response` on the second call.
+    pub fn new(
+        base_response: Vec<PackageVulnerabilities>,
+        current_response: Vec<PackageVulnerabilities>,
+    ) -> Self {
+        let mut queue = VecDeque::new();
+        queue.push_back(base_response);
+        queue.push_back(current_response);
+        Self {
+            queue: Arc::new(Mutex::new(queue)),
+        }
+    }
+}
+
+#[async_trait]
+impl VulnerabilityRepository for PairedMockVulnerabilityRepository {
+    async fn fetch_vulnerabilities(
+        &self,
+        _packages: Vec<Package>,
+    ) -> Result<Vec<PackageVulnerabilities>> {
+        Ok(self.queue.lock().unwrap().pop_front().unwrap_or_default())
+    }
+}
+
 /// Configurable in-memory mock implementing `MaintenanceRepository`.
 ///
 /// Each call to `fetch_maintenance_info` pops the next response from the queue.

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -182,6 +182,28 @@ pub struct Messages {
     pub col_last_release: &'static str,
     pub col_days_inactive: &'static str,
     pub col_type: &'static str,
+
+    // Diff Markdown formatter strings
+    pub diff_section_title: &'static str,
+    pub diff_compared_line: &'static str,
+    pub diff_section_summary: &'static str,
+    pub diff_col_metric: &'static str,
+    pub diff_col_count: &'static str,
+    pub diff_label_added: &'static str,
+    pub diff_label_removed: &'static str,
+    pub diff_label_updated: &'static str,
+    pub diff_label_unchanged: &'static str,
+    pub diff_section_changes: &'static str,
+    pub diff_col_change: &'static str,
+    pub diff_col_old_version: &'static str,
+    pub diff_col_new_version: &'static str,
+    pub diff_col_vulnerabilities: &'static str,
+    pub diff_vuln_none: &'static str,
+    pub diff_section_cve_delta: &'static str,
+    pub diff_new_vulns_header: &'static str,
+    pub diff_resolved_vulns_header: &'static str,
+    pub diff_no_new_vulns: &'static str,
+    pub diff_no_resolved_vulns: &'static str,
 }
 
 impl Messages {
@@ -367,6 +389,28 @@ static EN_MESSAGES: Messages = Messages {
     col_last_release: "Last Release",
     col_days_inactive: "Days Inactive",
     col_type: "Type",
+
+    // Diff Markdown formatter strings
+    diff_section_title: "## Dependency Diff Report",
+    diff_compared_line: "Compared: `{}` vs current `uv.lock`",
+    diff_section_summary: "### Summary",
+    diff_col_metric: "Metric",
+    diff_col_count: "Count",
+    diff_label_added: "Added",
+    diff_label_removed: "Removed",
+    diff_label_updated: "Updated",
+    diff_label_unchanged: "Unchanged",
+    diff_section_changes: "### Changes",
+    diff_col_change: "Change",
+    diff_col_old_version: "Old Version",
+    diff_col_new_version: "New Version",
+    diff_col_vulnerabilities: "Vulnerabilities",
+    diff_vuln_none: "None",
+    diff_section_cve_delta: "## CVE Delta",
+    diff_new_vulns_header: "### 🔴 New Vulnerabilities ({})",
+    diff_resolved_vulns_header: "### ✅ Resolved Vulnerabilities ({})",
+    diff_no_new_vulns: "No new vulnerabilities",
+    diff_no_resolved_vulns: "No resolved vulnerabilities",
 };
 
 static JA_MESSAGES: Messages = Messages {
@@ -523,6 +567,28 @@ static JA_MESSAGES: Messages = Messages {
     col_last_release: "最終リリース",
     col_days_inactive: "非アクティブ日数",
     col_type: "種別",
+
+    // Diff Markdown formatter strings
+    diff_section_title: "## 依存関係差分レポート",
+    diff_compared_line: "比較: `{}` と現在の `uv.lock`",
+    diff_section_summary: "### サマリー",
+    diff_col_metric: "指標",
+    diff_col_count: "件数",
+    diff_label_added: "追加",
+    diff_label_removed: "削除",
+    diff_label_updated: "更新",
+    diff_label_unchanged: "変更なし",
+    diff_section_changes: "### 変更一覧",
+    diff_col_change: "変更種別",
+    diff_col_old_version: "旧バージョン",
+    diff_col_new_version: "新バージョン",
+    diff_col_vulnerabilities: "脆弱性",
+    diff_vuln_none: "なし",
+    diff_section_cve_delta: "## CVE デルタ",
+    diff_new_vulns_header: "### 🔴 新たな脆弱性 ({})",
+    diff_resolved_vulns_header: "### ✅ 解消された脆弱性 ({})",
+    diff_no_new_vulns: "新たな脆弱性はありません",
+    diff_no_resolved_vulns: "解消された脆弱性はありません",
 };
 
 #[cfg(test)]
@@ -1024,5 +1090,73 @@ mod tests {
         assert_eq!(msgs.col_last_release, "最終リリース");
         assert_eq!(msgs.col_days_inactive, "非アクティブ日数");
         assert_eq!(msgs.col_type, "種別");
+    }
+
+    #[test]
+    fn test_messages_diff_fields_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(msgs.diff_section_title, "## Dependency Diff Report");
+        assert_eq!(
+            msgs.diff_compared_line,
+            "Compared: `{}` vs current `uv.lock`"
+        );
+        assert_eq!(msgs.diff_section_summary, "### Summary");
+        assert_eq!(msgs.diff_col_metric, "Metric");
+        assert_eq!(msgs.diff_col_count, "Count");
+        assert_eq!(msgs.diff_label_added, "Added");
+        assert_eq!(msgs.diff_label_removed, "Removed");
+        assert_eq!(msgs.diff_label_updated, "Updated");
+        assert_eq!(msgs.diff_label_unchanged, "Unchanged");
+        assert_eq!(msgs.diff_section_changes, "### Changes");
+        assert_eq!(msgs.diff_col_change, "Change");
+        assert_eq!(msgs.diff_col_old_version, "Old Version");
+        assert_eq!(msgs.diff_col_new_version, "New Version");
+        assert_eq!(msgs.diff_col_vulnerabilities, "Vulnerabilities");
+        assert_eq!(msgs.diff_vuln_none, "None");
+        assert_eq!(msgs.diff_section_cve_delta, "## CVE Delta");
+        assert_eq!(
+            msgs.diff_new_vulns_header,
+            "### 🔴 New Vulnerabilities ({})"
+        );
+        assert_eq!(
+            msgs.diff_resolved_vulns_header,
+            "### ✅ Resolved Vulnerabilities ({})"
+        );
+        assert_eq!(msgs.diff_no_new_vulns, "No new vulnerabilities");
+        assert_eq!(msgs.diff_no_resolved_vulns, "No resolved vulnerabilities");
+    }
+
+    #[test]
+    fn test_messages_diff_fields_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(msgs.diff_section_title, "## 依存関係差分レポート");
+        assert_eq!(
+            msgs.diff_compared_line,
+            "比較: `{}` と現在の `uv.lock`"
+        );
+        assert_eq!(msgs.diff_section_summary, "### サマリー");
+        assert_eq!(msgs.diff_col_metric, "指標");
+        assert_eq!(msgs.diff_col_count, "件数");
+        assert_eq!(msgs.diff_label_added, "追加");
+        assert_eq!(msgs.diff_label_removed, "削除");
+        assert_eq!(msgs.diff_label_updated, "更新");
+        assert_eq!(msgs.diff_label_unchanged, "変更なし");
+        assert_eq!(msgs.diff_section_changes, "### 変更一覧");
+        assert_eq!(msgs.diff_col_change, "変更種別");
+        assert_eq!(msgs.diff_col_old_version, "旧バージョン");
+        assert_eq!(msgs.diff_col_new_version, "新バージョン");
+        assert_eq!(msgs.diff_col_vulnerabilities, "脆弱性");
+        assert_eq!(msgs.diff_vuln_none, "なし");
+        assert_eq!(msgs.diff_section_cve_delta, "## CVE デルタ");
+        assert_eq!(
+            msgs.diff_new_vulns_header,
+            "### 🔴 新たな脆弱性 ({})"
+        );
+        assert_eq!(
+            msgs.diff_resolved_vulns_header,
+            "### ✅ 解消された脆弱性 ({})"
+        );
+        assert_eq!(msgs.diff_no_new_vulns, "新たな脆弱性はありません");
+        assert_eq!(msgs.diff_no_resolved_vulns, "解消された脆弱性はありません");
     }
 }

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -1130,10 +1130,7 @@ mod tests {
     fn test_messages_diff_fields_ja() {
         let msgs = Messages::for_locale(Locale::Ja);
         assert_eq!(msgs.diff_section_title, "## 依存関係差分レポート");
-        assert_eq!(
-            msgs.diff_compared_line,
-            "比較: `{}` と現在の `uv.lock`"
-        );
+        assert_eq!(msgs.diff_compared_line, "比較: `{}` と現在の `uv.lock`");
         assert_eq!(msgs.diff_section_summary, "### サマリー");
         assert_eq!(msgs.diff_col_metric, "指標");
         assert_eq!(msgs.diff_col_count, "件数");
@@ -1148,10 +1145,7 @@ mod tests {
         assert_eq!(msgs.diff_col_vulnerabilities, "脆弱性");
         assert_eq!(msgs.diff_vuln_none, "なし");
         assert_eq!(msgs.diff_section_cve_delta, "## CVE デルタ");
-        assert_eq!(
-            msgs.diff_new_vulns_header,
-            "### 🔴 新たな脆弱性 ({})"
-        );
+        assert_eq!(msgs.diff_new_vulns_header, "### 🔴 新たな脆弱性 ({})");
         assert_eq!(
             msgs.diff_resolved_vulns_header,
             "### ✅ 解消された脆弱性 ({})"

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -58,6 +58,8 @@ pub struct Messages {
     pub progress_verifying_links: &'static str,
     pub progress_fetching_license: &'static str,
     pub progress_fetching_vulns: &'static str,
+    pub progress_diff_checking_base: &'static str,
+    pub progress_diff_checking_current: &'static str,
 
     // Progress messages (use case layer)
     pub progress_loading_lockfile: &'static str,
@@ -241,6 +243,8 @@ static EN_MESSAGES: Messages = Messages {
     progress_verifying_links: "🔗 Verifying PyPI links...",
     progress_fetching_license: "🔍 Fetching license information...",
     progress_fetching_vulns: "🔍 Fetching vulnerability information...",
+    progress_diff_checking_base: "🔍 Checking vulnerabilities in base lockfile...",
+    progress_diff_checking_current: "🔍 Checking vulnerabilities in current lockfile...",
 
     // Progress messages (use case layer)
     progress_loading_lockfile: "📖 Loading uv.lock file from: {}",
@@ -393,6 +397,8 @@ static JA_MESSAGES: Messages = Messages {
     progress_verifying_links: "🔗 PyPIリンクを検証中...",
     progress_fetching_license: "🔍 ライセンス情報を取得中...",
     progress_fetching_vulns: "🔍 脆弱性情報を取得中...",
+    progress_diff_checking_base: "🔍 ベースロックファイルの脆弱性をチェック中...",
+    progress_diff_checking_current: "🔍 現在のロックファイルの脆弱性をチェック中...",
 
     // Progress messages (use case layer)
     progress_loading_lockfile: "📖 uv.lockファイルを読み込み中: {}",
@@ -645,6 +651,32 @@ mod tests {
         assert_eq!(
             msgs.progress_license_unknown_packages,
             "⚠️  ライセンスコンプライアンス: ライセンス不明のパッケージが{}件あります"
+        );
+    }
+
+    #[test]
+    fn test_diff_progress_messages_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(
+            msgs.progress_diff_checking_base,
+            "🔍 Checking vulnerabilities in base lockfile..."
+        );
+        assert_eq!(
+            msgs.progress_diff_checking_current,
+            "🔍 Checking vulnerabilities in current lockfile..."
+        );
+    }
+
+    #[test]
+    fn test_diff_progress_messages_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(
+            msgs.progress_diff_checking_base,
+            "🔍 ベースロックファイルの脆弱性をチェック中..."
+        );
+        assert_eq!(
+            msgs.progress_diff_checking_current,
+            "🔍 現在のロックファイルの脆弱性をチェック中..."
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,6 +534,10 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         GitLockfileReader::new(),
         vulnerability_repository,
     );
+    if check_cve {
+        let msgs = Messages::for_locale(locale);
+        eprintln!("{}", msgs.progress_fetching_vulns);
+    }
     let result = use_case.execute(request).await?;
     let diff = &result.diff;
     let cve_delta = result.cve_delta.as_ref();

--- a/src/main.rs
+++ b/src/main.rs
@@ -540,7 +540,7 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     let cve_delta = result.cve_delta.as_ref();
 
     let formatted = match merged.format {
-        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(diff, cve_delta),
+        OutputFormat::Markdown => DiffMarkdownFormatter::new(locale).format(diff, cve_delta),
         OutputFormat::Json => DiffJsonFormatter::new().format(diff, cve_delta)?,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,10 +534,11 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     );
     let result = use_case.execute(request).await?;
     let diff = &result.diff;
+    let cve_delta = result.cve_delta.as_ref();
 
     let formatted = match merged.format {
-        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(diff),
-        OutputFormat::Json => DiffJsonFormatter::new().format(diff)?,
+        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(diff, cve_delta),
+        OutputFormat::Json => DiffJsonFormatter::new().format(diff, cve_delta)?,
     };
 
     let presenter_type = if let Some(output_path) = args.output {
@@ -548,6 +549,5 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted)?;
 
-    // TODO(#600): incorporate result.cve_delta into exit-code logic once formatter wires it in
     Ok(diff.changes.iter().any(|c| c.vulnerability_count > 0) && check_cve)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,6 +520,8 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         source,
         project_path: project_path.clone(),
         check_cve,
+        severity_threshold: merged.severity_threshold,
+        cvss_threshold: merged.cvss_threshold,
     };
 
     let vulnerability_repository = if check_cve {
@@ -549,5 +551,5 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted)?;
 
-    Ok(diff.changes.iter().any(|c| c.vulnerability_count > 0) && check_cve)
+    Ok(check_cve && cve_delta.is_some_and(|d| !d.new.is_empty()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,11 +533,8 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         FileSystemReader::new(),
         GitLockfileReader::new(),
         vulnerability_repository,
+        locale,
     );
-    if check_cve {
-        let msgs = Messages::for_locale(locale);
-        eprintln!("{}", msgs.progress_fetching_vulns);
-    }
     let result = use_case.execute(request).await?;
     let diff = &result.diff;
     let cve_delta = result.cve_delta.as_ref();

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,9 +504,6 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
 ///
 /// Returns `Ok(true)` if vulnerabilities were detected in new/updated packages
 /// and CVE checking is enabled, `Ok(false)` otherwise.
-///
-/// Note: CVE enrichment is currently a no-op in `GenerateDiffUseCase::execute`,
-/// so this will always return `Ok(false)` until a follow-up issue wires it in.
 async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     display_banner();
 
@@ -525,13 +522,22 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
         check_cve,
     };
 
-    // execute() is synchronous — call directly without .await
-    let use_case = GenerateDiffUseCase::new(FileSystemReader::new(), GitLockfileReader::new());
-    let diff = use_case.execute(request)?;
+    let vulnerability_repository = if check_cve {
+        Some(OsvClient::new()?)
+    } else {
+        None
+    };
+    let use_case = GenerateDiffUseCase::new(
+        FileSystemReader::new(),
+        GitLockfileReader::new(),
+        vulnerability_repository,
+    );
+    let result = use_case.execute(request).await?;
+    let diff = &result.diff;
 
     let formatted = match merged.format {
-        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(&diff),
-        OutputFormat::Json => DiffJsonFormatter::new().format(&diff)?,
+        OutputFormat::Markdown => DiffMarkdownFormatter::new().format(diff),
+        OutputFormat::Json => DiffJsonFormatter::new().format(diff)?,
     };
 
     let presenter_type = if let Some(output_path) = args.output {
@@ -542,5 +548,6 @@ async fn run_diff(args: Args, source: DiffSource) -> Result<bool> {
     let presenter = PresenterFactory::create(presenter_type, locale);
     presenter.present(&formatted)?;
 
+    // TODO(#600): incorporate result.cve_delta into exit-code logic once formatter wires it in
     Ok(diff.changes.iter().any(|c| c.vulnerability_count > 0) && check_cve)
 }

--- a/src/sbom_generation/domain/vulnerability.rs
+++ b/src/sbom_generation/domain/vulnerability.rs
@@ -111,6 +111,11 @@ impl Vulnerability {
     pub fn fixed_version(&self) -> Option<&str> {
         self.fixed_version.as_deref()
     }
+
+    /// Returns the summary if available
+    pub fn summary(&self) -> Option<&str> {
+        self.summary.as_deref()
+    }
 }
 
 /// Severity levels based on CVSS scores


### PR DESCRIPTION
## Summary

Merge release v2.5.0 from develop into main.

## Highlights

- **CVE Delta in `--diff` output**: Markdown and JSON diff output now includes a CVE Delta section showing newly introduced and resolved vulnerabilities (#600)
- **Severity/CVSS thresholds for `--diff` mode**: `--severity-threshold` and `--cvss-threshold` now filter CVE delta entries (#601)
- **`--lang` flag applies to `--diff -f markdown` output**: Section headings and labels are now rendered in the selected locale (#615)
- **Progress indicators in `--diff` CVE lookup**: indicatif spinner and per-package progress bar shown during OSV API calls (#611, #613)

## Post-Merge Steps
After merging:
1. `git checkout main && git pull origin main`
2. `git tag v2.5.0`
3. `git push origin v2.5.0`

---
Generated with [Claude Code](https://claude.com/claude-code)