### PR TITLE
feat(domain): add GroupReachabilityAnalyzer for dependency group filtering

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -221,6 +221,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `GenerateDiffUseCase<LR,DLR,VR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer, optionally fetches CVE delta via VulnerabilityRepository; 3rd param `VR` (default `()`) added in #599 |
 | `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; wired into `GenerateDiffUseCase` in #599; consumed by diff formatters (Markdown/JSON) in #600 |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
+| `GroupReachabilityAnalyzer` | `src/sbom_generation/domain/services/group_reachability_analyzer.rs` | Pure domain service for BFS-based group reachability traversal; determines which packages are exclusively reachable from excluded dependency groups (WIRE(#629)) |
 
 ### Important Invariants
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
     paths-ignore:
       - '**.md'
       - '.gitignore'
+      - 'examples/**'
+      - '.claude/**'
   pull_request:
     branches:
       - main
@@ -25,6 +27,8 @@ on:
     paths-ignore:
       - '**.md'
       - '.gitignore'
+      - 'examples/**'
+      - '.claude/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ on:
     paths-ignore:
       - '**.md'
       - '.gitignore'
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -155,7 +155,7 @@ pub fn parse_lockfile_content_for_member(
     Ok((packages, dependency_map))
 }
 
-#[allow(dead_code)] // WIRE(#622): remove when group reachability traversal calls parse_group_roots
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls read_and_parse_group_roots
 /// Parse `[manifest.dependency-groups]` from uv.lock content.
 ///
 /// Returns a map of group name → list of root package names.

--- a/src/ports/outbound/lockfile_reader.rs
+++ b/src/ports/outbound/lockfile_reader.rs
@@ -9,7 +9,7 @@ pub type DependencyMap = HashMap<String, Vec<String>>;
 /// Type alias for lockfile parsing result: (packages, dependency map)
 pub type LockfileParseResult = (Vec<Package>, DependencyMap);
 
-#[allow(dead_code)] // WIRE(#622): remove when group reachability traversal consumes GroupRoots
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls read_and_parse_group_roots
 /// Group name -> list of root package names declared for that dependency group.
 ///
 /// Extracted from `[manifest.dependency-groups]` in `uv.lock`.
@@ -78,7 +78,7 @@ pub trait LockfileReader {
         member_name: &str,
     ) -> Result<LockfileParseResult>;
 
-    #[allow(dead_code)] // WIRE(#622): remove when group reachability traversal calls read_and_parse_group_roots
+    #[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls read_and_parse_group_roots
     /// Extract dependency-group roots from `[manifest.dependency-groups]` in `uv.lock`.
     ///
     /// Returns an empty map when no `[manifest.dependency-groups]` section is present,

--- a/src/sbom_generation/domain/mod.rs
+++ b/src/sbom_generation/domain/mod.rs
@@ -25,6 +25,9 @@ pub use package::{Package, PackageName};
 #[allow(unused_imports)]
 pub use resolution_guide::{IntroducedBy, ResolutionEntry};
 pub use sbom_metadata::SbomMetadata;
+// Note: GroupReachabilityAnalyzer will be wired into the use case in #629
+#[allow(unused_imports)]
+pub use services::GroupReachabilityAnalyzer;
 // Note: ResolutionAnalyzer will be used in subsequent subtasks (Issue #221 sub-tasks 3-4)
 #[allow(unused_imports)]
 pub use services::ResolutionAnalyzer;

--- a/src/sbom_generation/domain/services/group_reachability_analyzer.rs
+++ b/src/sbom_generation/domain/services/group_reachability_analyzer.rs
@@ -34,10 +34,13 @@ impl GroupReachabilityAnalyzer {
         }
 
         let excluded_root_names = collect_excluded_root_names(group_roots, groups_to_exclude);
-        let production_reachable =
-            compute_production_reachable(dep_graph, &excluded_root_names);
-        let exclude_set =
-            compute_exclude_set(dep_graph, group_roots, groups_to_exclude, &production_reachable);
+        let production_reachable = compute_production_reachable(dep_graph, &excluded_root_names);
+        let exclude_set = compute_exclude_set(
+            dep_graph,
+            group_roots,
+            groups_to_exclude,
+            &production_reachable,
+        );
 
         all_packages
             .iter()
@@ -154,12 +157,7 @@ mod tests {
     fn make_group_roots(groups: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
         groups
             .iter()
-            .map(|&(g, roots)| {
-                (
-                    g.to_string(),
-                    roots.iter().map(|s| s.to_string()).collect(),
-                )
-            })
+            .map(|&(g, roots)| (g.to_string(), roots.iter().map(|s| s.to_string()).collect()))
             .collect()
     }
 
@@ -210,7 +208,10 @@ mod tests {
 
         let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
         assert!(!names.contains(&"pytest"), "dev root must be excluded");
-        assert!(!names.contains(&"iniconfig"), "dev transitive must be excluded");
+        assert!(
+            !names.contains(&"iniconfig"),
+            "dev transitive must be excluded"
+        );
         assert!(names.contains(&"requests"));
         assert!(names.contains(&"myapp"));
     }
@@ -218,12 +219,7 @@ mod tests {
     #[test]
     fn test_shared_package_retained() {
         // certifi is reachable from both production (requests) and dev (pytest)
-        let all_packages = vec![
-            pkg("myapp"),
-            pkg("requests"),
-            pkg("certifi"),
-            pkg("pytest"),
-        ];
+        let all_packages = vec![pkg("myapp"), pkg("requests"), pkg("certifi"), pkg("pytest")];
         let dep_graph = make_dep_graph(&[
             ("myapp", &["requests"]),
             ("requests", &["certifi"]),
@@ -240,7 +236,10 @@ mod tests {
         );
 
         let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
-        assert!(names.contains(&"certifi"), "shared package must be retained");
+        assert!(
+            names.contains(&"certifi"),
+            "shared package must be retained"
+        );
         assert!(!names.contains(&"pytest"), "dev-only root must be excluded");
     }
 
@@ -263,8 +262,11 @@ mod tests {
     #[test]
     fn test_empty_groups_to_exclude_returns_all() {
         let all_packages = vec![pkg("requests"), pkg("urllib3"), pkg("pytest")];
-        let dep_graph =
-            make_dep_graph(&[("requests", &["urllib3"]), ("urllib3", &[]), ("pytest", &[])]);
+        let dep_graph = make_dep_graph(&[
+            ("requests", &["urllib3"]),
+            ("urllib3", &[]),
+            ("pytest", &[]),
+        ]);
         let group_roots = make_group_roots(&[("dev", &["pytest"])]);
 
         let result = GroupReachabilityAnalyzer::filter_excluded_groups(
@@ -293,8 +295,7 @@ mod tests {
             ("iniconfig", &[]),
             ("ruff", &[]),
         ]);
-        let group_roots =
-            make_group_roots(&[("dev", &["pytest"]), ("lint", &["ruff"])]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"]), ("lint", &["ruff"])]);
 
         let result = GroupReachabilityAnalyzer::filter_excluded_groups(
             &all_packages,

--- a/src/sbom_generation/domain/services/group_reachability_analyzer.rs
+++ b/src/sbom_generation/domain/services/group_reachability_analyzer.rs
@@ -1,0 +1,339 @@
+use crate::sbom_generation::domain::Package;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Pure domain service that determines which packages should be retained
+/// in a production SBOM after excluding specified dependency groups.
+///
+/// Performs BFS graph traversal to distinguish packages exclusively reachable
+/// from dev/optional groups (safe to exclude) from those on any production path
+/// (must be retained).
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
+pub struct GroupReachabilityAnalyzer;
+
+impl GroupReachabilityAnalyzer {
+    /// Returns the subset of `all_packages` after removing packages that are
+    /// exclusively reachable from the specified dependency groups.
+    ///
+    /// A package is excluded only when:
+    /// - It is reachable from at least one excluded group root, AND
+    /// - It is NOT reachable from any production root.
+    ///
+    /// Production roots are packages in `dep_graph` that have no incoming edges
+    /// and are not roots of any excluded group.
+    ///
+    /// Unknown group names in `groups_to_exclude` are silently ignored.
+    #[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
+    pub fn filter_excluded_groups(
+        all_packages: &[Package],
+        dep_graph: &HashMap<String, Vec<String>>,
+        group_roots: &HashMap<String, Vec<String>>,
+        groups_to_exclude: &[String],
+    ) -> Vec<Package> {
+        if groups_to_exclude.is_empty() {
+            return all_packages.to_vec();
+        }
+
+        let excluded_root_names = collect_excluded_root_names(group_roots, groups_to_exclude);
+        let production_reachable =
+            compute_production_reachable(dep_graph, &excluded_root_names);
+        let exclude_set =
+            compute_exclude_set(dep_graph, group_roots, groups_to_exclude, &production_reachable);
+
+        all_packages
+            .iter()
+            .filter(|p| !exclude_set.contains(p.name()))
+            .cloned()
+            .collect()
+    }
+}
+
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
+fn collect_excluded_root_names<'a>(
+    group_roots: &'a HashMap<String, Vec<String>>,
+    groups_to_exclude: &[String],
+) -> HashSet<&'a str> {
+    groups_to_exclude
+        .iter()
+        .filter_map(|g| group_roots.get(g.as_str()))
+        .flat_map(|roots| roots.iter().map(|s| s.as_str()))
+        .collect()
+}
+
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
+fn compute_production_reachable(
+    dep_graph: &HashMap<String, Vec<String>>,
+    excluded_root_names: &HashSet<&str>,
+) -> HashSet<String> {
+    let mut has_parent: HashSet<&str> = HashSet::new();
+    for deps in dep_graph.values() {
+        for dep in deps {
+            has_parent.insert(dep.as_str());
+        }
+    }
+
+    // Production seeds: DAG roots that are not an excluded-group root.
+    let seeds: Vec<&str> = dep_graph
+        .keys()
+        .map(|k| k.as_str())
+        .filter(|name| !has_parent.contains(name) && !excluded_root_names.contains(name))
+        .collect();
+
+    bfs_reachable(dep_graph, &seeds)
+}
+
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
+fn compute_exclude_set(
+    dep_graph: &HashMap<String, Vec<String>>,
+    group_roots: &HashMap<String, Vec<String>>,
+    groups_to_exclude: &[String],
+    production_reachable: &HashSet<String>,
+) -> HashSet<String> {
+    let mut exclude_set = HashSet::new();
+    for group in groups_to_exclude {
+        let Some(roots) = group_roots.get(group.as_str()) else {
+            continue;
+        };
+        let seeds: Vec<&str> = roots.iter().map(|s| s.as_str()).collect();
+        let group_reachable = bfs_reachable(dep_graph, &seeds);
+        for pkg in group_reachable {
+            if !production_reachable.contains(&pkg) {
+                exclude_set.insert(pkg);
+            }
+        }
+    }
+    exclude_set
+}
+
+#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
+fn bfs_reachable(dep_graph: &HashMap<String, Vec<String>>, seeds: &[&str]) -> HashSet<String> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    for &seed in seeds {
+        if visited.insert(seed.to_string()) {
+            queue.push_back(seed.to_string());
+        }
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if let Some(deps) = dep_graph.get(&current) {
+            for dep in deps {
+                if visited.insert(dep.clone()) {
+                    queue.push_back(dep.clone());
+                }
+            }
+        }
+    }
+
+    visited
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pkg(name: &str) -> Package {
+        Package::new(name.to_string(), "1.0.0".to_string()).unwrap()
+    }
+
+    /// Build a dep_graph ensuring every mentioned package appears as a key.
+    fn make_dep_graph(edges: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for &(parent, deps) in edges {
+            let entry = map.entry(parent.to_string()).or_default();
+            for &dep in deps {
+                entry.push(dep.to_string());
+            }
+            for &dep in deps {
+                map.entry(dep.to_string()).or_default();
+            }
+        }
+        map
+    }
+
+    fn make_group_roots(groups: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+        groups
+            .iter()
+            .map(|&(g, roots)| {
+                (
+                    g.to_string(),
+                    roots.iter().map(|s| s.to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_production_only_package_retained() {
+        let all_packages = vec![pkg("myapp"), pkg("requests"), pkg("urllib3")];
+        let dep_graph = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &["urllib3"]),
+            ("urllib3", &[]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &["dev".to_string()],
+        );
+
+        let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
+        assert!(names.contains(&"requests"));
+        assert!(names.contains(&"urllib3"));
+    }
+
+    #[test]
+    fn test_dev_only_package_excluded() {
+        let all_packages = vec![
+            pkg("myapp"),
+            pkg("requests"),
+            pkg("pytest"),
+            pkg("iniconfig"),
+        ];
+        let dep_graph = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &[]),
+            ("pytest", &["iniconfig"]),
+            ("iniconfig", &[]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &["dev".to_string()],
+        );
+
+        let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
+        assert!(!names.contains(&"pytest"), "dev root must be excluded");
+        assert!(!names.contains(&"iniconfig"), "dev transitive must be excluded");
+        assert!(names.contains(&"requests"));
+        assert!(names.contains(&"myapp"));
+    }
+
+    #[test]
+    fn test_shared_package_retained() {
+        // certifi is reachable from both production (requests) and dev (pytest)
+        let all_packages = vec![
+            pkg("myapp"),
+            pkg("requests"),
+            pkg("certifi"),
+            pkg("pytest"),
+        ];
+        let dep_graph = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &["certifi"]),
+            ("pytest", &["certifi"]),
+            ("certifi", &[]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &["dev".to_string()],
+        );
+
+        let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
+        assert!(names.contains(&"certifi"), "shared package must be retained");
+        assert!(!names.contains(&"pytest"), "dev-only root must be excluded");
+    }
+
+    #[test]
+    fn test_unknown_group_name_ignored() {
+        let all_packages = vec![pkg("myapp"), pkg("requests")];
+        let dep_graph = make_dep_graph(&[("myapp", &["requests"]), ("requests", &[])]);
+        let group_roots: HashMap<String, Vec<String>> = HashMap::new();
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &["nonexistent".to_string()],
+        );
+
+        assert_eq!(result.len(), all_packages.len());
+    }
+
+    #[test]
+    fn test_empty_groups_to_exclude_returns_all() {
+        let all_packages = vec![pkg("requests"), pkg("urllib3"), pkg("pytest")];
+        let dep_graph =
+            make_dep_graph(&[("requests", &["urllib3"]), ("urllib3", &[]), ("pytest", &[])]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &[],
+        );
+
+        assert_eq!(result.len(), all_packages.len());
+    }
+
+    #[test]
+    fn test_multiple_groups_all_exclusive_packages_excluded() {
+        let all_packages = vec![
+            pkg("myapp"),
+            pkg("requests"),
+            pkg("pytest"),
+            pkg("ruff"),
+            pkg("iniconfig"),
+        ];
+        let dep_graph = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &[]),
+            ("pytest", &["iniconfig"]),
+            ("iniconfig", &[]),
+            ("ruff", &[]),
+        ]);
+        let group_roots =
+            make_group_roots(&[("dev", &["pytest"]), ("lint", &["ruff"])]);
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &["dev".to_string(), "lint".to_string()],
+        );
+
+        let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
+        assert!(!names.contains(&"pytest"));
+        assert!(!names.contains(&"iniconfig"));
+        assert!(!names.contains(&"ruff"));
+        assert!(names.contains(&"requests"));
+        assert!(names.contains(&"myapp"));
+    }
+
+    #[test]
+    fn test_cycle_in_dep_graph_handled_safely() {
+        // a -> b -> a (cycle), plus prod: myapp -> requests
+        let all_packages = vec![pkg("myapp"), pkg("requests"), pkg("a"), pkg("b")];
+        let dep_graph = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &[]),
+            ("a", &["b"]),
+            ("b", &["a"]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["a"])]);
+
+        let result = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &all_packages,
+            &dep_graph,
+            &group_roots,
+            &["dev".to_string()],
+        );
+
+        let names: Vec<&str> = result.iter().map(|p| p.name()).collect();
+        assert!(!names.contains(&"a"));
+        assert!(!names.contains(&"b"));
+        assert!(names.contains(&"requests"));
+        assert!(names.contains(&"myapp"));
+    }
+}

