### PR TITLE
fix(ci): fix duplicate-run cancellation and add docs/** branch pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 concurrency:
-  group: ci-${{ github.event.pull_request.head.sha || github.sha }}
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -14,6 +14,7 @@ on:
       - 'fix/**'        # Legacy: kept for backward compatibility
       - 'refactor/**'
       - 'doc/**'
+      - 'docs/**'
       - 'hotfix/**'
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
## Summary
- Fix concurrency group key to include `github.event_name` and `github.ref`, preventing `push` and `pull_request` events for the same commit from cancelling each other while preserving cancellation of rapid successive pushes on the same branch
- Add `docs/**` to push branch trigger list alongside `doc/**` so `docs/NNN-*` branches receive CI runs on push

## Related Issue
Closes #642

## Changes Made
- `.github/workflows/ci.yml` line 4: Change concurrency group from `ci-${{ github.event.pull_request.head.sha || github.sha }}` to `ci-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref }}`
- `.github/workflows/ci.yml` line 18: Add `'docs/**'` to push branches list

## Test Plan
- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] A push to a `docs/NNN-*` branch triggers a CI run
- [ ] A push to a `bugfix/NNN-*` branch with an open PR results in two separate CI runs — neither cancels the other

## Notes
⚠️ CHANGELOG not updated — confirmed internal-only (CI configuration change, not user-facing).

---
Generated with [Claude Code](https://claude.com/claude-code)