### PR TITLE
feat(cli): add --exclude-groups and --production-only flags with config key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--exclude-groups` and `--production-only` CLI flags**: Exclude packages that are exclusively reachable through specified dependency groups. `--exclude-groups dev,test,lint` accepts a comma-separated list of group names; `--production-only` automatically discovers all non-default groups from `[manifest.dependency-groups]` in `uv.lock` and excludes them. The two flags are mutually exclusive. A corresponding `exclude_groups` config key is supported in `uv-sbom.config.yml`; CLI overrides config entirely (not merged). Implemented as part of the group-based SBOM filtering feature (#624).
+
 ## [2.5.0] - 2026-06-08
 
 ### Added

--- a/README-JP.md
+++ b/README-JP.md
@@ -235,6 +235,35 @@ uv-sbom --format json --output sbom.json -e "pytest" -e "*-dev"
 **情報の外部送信を防止する:**
 独自の社内ライブラリなど、PyPI等の外部レジストリに名前を送信したくないパッケージがある場合は、`--exclude` オプションを使用してください。これにより、メタデータ取得時の通信から特定のライブラリ名を除外し、秘匿性を保つことができます。
 
+### 依存関係グループによるパッケージの除外
+
+`--exclude-groups` を使用すると、指定した[依存関係グループ](https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups)（例: `dev`, `test`, `lint`）からのみ到達可能なパッケージを除外できます。本番の依存関係と共有されているパッケージは常に保持されます。
+
+```bash
+# "dev"グループからのみ到達可能なパッケージを除外
+uv-sbom --exclude-groups dev --format markdown
+
+# 複数グループを除外（カンマ区切り）
+uv-sbom --exclude-groups dev,test,lint --format markdown
+
+# プロダクションのみモード: すべての非デフォルト依存関係グループを自動的に除外
+uv-sbom --production-only --format markdown
+```
+
+`--production-only` は実行時に `uv.lock` ファイルの `[manifest.dependency-groups]` セクションを読み込み、検出されたすべてのグループに `--exclude-groups` を設定します。グループを明示的にすべて列挙するのと同等ですが、より簡潔で、グループの追加・削除に自動で対応します。
+
+> **注意:** `--exclude-groups` と `--production-only` は相互排他的です。
+
+設定ファイルでも指定できます:
+
+```yaml
+# これらの依存関係グループからのみ到達可能なパッケージを除外
+exclude_groups:
+  - dev
+  - test
+  - lint
+```
+
 ### 設定ファイル
 
 設定ファイル（`uv-sbom.config.yml`）を使用して、毎回コマンドラインでオプションを渡す代わりにデフォルトオプションを設定できます。
@@ -318,6 +347,7 @@ license_policy:
 | `license_policy.unknown` | string | No | 不明ライセンスの処理（`warn` / `deny` / `allow`） |
 | `check_abandoned` | bool | No | 廃止パッケージ検出を有効化（オプトイン、デフォルト: false） |
 | `abandoned_threshold_days` | integer | No | 廃止パッケージ検出の非アクティブ期間しきい値（日数、デフォルト: 730） |
+| `exclude_groups` | string[] | No | SBOMから除外する依存関係グループ（そのグループからのみ到達可能なパッケージを除外） |
 
 #### 優先度とマージルール
 
@@ -328,6 +358,7 @@ license_policy:
 - **`check_license`** はCLIフラグまたは設定ファイルのいずれかで設定されていれば有効化（論理OR、`check_cve`と同様）
 - **`--license-allow`** と **`--license-deny`** CLIオプションは設定ファイルの `license_policy.allow` / `license_policy.deny` を**完全に上書き**します（マージされません）
 - **`check_abandoned`** はオプトイン（デフォルト: false）です。CLIフラグ `--check-abandoned` または設定ファイルの `check_abandoned: true` で有効化できます。`abandoned_threshold_days` の値はCLI > 設定ファイル > デフォルト（730）の順に解決されます。
+- **`exclude_groups`**: CLIの `--exclude-groups` は設定ファイルの値を**完全に上書き**します（マージされません）。`--production-only` は実行時にlockfileからすべてのグループ名を解決し、CLIと設定ファイルの両方より優先されます。
 
 ### 特定のCVEを無視する
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,35 @@ uv-sbom --format json --output sbom.json -e "pytest" -e "*-dev"
 **Preventing Information Leakage:**
 Use the `--exclude` option to skip specific internal or proprietary libraries. This prevents their names from being sent to external registries (like PyPI) during metadata retrieval, ensuring your internal project structure remains private.
 
+### Excluding packages by dependency group
+
+Use `--exclude-groups` to exclude packages that are **exclusively reachable** through specified [dependency groups](https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups) (e.g., `dev`, `test`, `lint`). Packages shared with production dependencies are always retained.
+
+```bash
+# Exclude packages only reachable via the "dev" group
+uv-sbom --exclude-groups dev --format markdown
+
+# Exclude multiple groups (comma-separated)
+uv-sbom --exclude-groups dev,test,lint --format markdown
+
+# Production-only mode: exclude ALL non-default dependency groups automatically
+uv-sbom --production-only --format markdown
+```
+
+`--production-only` reads the `[manifest.dependency-groups]` section of your `uv.lock` file at runtime and sets `--exclude-groups` to every group it finds. This is equivalent to listing all groups explicitly but is more concise and automatically adapts as groups are added or removed.
+
+> **Note:** `--exclude-groups` and `--production-only` are mutually exclusive.
+
+You can also set this in the config file:
+
+```yaml
+# Exclude packages reachable only through these dependency groups
+exclude_groups:
+  - dev
+  - test
+  - lint
+```
+
 ### Configuration file
 
 You can use a configuration file (`uv-sbom.config.yml`) to set default options instead of passing them on the command line every time.
@@ -319,6 +348,7 @@ license_policy:
 | `license_policy.unknown` | string | No | Unknown license handling (`warn` / `deny` / `allow`) |
 | `check_abandoned` | bool | No | Enable abandoned package detection (opt-in, default: false) |
 | `abandoned_threshold_days` | integer | No | Inactivity threshold in days for abandoned package detection (default: 730) |
+| `exclude_groups` | string[] | No | Dependency groups whose exclusively-reachable packages are excluded from the SBOM |
 
 #### Priority and Merge Rules
 
@@ -329,6 +359,7 @@ license_policy:
 - **`check_license`** is enabled if set via CLI flag OR config file (logical OR, same as `check_cve`)
 - **`--license-allow`** and **`--license-deny`** CLI options **override** config file `license_policy.allow` / `license_policy.deny` entirely (not merged)
 - **`check_abandoned`** is opt-in (default: false). Enable via CLI flag `--check-abandoned` or config file `check_abandoned: true`. The `abandoned_threshold_days` value follows CLI > config file > default (730) resolution order.
+- **`exclude_groups`**: CLI `--exclude-groups` **overrides** the config file value entirely (not merged). `--production-only` resolves all group names from the lockfile at runtime and takes precedence over both CLI and config.
 
 ### Ignoring specific CVEs
 

--- a/examples/sample-project/config/uv-sbom.config.yml
+++ b/examples/sample-project/config/uv-sbom.config.yml
@@ -40,6 +40,11 @@ license_policy:
     - "AGPL-*"
   unknown: warn
 
+# Exclude packages reachable only through these dependency groups (e.g. dev, test, lint)
+# exclude_groups:
+#   - dev
+#   - test
+
 ignore_cves:
   # pillow 8.3.2 - CRITICAL: buffer overflow in TiffDecode.c
   - id: GHSA-8vj2-vxx3-667w

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -228,7 +228,6 @@ impl SbomRequestBuilder {
         self
     }
 
-    #[allow(dead_code)] // WIRE(#624): remove when --exclude-groups CLI flag calls this method
     /// Sets dependency group names to exclude from the SBOM (e.g. `["dev", "lint"]`).
     pub fn exclude_groups(mut self, groups: Vec<String>) -> Self {
         self.exclude_groups = groups;

--- a/src/cli/config_resolver.rs
+++ b/src/cli/config_resolver.rs
@@ -20,6 +20,11 @@ pub struct MergedConfig {
     pub suggest_fix: bool,
     pub check_abandoned: bool,
     pub abandoned_threshold_days: u64,
+    /// Dependency groups whose exclusively-reachable packages should be excluded from the SBOM.
+    /// Populated from `--exclude-groups` (CLI) or `exclude_groups` (config file).
+    /// When `--production-only` is set, `main.rs` overrides this with all group names from the
+    /// lockfile, since that resolution requires I/O that config_resolver must not perform.
+    pub exclude_groups: Vec<String>,
 }
 
 /// Load a config file from an explicit path or via auto-discovery.
@@ -133,6 +138,7 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
                 suggest_fix: args.suggest_fix,
                 check_abandoned: args.check_abandoned,
                 abandoned_threshold_days: args.abandoned_threshold_days.unwrap_or(730),
+                exclude_groups: args.exclude_groups.clone(),
             };
         }
     };
@@ -248,6 +254,15 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
         .or(config.abandoned_threshold_days)
         .unwrap_or(730);
 
+    // exclude_groups: CLI overrides config entirely (not merged/deduplicated like exclude_patterns).
+    // --production-only is resolved in main.rs after lockfile I/O; when it is set, args.exclude_groups
+    // is guaranteed empty by clap's conflicts_with, so this resolves to the config value or empty.
+    let exclude_groups = if !args.exclude_groups.is_empty() {
+        args.exclude_groups.clone()
+    } else {
+        config.exclude_groups.clone().unwrap_or_default()
+    };
+
     MergedConfig {
         format,
         exclude_patterns,
@@ -260,6 +275,7 @@ pub fn merge_config(args: &Args, config: &Option<ConfigFile>) -> MergedConfig {
         suggest_fix,
         check_abandoned,
         abandoned_threshold_days,
+        exclude_groups,
     }
 }
 
@@ -668,5 +684,70 @@ mod tests {
         let result = merge_config(&args, &None);
         assert!(result.check_abandoned);
         assert_eq!(result.abandoned_threshold_days, 180);
+    }
+
+    // --- exclude_groups merge tests ---
+
+    #[test]
+    fn test_merge_config_exclude_groups_default_empty() {
+        // No CLI flag, no config → exclude_groups is empty
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert!(result.exclude_groups.is_empty());
+    }
+
+    #[test]
+    fn test_merge_config_exclude_groups_from_cli() {
+        // --exclude-groups dev,test → populated from CLI
+        let args = Args::parse_from(["uv-sbom", "--exclude-groups", "dev,test"]);
+        let config = Some(ConfigFile {
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.exclude_groups, vec!["dev", "test"]);
+    }
+
+    #[test]
+    fn test_merge_config_exclude_groups_from_config() {
+        // No CLI flag, config provides exclude_groups
+        let args = Args::parse_from(["uv-sbom"]);
+        let config = Some(ConfigFile {
+            exclude_groups: Some(vec!["dev".to_string(), "lint".to_string()]),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.exclude_groups, vec!["dev", "lint"]);
+    }
+
+    #[test]
+    fn test_merge_config_exclude_groups_cli_overrides_config() {
+        // CLI wins entirely — does NOT merge with config (unlike exclude_patterns)
+        let args = Args::parse_from(["uv-sbom", "--exclude-groups", "dev"]);
+        let config = Some(ConfigFile {
+            exclude_groups: Some(vec!["lint".to_string()]),
+            ..Default::default()
+        });
+        let result = merge_config(&args, &config);
+        assert_eq!(result.exclude_groups, vec!["dev"]);
+        assert!(!result.exclude_groups.contains(&"lint".to_string()));
+    }
+
+    #[test]
+    fn test_merge_config_no_config_file_exclude_groups() {
+        // No config file; exercises the early-return branch with --exclude-groups
+        let args = Args::parse_from(["uv-sbom", "--exclude-groups", "dev,test,lint"]);
+        let result = merge_config(&args, &None);
+        assert_eq!(result.exclude_groups, vec!["dev", "test", "lint"]);
+    }
+
+    #[test]
+    fn test_merge_config_no_config_file_exclude_groups_default_empty() {
+        // No CLI, no config file → empty (early-return branch)
+        let args = Args::parse_from(["uv-sbom"]);
+        let result = merge_config(&args, &None);
+        assert!(result.exclude_groups.is_empty());
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,6 +105,16 @@ pub struct Args {
     /// Output language for human-readable formats: en (default) or ja
     #[arg(long, default_value = "en", value_parser = parse_lang)]
     pub lang: Locale,
+
+    /// Exclude packages reachable only through the specified dependency groups (comma-separated).
+    /// Example: --exclude-groups dev,test,lint
+    #[arg(long, value_delimiter = ',')]
+    pub exclude_groups: Vec<String>,
+
+    /// Exclude all non-default dependency groups (production-only mode).
+    /// Equivalent to --exclude-groups <all-groups>.
+    #[arg(long, conflicts_with = "exclude_groups")]
+    pub production_only: bool,
 }
 
 fn parse_lang(s: &str) -> Result<Locale, String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,11 @@ const CONFIG_TEMPLATE: &str = r#"# uv-sbom configuration file
 
 # Inactivity threshold in days for abandoned-package detection (default: 730)
 # abandoned_threshold_days: 730
+
+# Dependency groups to exclude from the SBOM (e.g. dev, test, lint)
+# exclude_groups:
+#   - "dev"
+#   - "test"
 "#;
 
 /// Generate a config template file in the specified directory.
@@ -109,6 +114,7 @@ pub struct ConfigFile {
     pub suggest_fix: Option<bool>,
     pub check_abandoned: Option<bool>,
     pub abandoned_threshold_days: Option<u64>,
+    pub exclude_groups: Option<Vec<String>>,
     /// Captures unknown fields for warnings.
     #[serde(flatten)]
     pub unknown_fields: HashMap<String, serde_yaml_ng::Value>,
@@ -375,7 +381,28 @@ another_unknown: value
         assert!(config.ignore_cves.is_none());
         assert!(config.check_abandoned.is_none());
         assert!(config.abandoned_threshold_days.is_none());
+        assert!(config.exclude_groups.is_none());
         assert!(config.unknown_fields.is_empty());
+    }
+
+    #[test]
+    fn test_load_config_with_exclude_groups() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("config.yml");
+        fs::write(
+            &config_path,
+            r#"
+exclude_groups:
+  - dev
+  - test
+  - lint
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from_path(&config_path).unwrap();
+        let groups = config.exclude_groups.unwrap();
+        assert_eq!(groups, vec!["dev", "test", "lint"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,17 @@ async fn run(args: Args) -> Result<bool> {
     // Pre-flight check for --suggest-fix
     let suggest_fix = resolve_suggest_fix(merged.suggest_fix, &project_path);
 
+    // Resolve exclude_groups: --production-only expands to all group names in the lockfile.
+    // This requires lockfile I/O so it lives here rather than in config_resolver.
+    let exclude_groups = if args.production_only {
+        FileSystemReader::new()
+            .read_and_parse_group_roots(&project_path)?
+            .into_keys()
+            .collect::<Vec<_>>()
+    } else {
+        merged.exclude_groups.clone()
+    };
+
     // Create request using builder pattern
     let include_dependency_info = matches!(merged.format, OutputFormat::Markdown);
     let request = SbomRequest::builder()
@@ -288,6 +299,7 @@ async fn run(args: Args) -> Result<bool> {
         .suggest_fix(suggest_fix)
         .check_abandoned(merged.check_abandoned)
         .abandoned_threshold_days(merged.abandoned_threshold_days)
+        .exclude_groups(exclude_groups)
         .locale(locale)
         .build()?;
 
@@ -407,6 +419,17 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
     let config = load_config(&args, &workspace_root)?;
     let merged = merge_config(&args, &config);
 
+    // Resolve exclude_groups for workspace mode: --production-only reads group roots from
+    // the workspace-root lockfile. --exclude-groups / config value is used otherwise.
+    let workspace_exclude_groups = if args.production_only {
+        FileSystemReader::new()
+            .read_and_parse_group_roots(&workspace_root)?
+            .into_keys()
+            .collect::<Vec<_>>()
+    } else {
+        merged.exclude_groups.clone()
+    };
+
     let format_ext = match merged.format {
         OutputFormat::Json => "json",
         OutputFormat::Markdown => "md",
@@ -463,6 +486,7 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             .suggest_fix(false)
             .check_abandoned(merged.check_abandoned)
             .abandoned_threshold_days(merged.abandoned_threshold_days)
+            .exclude_groups(workspace_exclude_groups.clone())
             .locale(locale)
             .build()?;
 


### PR DESCRIPTION
## Summary

- Add `--exclude-groups dev,test,lint` CLI flag: excludes packages exclusively reachable through the specified dependency groups (comma-separated). CLI overrides config file entirely (not merged, unlike `--exclude`).
- Add `--production-only` flag: auto-discovers all non-default group names from `[manifest.dependency-groups]` in `uv.lock` at runtime and applies them as `exclude_groups`. Mutually exclusive with `--exclude-groups`.
- Add `exclude_groups` config key in `ConfigFile` and `CONFIG_TEMPLATE`; wire through `MergedConfig` with CLI > config file > empty priority order.

## Related Issue

Closes #624
Part of #595

## Changes Made

- `src/cli/mod.rs`: Add `exclude_groups: Vec<String>` (`value_delimiter = ','`) and `production_only: bool` (`conflicts_with = "exclude_groups"`) to `Args`
- `src/config.rs`: Add `exclude_groups: Option<Vec<String>>` to `ConfigFile`; add commented template entry to `CONFIG_TEMPLATE`
- `src/cli/config_resolver.rs`: Add `exclude_groups: Vec<String>` to `MergedConfig`; implement CLI-overrides-config merge logic (not merged/deduplicated); add 6 unit tests
- `src/application/dto/sbom_request.rs`: Remove `#[allow(dead_code)] // WIRE(#624)` annotation from `SbomRequestBuilder::exclude_groups` (WIRE gate cleanup)
- `src/main.rs`: Resolve `--production-only` by reading lockfile group roots via `FileSystemReader::read_and_parse_group_roots` (deferred from `config_resolver` to keep it I/O-free); wire `exclude_groups` into `SbomRequest::builder()` in both `run()` and `run_workspace()`
- `README.md` / `README-JP.md`: New "Excluding packages by dependency group" section; `exclude_groups` config schema table entry; priority rules note
- `examples/sample-project/config/uv-sbom.config.yml`: Commented `exclude_groups` example entry
- `CHANGELOG.md`: `[Unreleased]` entry under `### Added`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [x] `cargo test --lib` passes (760 unit tests)
- [x] Code review: PASS (no findings)
- [x] WIRE(#624) annotation removed from `SbomRequestBuilder::exclude_groups`
- [x] `test_merge_config_exclude_groups_*` (6 tests): CLI, config, CLI-overrides-config, default-empty, no-config-file variants
- [x] `test_load_config_with_exclude_groups`: YAML parsing of `exclude_groups`
- [x] `test_default_config`: asserts `config.exclude_groups.is_none()`
- [x] `test_template_is_valid_yaml_when_uncommented`: validates new template entry

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUpYST1pma7iSuvAcatFG5)_