### PR TITLE
feat(application): add exclude_groups to SbomRequest and wire GroupReachabilityAnalyzer

### DIFF
--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -155,7 +155,6 @@ pub fn parse_lockfile_content_for_member(
     Ok((packages, dependency_map))
 }
 
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls read_and_parse_group_roots
 /// Parse `[manifest.dependency-groups]` from uv.lock content.
 ///
 /// Returns a map of group name → list of root package names.

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -40,6 +40,9 @@ pub struct SbomRequest {
     /// Inactivity threshold in days for abandoned-package detection.
     /// Only meaningful when `check_abandoned` is true.
     pub abandoned_threshold_days: u64,
+    /// Dependency group names to exclude from the SBOM (e.g. ["dev", "lint"]).
+    /// Empty = no group filtering.
+    pub exclude_groups: Vec<String>,
     /// Output locale for human-readable formats
     pub locale: Locale,
 }
@@ -104,6 +107,7 @@ pub struct SbomRequestBuilder {
     suggest_fix: bool,
     check_abandoned: bool,
     abandoned_threshold_days: u64,
+    exclude_groups: Vec<String>,
     locale: Locale,
 }
 
@@ -133,6 +137,7 @@ impl SbomRequestBuilder {
             suggest_fix: false,
             check_abandoned: false,
             abandoned_threshold_days: 730,
+            exclude_groups: Vec::new(),
             locale: Locale::default(),
         }
     }
@@ -223,6 +228,13 @@ impl SbomRequestBuilder {
         self
     }
 
+    #[allow(dead_code)] // WIRE(#624): remove when --exclude-groups CLI flag calls this method
+    /// Sets dependency group names to exclude from the SBOM (e.g. `["dev", "lint"]`).
+    pub fn exclude_groups(mut self, groups: Vec<String>) -> Self {
+        self.exclude_groups = groups;
+        self
+    }
+
     /// Sets the output locale for human-readable formats.
     pub fn locale(mut self, locale: Locale) -> Self {
         self.locale = locale;
@@ -253,6 +265,7 @@ impl SbomRequestBuilder {
             suggest_fix: self.suggest_fix,
             check_abandoned: self.check_abandoned,
             abandoned_threshold_days: self.abandoned_threshold_days,
+            exclude_groups: self.exclude_groups,
             locale: self.locale,
         })
     }
