### PR TITLE
docs: add --exclude-groups and --production-only to command-line options section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -221,7 +221,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `GenerateDiffUseCase<LR,DLR,VR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer, optionally fetches CVE delta via VulnerabilityRepository; 3rd param `VR` (default `()`) added in #599 |
 | `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; wired into `GenerateDiffUseCase` in #599; consumed by diff formatters (Markdown/JSON) in #600 |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
-| `GroupReachabilityAnalyzer` | `src/sbom_generation/domain/services/group_reachability_analyzer.rs` | Pure domain service for BFS-based group reachability traversal; determines which packages are exclusively reachable from excluded dependency groups (WIRE(#629)) |
+| `GroupReachabilityAnalyzer` | `src/sbom_generation/domain/services/group_reachability_analyzer.rs` | Pure domain service for BFS-based group reachability traversal; wired into `GenerateSbomUseCase` via `apply_group_filter` in #623 |
+| `GroupRoots` | `src/ports/outbound/lockfile_reader.rs` | Type alias `HashMap<String, Vec<String>>` mapping dependency group name → root package names; extracted from `[manifest.dependency-groups]` in `uv.lock`; consumed by group reachability traversal in #622; wired into use case in #623 |
 
 ### Important Invariants
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -910,6 +910,10 @@ Options:
       --check-license                ライセンスコンプライアンスをポリシーに対してチェック
       --license-allow <LIST>         許可するライセンスパターンのカンマ区切りリスト（設定ファイルを上書き）
       --license-deny <LIST>          拒否するライセンスパターンのカンマ区切りリスト（設定ファイルを上書き）
+      --exclude-groups <GROUPS>      指定した依存関係グループからのみ到達可能なパッケージを除外（カンマ区切り）
+                                     例: --exclude-groups dev,test,lint。--production-onlyとの同時使用は不可
+      --production-only              すべての非デフォルト依存関係グループを除外（プロダクションのみモード）
+                                     --exclude-groupsとの同時使用は不可
   -h, --help                         ヘルプを表示
   -V, --version                      バージョンを表示
 ```

--- a/README.md
+++ b/README.md
@@ -916,6 +916,10 @@ Options:
       --check-license                Check license compliance against policy
       --license-allow <LIST>         Comma-separated list of allowed license patterns (overrides config)
       --license-deny <LIST>          Comma-separated list of denied license patterns (overrides config)
+      --exclude-groups <GROUPS>      Exclude packages reachable only through the specified dependency groups (comma-separated)
+                                     Example: --exclude-groups dev,test,lint. Cannot be used with --production-only
+      --production-only              Exclude all non-default dependency groups (production-only mode)
+                                     Cannot be used with --exclude-groups
   -h, --help                         Print help
   -V, --version                      Print version
 ```


### PR DESCRIPTION
## Summary
- Add `--exclude-groups` and `--production-only` to the \"Command-line options\" reference block in `README.md`
- Add corresponding Japanese entries to the コマンドラインオプション block in `README-JP.md`
- Update `.claude/CLAUDE.md` Architecture Overview: remove stale `WIRE(#629)` annotation and add missing `GroupRoots` type alias entry

## Related Issue
Closes #625

## Changes Made
- `README.md`: Added `--exclude-groups <GROUPS>` and `--production-only` entries to the CLI options block (usage examples and config key reference were already added in #624)
- `README-JP.md`: Added Japanese translations of the two new CLI flag entries
- `.claude/CLAUDE.md`: Updated `GroupReachabilityAnalyzer` entry to reflect #623 wiring; added `GroupRoots` type alias row

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] Documentation-only change; no runtime behavior affected

---
Generated with [Claude Code](https://claude.com/claude-code)