--- a/src/sbom_generation/domain/services/mod.rs
+++ b/src/sbom_generation/domain/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod cve_filter;
 pub mod dependency_diff_analyzer;
+pub mod group_reachability_analyzer;
 pub mod license_compliance_checker;
 pub mod resolution_analyzer;
 pub mod upgrade_advisor;
@@ -7,6 +8,7 @@ pub mod vulnerability_checker;
 
 #[allow(unused_imports)]
 pub use dependency_diff_analyzer::DependencyDiffAnalyzer;
+pub use group_reachability_analyzer::GroupReachabilityAnalyzer;
 pub use license_compliance_checker::LicenseComplianceChecker;
 pub use resolution_analyzer::ResolutionAnalyzer;
 pub use upgrade_advisor::UpgradeAdvisor;


### PR DESCRIPTION
## Summary

- Implement `GroupReachabilityAnalyzer` pure domain service in `src/sbom_generation/domain/services/`
- BFS-based graph traversal determines which packages are exclusively reachable from dev/optional dependency groups and can safely be excluded from a production SBOM
- Update WIRE annotations from #622 → #629 (consuming issue for `GenerateSbomUseCase` wiring)

## Related Issue

Closes #622
Part of #595

## Changes Made

- **New**: `src/sbom_generation/domain/services/group_reachability_analyzer.rs` — `GroupReachabilityAnalyzer` struct with `filter_excluded_groups` static method + 7 unit tests
- **Modified**: `src/sbom_generation/domain/services/mod.rs` — register and re-export new module
- **Modified**: `src/sbom_generation/domain/mod.rs` — re-export `GroupReachabilityAnalyzer` (with WIRE note for #629)
- **Modified**: `src/ports/outbound/lockfile_reader.rs` — update WIRE(#622) → WIRE(#629) on `GroupRoots` and `read_and_parse_group_roots`
- **Modified**: `src/adapters/outbound/filesystem/lockfile_parser.rs` — update WIRE(#622) → WIRE(#629) on `parse_group_roots`

## Algorithm

Production roots are identified as DAG nodes with no incoming edges that are not roots of any excluded group. BFS from production roots determines what is "production-reachable". A package is excluded only when it is group-reachable but NOT production-reachable — preserving the invariant that a package shared between production and a dev group is always retained.

## WIRE Annotations

This PR introduces `WIRE(#629)` annotations. Issue #629 (`feat(application): wire GroupReachabilityAnalyzer into GenerateSbomUseCase`) is open and will consume these items.

## Test Plan

- [x] `cargo test --lib --all` passes (754 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] 7 unit tests cover all acceptance criteria: production-only retained, dev-only excluded, shared package retained, unknown group silently ignored, empty groups returns all, multiple groups, cycle safety

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019jXpHVbTarusAArXHVr7Tj)_