@@ -284,6 +297,21 @@ mod tests {
         assert!(request.severity_threshold.is_none());
         assert!(request.cvss_threshold.is_none());
         assert!(request.ignore_cves.is_empty());
+        assert!(request.exclude_groups.is_empty());
+    }
+
+    #[test]
+    fn test_exclude_groups_builder() {
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .exclude_groups(vec!["dev".to_string(), "lint".to_string()])
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.exclude_groups,
+            vec!["dev".to_string(), "lint".to_string()]
+        );
     }
 
     #[test]

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -13,8 +13,8 @@ use crate::ports::outbound::{
 };
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::{
-    LicenseComplianceChecker, ResolutionAnalyzer, ThresholdConfig, UpgradeAdvisor,
-    VulnerabilityCheckResult, VulnerabilityChecker,
+    GroupReachabilityAnalyzer, LicenseComplianceChecker, ResolutionAnalyzer, ThresholdConfig,
+    UpgradeAdvisor, VulnerabilityCheckResult, VulnerabilityChecker,
 };
 use crate::sbom_generation::domain::{
     DependencyGraph, Package, PackageName, UpgradeRecommendation,
@@ -97,6 +97,11 @@ where
         // The root project may be excluded from packages but we still need its entry
         // in dependency_map to correctly identify direct vs transitive dependencies.
         let filtered_packages = self.apply_exclusion_filters(packages, &request)?;
+
+        // Step 2b: Apply group reachability filter when exclude_groups is non-empty.
+        // dependency_map is borrowed (not filtered) to preserve direct/transitive classification.
+        let filtered_packages =
+            self.apply_group_filter(filtered_packages, &dependency_map, &request)?;
 
         // Early return for dry-run mode (validation only)
         if request.dry_run {
@@ -325,6 +330,49 @@ where
         }
 
         Ok(filtered_pkgs)
+    }
+
+    /// Applies group reachability filtering when `exclude_groups` is non-empty.
+    ///
+    /// Reads `[manifest.dependency-groups]` from the lockfile, then delegates to
+    /// `GroupReachabilityAnalyzer::filter_excluded_groups` to remove packages that are
+    /// exclusively reachable from the specified groups.
+    ///
+    /// `dependency_map` is intentionally NOT filtered — Step 3 relies on the full map
+    /// to classify direct vs transitive dependencies (issue #206 invariant).
+    fn apply_group_filter(
+        &self,
+        packages: Vec<Package>,
+        dependency_map: &std::collections::HashMap<String, Vec<String>>,
+        request: &SbomRequest,
+    ) -> Result<Vec<Package>> {
+        if request.exclude_groups.is_empty() {
+            return Ok(packages);
+        }
+
+        let group_roots = self
+            .lockfile_reader
+            .read_and_parse_group_roots(&request.project_path)?;
+
+        let original_count = packages.len();
+        let filtered = GroupReachabilityAnalyzer::filter_excluded_groups(
+            &packages,
+            dependency_map,
+            &group_roots,
+            &request.exclude_groups,
+        );
+
+        let excluded_count = original_count - filtered.len();
+        if excluded_count > 0 {
+            let msgs = Messages::for_locale(self.locale);
+            let group_names = request.exclude_groups.join(", ");
+            self.progress_reporter.report(&Messages::format(
+                msgs.progress_excluded_groups,
+                &[&excluded_count.to_string(), &group_names],
+            ));
+        }
+
+        Ok(filtered)
     }
 
     /// Builds a response for dry-run mode (validation only)

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 struct MockLockfileReader {
     packages: Vec<Package>,
     deps: HashMap<String, Vec<String>>,
+    group_roots: GroupRoots,
 }
 
 impl LockfileReader for MockLockfileReader {
@@ -30,7 +31,7 @@ impl LockfileReader for MockLockfileReader {
     }
 
     fn read_and_parse_group_roots(&self, _path: &Path) -> Result<GroupRoots> {
-        Ok(HashMap::new())
+        Ok(self.group_roots.clone())
     }
 }
 
