### PR TITLE
fix(adapters): remove dev-group edge injection in parse_lockfile_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`--production-only` and `--exclude-groups dev` failed to exclude the `dev`-named group**: Packages listed under `[package.dev-dependencies]` with the group key `dev` were incorrectly added as children of the root project in the internal dependency map. This caused `GroupReachabilityAnalyzer` to treat them as production-reachable, so they were never excluded even though groups with other names (e.g. `test`) were correctly excluded. Fixed by removing the spurious dev-group edge injection; dev-group packages are now orphan roots in the dependency map as required by the group reachability algorithm (#645).
 - **`--exclude-groups` and `--production-only` were silent no-ops on uv 0.4+ projects**: uv lockfile revision 3 (introduced in uv 0.4+) stores dependency-group roots in `[package.dev-dependencies]` within the project's `[[package]]` entry instead of the `[manifest.dependency-groups]` section read by the parser. The parser now falls back to reading `[package.dev-dependencies]` when no `[manifest.dependency-groups]` section is present, restoring group filtering for projects using modern uv versions (#640).
 
 ### Added

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -44,8 +44,6 @@ pub fn parse_lockfile_content(content: &str, project_path: &Path) -> Result<Lock
         version: String,
         #[serde(default)]
         dependencies: Vec<UvDependency>,
-        #[serde(default, rename = "dev-dependencies")]
-        dev_dependencies: Option<DevDependencies>,
     }
 
     #[derive(Debug, Deserialize)]
@@ -64,15 +62,7 @@ pub fn parse_lockfile_content(content: &str, project_path: &Path) -> Result<Lock
     for pkg in lockfile.package {
         packages.push(Package::new(pkg.name.clone(), pkg.version.clone())?);
 
-        let mut deps = Vec::new();
-        for dep in &pkg.dependencies {
-            deps.push(dep.name.clone());
-        }
-        if let Some(dev_deps) = &pkg.dev_dependencies {
-            for dep in &dev_deps.dev {
-                deps.push(dep.name.clone());
-            }
-        }
+        let deps: Vec<String> = pkg.dependencies.iter().map(|d| d.name.clone()).collect();
         dependency_map.insert(pkg.name, deps);
     }
 
@@ -302,6 +292,87 @@ name = "urllib3"
 version = "2.0.7"
 source = { registry = "https://pypi.org/simple" }
 "#;
+
+    // Revision-3 lockfile with dev-dependency groups on the local project package.
+    // Production dep: requests. Dev groups: dev=[mypy, ruff], test=[pytest].
+    const LOCK_REV3_WITH_DEV_GROUPS: &str = r#"
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "requests" },
+]
+
+[package.dev-dependencies]
+dev = [{ name = "mypy" }, { name = "ruff" }]
+test = [{ name = "pytest" }]
+
+[[package]]
+name = "mypy"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "pytest"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "ruff"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+"#;
+
+    #[test]
+    fn test_parse_lockfile_content_dev_group_packages_not_added_to_dep_map_as_children() {
+        let (_packages, dep_map) =
+            parse_lockfile_content(LOCK_REV3_WITH_DEV_GROUPS, Path::new("/project")).unwrap();
+
+        let root_deps = &dep_map["my-app"];
+        assert!(
+            root_deps.contains(&"requests".to_string()),
+            "production dep must remain a child of root"
+        );
+        assert!(
+            !root_deps.contains(&"mypy".to_string()),
+            "dev-group package must NOT be a child of root"
+        );
+        assert!(!root_deps.contains(&"ruff".to_string()));
+        assert!(!root_deps.contains(&"pytest".to_string()));
+
+        // Dev packages are orphan roots: no package in the map points to them.
+        let has_parent: HashSet<&String> = dep_map.values().flatten().collect();
+        for orphan in ["mypy", "ruff", "pytest"] {
+            assert!(
+                !has_parent.contains(&orphan.to_string()),
+                "{orphan} must be an orphan root (no parent edge)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_lockfile_content_all_packages_present_without_group_filter() {
+        let (packages, _dep_map) =
+            parse_lockfile_content(LOCK_REV3_WITH_DEV_GROUPS, Path::new("/project")).unwrap();
+
+        let names: HashSet<String> = packages.iter().map(|p| p.name().to_string()).collect();
+        for expected in ["my-app", "requests", "mypy", "ruff", "pytest"] {
+            assert!(
+                names.contains(expected),
+                "{expected} must still appear in the packages list"
+            );
+        }
+    }
 
     #[test]
     fn test_parse_lockfile_content_basic_returns_packages_and_deps() {


### PR DESCRIPTION
## Summary

- `--production-only` and `--exclude-groups dev` failed to exclude packages from the `dev`-named dependency group because they were incorrectly added as children of the root project in the dependency map
- Fixed by removing the spurious `dev_dependencies.dev` edge injection from `parse_lockfile_content`; dev-group packages are now orphan roots in the dependency map, which is the invariant `GroupReachabilityAnalyzer` requires
- Added two regression tests to lock in the correct behavior

## Related Issue

Closes #645

## Root Cause

`parse_lockfile_content` contained a `DevDependencies` struct that only captured the literal `dev` field from `[package.dev-dependencies]`. The code added those packages as edges from the root project in the `dependency_map`, causing `GroupReachabilityAnalyzer::compute_production_reachable` to treat them as reachable from a production seed and therefore exempt from exclusion. Other groups (e.g. `test`) were silently ignored during dep-map construction, so they happened to work correctly.

## Changes Made

- `src/adapters/outbound/filesystem/lockfile_parser.rs`: removed `dev_dependencies: Option<DevDependencies>` from the function-local `UvPackage` struct in `parse_lockfile_content` and replaced the manual collection loop with a single iterator chain over `pkg.dependencies` only
- Added fixture `LOCK_REV3_WITH_DEV_GROUPS` and two tests:
  - `test_parse_lockfile_content_dev_group_packages_not_added_to_dep_map_as_children`
  - `test_parse_lockfile_content_all_packages_present_without_group_filter`
- `CHANGELOG.md`: added `### Fixed` entry under `[Unreleased]`

**Not changed**: The module-level `DevDependencies` struct and `collect_all_deps` helper remain — they continue to serve `parse_lockfile_content_for_member` for workspace member scoping.

**Behavioral note**: In the unfiltered SBOM (no group filter), dev packages still appear in the packages list but are no longer classified as direct dependencies of the project root in `--show-dependencies` output. This is the correct behavior.

## Test Plan

- [x] `cargo test --all` passes (771 + 7 tests, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Two new regression tests cover the fixed behavior

---
Generated with [Claude Code](https://claude.com/claude-code)