@@ -88,6 +89,7 @@ mod test_helpers {
     pub(super) struct UseCaseBuilder {
         packages: Vec<Package>,
         deps: HashMap<String, Vec<String>>,
+        group_roots: GroupRoots,
         project_name: String,
         vuln: Option<MockVulnerabilityRepository>,
         maint: Option<MockMaintenanceRepository>,
@@ -98,6 +100,7 @@ mod test_helpers {
             Self {
                 packages: Vec::new(),
                 deps: HashMap::new(),
+                group_roots: HashMap::new(),
                 project_name: "test-project".to_string(),
                 vuln: None,
                 maint: None,
@@ -121,6 +124,11 @@ mod test_helpers {
             self
         }
 
+        pub(super) fn with_group_roots(mut self, roots: GroupRoots) -> Self {
+            self.group_roots = roots;
+            self
+        }
+
         pub(super) fn with_project_name(mut self, name: impl Into<String>) -> Self {
             self.project_name = name.into();
             self
@@ -141,6 +149,7 @@ mod test_helpers {
                 MockLockfileReader {
                     packages: self.packages,
                     deps: self.deps,
+                    group_roots: self.group_roots,
                 },
                 MockProjectConfigReader {
                     project_name: self.project_name,
@@ -915,5 +924,157 @@ mod tests_regression {
 
         let response = use_case.execute(request).await.unwrap();
         assert_eq!(response.enriched_packages.len(), 1);
+    }
+}
+
+mod tests_group_exclusion {
+    use super::test_helpers::*;
+    use super::*;
+
+    fn make_dep_graph(edges: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for &(parent, deps) in edges {
+            let entry = map.entry(parent.to_string()).or_default();
+            for &dep in deps {
+                entry.push(dep.to_string());
+            }
+            for &dep in deps {
+                map.entry(dep.to_string()).or_default();
+            }
+        }
+        map
+    }
+
+    fn make_group_roots(groups: &[(&str, &[&str])]) -> GroupRoots {
+        groups
+            .iter()
+            .map(|&(g, roots)| (g.to_string(), roots.iter().map(|s| s.to_string()).collect()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_empty_exclude_groups_returns_all_packages() {
+        let packages = vec![
+            pkg("myapp", "1.0.0"),
+            pkg("requests", "2.0.0"),
+            pkg("pytest", "7.0.0"),
+        ];
+        let deps = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &[]),
+            ("pytest", &[]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_group_roots(group_roots)
+            .build();
+
+        let response = use_case.execute(default_request()).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_dev_only_package_excluded_via_execute() {
+        let packages = vec![
+            pkg("myapp", "1.0.0"),
+            pkg("requests", "2.0.0"),
+            pkg("pytest", "7.0.0"),
+            pkg("iniconfig", "2.0.0"),
+        ];
+        let deps = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &[]),
+            ("pytest", &["iniconfig"]),
+            ("iniconfig", &[]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_group_roots(group_roots)
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .exclude_groups(vec!["dev".to_string()])
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        let names: Vec<&str> = response
+            .enriched_packages
+            .iter()
+            .map(|ep| ep.package.name())
+            .collect();
+        assert!(!names.contains(&"pytest"), "dev root must be excluded");
+        assert!(
+            !names.contains(&"iniconfig"),
+            "dev transitive must be excluded"
+        );
+        assert!(names.contains(&"requests"));
+        assert!(names.contains(&"myapp"));
+    }
+
+    #[tokio::test]
+    async fn test_shared_package_retained() {
+        let packages = vec![
+            pkg("myapp", "1.0.0"),
+            pkg("requests", "2.0.0"),
+            pkg("certifi", "2024.1.1"),
+            pkg("pytest", "7.0.0"),
+        ];
+        let deps = make_dep_graph(&[
+            ("myapp", &["requests"]),
+            ("requests", &["certifi"]),
+            ("pytest", &["certifi"]),
+            ("certifi", &[]),
+        ]);
+        let group_roots = make_group_roots(&[("dev", &["pytest"])]);
+
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_group_roots(group_roots)
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .exclude_groups(vec!["dev".to_string()])
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        let names: Vec<&str> = response
+            .enriched_packages
+            .iter()
+            .map(|ep| ep.package.name())
+            .collect();
+        assert!(names.contains(&"certifi"), "shared package must be retained");
+        assert!(!names.contains(&"pytest"), "dev-only root must be excluded");
+    }
+
+    #[tokio::test]
+    async fn test_unknown_group_name_is_ignored() {
+        let packages = vec![pkg("myapp", "1.0.0"), pkg("requests", "2.0.0")];
+        let deps = make_dep_graph(&[("myapp", &["requests"]), ("requests", &[])]);
+
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile_and_deps(packages, deps)
+            .with_group_roots(HashMap::new())
+            .build();
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .exclude_groups(vec!["nonexistent".to_string()])
+            .build()
+            .unwrap();
+
+        let response = use_case.execute(request).await.unwrap();
+
+        assert_eq!(response.enriched_packages.len(), 2);
     }
 }

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -959,11 +959,7 @@ mod tests_group_exclusion {
             pkg("requests", "2.0.0"),
             pkg("pytest", "7.0.0"),
         ];
-        let deps = make_dep_graph(&[
-            ("myapp", &["requests"]),
-            ("requests", &[]),
-            ("pytest", &[]),
-        ]);
+        let deps = make_dep_graph(&[("myapp", &["requests"]), ("requests", &[]), ("pytest", &[])]);
         let group_roots = make_group_roots(&[("dev", &["pytest"])]);
 
         let use_case = UseCaseBuilder::default()
@@ -1053,7 +1049,10 @@ mod tests_group_exclusion {
             .iter()
             .map(|ep| ep.package.name())
             .collect();
-        assert!(names.contains(&"certifi"), "shared package must be retained");
+        assert!(
+            names.contains(&"certifi"),
+            "shared package must be retained"
+        );
         assert!(!names.contains(&"pytest"), "dev-only root must be excluded");
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -95,6 +95,7 @@ pub struct Messages {
     pub progress_fetching_abandoned: &'static str,
     pub progress_abandoned_found: &'static str,
     pub progress_abandoned_none: &'static str,
+    pub progress_excluded_groups: &'static str,
 
     // Section description paragraphs
     pub desc_sbom_report: &'static str,
@@ -303,6 +304,7 @@ static EN_MESSAGES: Messages = Messages {
     progress_fetching_abandoned: "🔍 Fetching package maintenance information...",
     progress_abandoned_found: "✅ Abandoned check complete: {} package(s) abandoned ({} direct, {} transitive), threshold: {} days",
     progress_abandoned_none: "✅ Abandoned check complete: No packages exceed {} day threshold",
+    progress_excluded_groups: "🚫 Excluded {} package(s) from dependency group(s): {}",
 
     // Section description paragraphs
     desc_sbom_report: "A comprehensive list of all software components and libraries included in this project.",
@@ -479,6 +481,7 @@ static JA_MESSAGES: Messages = Messages {
     progress_fetching_abandoned: "🔍 パッケージのメンテナンス情報を取得中...",
     progress_abandoned_found: "✅ 廃止パッケージチェック完了: {}件廃止（直接: {}件、間接: {}件）、閾値: {}日",
     progress_abandoned_none: "✅ 廃止パッケージチェック完了: {}日以上更新のないパッケージはありません",
+    progress_excluded_groups: "🚫 依存関係グループから{}個のパッケージを除外: {}",
 
     // Section description paragraphs
     desc_sbom_report: "このプロジェクトに含まれるすべてのソフトウェアコンポーネントとライブラリの一覧です。",

--- a/src/ports/outbound/lockfile_reader.rs
+++ b/src/ports/outbound/lockfile_reader.rs
@@ -9,7 +9,6 @@ pub type DependencyMap = HashMap<String, Vec<String>>;
 /// Type alias for lockfile parsing result: (packages, dependency map)
 pub type LockfileParseResult = (Vec<Package>, DependencyMap);
 
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls read_and_parse_group_roots
 /// Group name -> list of root package names declared for that dependency group.
 ///
 /// Extracted from `[manifest.dependency-groups]` in `uv.lock`.
@@ -78,7 +77,6 @@ pub trait LockfileReader {
         member_name: &str,
     ) -> Result<LockfileParseResult>;
 
-    #[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls read_and_parse_group_roots
     /// Extract dependency-group roots from `[manifest.dependency-groups]` in `uv.lock`.
     ///
     /// Returns an empty map when no `[manifest.dependency-groups]` section is present,

--- a/src/sbom_generation/domain/mod.rs
+++ b/src/sbom_generation/domain/mod.rs
@@ -25,7 +25,6 @@ pub use package::{Package, PackageName};
 #[allow(unused_imports)]
 pub use resolution_guide::{IntroducedBy, ResolutionEntry};
 pub use sbom_metadata::SbomMetadata;
-// Note: GroupReachabilityAnalyzer will be wired into the use case in #629
 #[allow(unused_imports)]
 pub use services::GroupReachabilityAnalyzer;
 // Note: ResolutionAnalyzer will be used in subsequent subtasks (Issue #221 sub-tasks 3-4)

--- a/src/sbom_generation/domain/services/group_reachability_analyzer.rs
+++ b/src/sbom_generation/domain/services/group_reachability_analyzer.rs
@@ -7,7 +7,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// Performs BFS graph traversal to distinguish packages exclusively reachable
 /// from dev/optional groups (safe to exclude) from those on any production path
 /// (must be retained).
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
 pub struct GroupReachabilityAnalyzer;
 
 impl GroupReachabilityAnalyzer {
@@ -22,7 +21,6 @@ impl GroupReachabilityAnalyzer {
     /// and are not roots of any excluded group.
     ///
     /// Unknown group names in `groups_to_exclude` are silently ignored.
-    #[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
     pub fn filter_excluded_groups(
         all_packages: &[Package],
         dep_graph: &HashMap<String, Vec<String>>,
@@ -50,7 +48,6 @@ impl GroupReachabilityAnalyzer {
     }
 }
 
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
 fn collect_excluded_root_names<'a>(
     group_roots: &'a HashMap<String, Vec<String>>,
     groups_to_exclude: &[String],
@@ -62,7 +59,6 @@ fn collect_excluded_root_names<'a>(
         .collect()
 }
 
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
 fn compute_production_reachable(
     dep_graph: &HashMap<String, Vec<String>>,
     excluded_root_names: &HashSet<&str>,
@@ -84,7 +80,6 @@ fn compute_production_reachable(
     bfs_reachable(dep_graph, &seeds)
 }
 
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
 fn compute_exclude_set(
     dep_graph: &HashMap<String, Vec<String>>,
     group_roots: &HashMap<String, Vec<String>>,
@@ -107,7 +102,6 @@ fn compute_exclude_set(
     exclude_set
 }
 
-#[allow(dead_code)] // WIRE(#629): remove when GenerateSbomUseCase calls filter_excluded_groups
 fn bfs_reachable(dep_graph: &HashMap<String, Vec<String>>, seeds: &[&str]) -> HashSet<String> {
     let mut visited: HashSet<String> = HashSet::new();
     let mut queue: VecDeque<String> = VecDeque::new();


### PR DESCRIPTION
## Summary

- Add `exclude_groups: Vec<String>` field to `SbomRequest` and `SbomRequestBuilder` (defaults to empty — no behavioral change for existing callers)
- Wire `GroupReachabilityAnalyzer::filter_excluded_groups` into `GenerateSbomUseCase::execute` as Step 2b, invoked after pattern-based exclusion and before dry-run check
- Remove all 9 WIRE(#629) dead_code annotations now that the annotated items are called

## Related Issue

Closes #623
Part of #595

> ⚠️ CHANGELOG not updated — author confirmed internal-only (no CLI flag yet; user-facing change deferred to #624).

## Changes Made

- `src/application/dto/sbom_request.rs`: add `exclude_groups` field + builder method (WIRE(#624) since main.rs does not call it yet)
- `src/application/use_cases/generate_sbom/mod.rs`: add `apply_group_filter` private helper; call it in `execute` between pattern exclusion and dry-run check; import `GroupReachabilityAnalyzer`
- `src/i18n/mod.rs`: add `progress_excluded_groups` key to both `EN_MESSAGES` and `JA_MESSAGES`
- `src/ports/outbound/lockfile_reader.rs`: remove 2 WIRE(#629) annotations
- `src/adapters/outbound/filesystem/lockfile_parser.rs`: remove 1 WIRE(#629) annotation
- `src/sbom_generation/domain/services/group_reachability_analyzer.rs`: remove 6 WIRE(#629) annotations
- `src/sbom_generation/domain/mod.rs`: remove stale TODO comment referencing #629
- `src/application/use_cases/generate_sbom/tests.rs`: extend `MockLockfileReader` and `UseCaseBuilder` with `group_roots`; add `tests_group_exclusion` module with 4 integration-level tests

## Test Plan

- [x] `cargo test --all-targets --all-features` passes (794 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New tests cover: no-op empty groups, dev-only exclusion end-to-end, shared-package retention, unknown group name silently ignored

---
Generated with [Claude Code](https://claude.com/claude-code)