### PR TITLE
feat(lockfile): add PackageSourceKind enum and read_and_parse_package_sources to LockfileReader trait

### DIFF
--- a/src/adapters/outbound/filesystem/file_reader.rs
+++ b/src/adapters/outbound/filesystem/file_reader.rs
@@ -1,8 +1,9 @@
 use super::lockfile_parser::{
     parse_group_roots, parse_lockfile_content, parse_lockfile_content_for_member,
+    parse_package_sources,
 };
 use crate::ports::outbound::{
-    GroupRoots, LockfileParseResult, LockfileReader, ProjectConfigReader,
+    GroupRoots, LockfileParseResult, LockfileReader, PackageSourceMap, ProjectConfigReader,
 };
 use crate::shared::error::SbomError;
 use crate::shared::security::{read_file_with_security, MAX_FILE_SIZE};
@@ -85,6 +86,11 @@ impl LockfileReader for FileSystemReader {
     fn read_and_parse_group_roots(&self, project_path: &Path) -> Result<GroupRoots> {
         let lockfile_content = self.read_lockfile(project_path)?;
         parse_group_roots(&lockfile_content, project_path)
+    }
+
+    fn read_and_parse_package_sources(&self, project_path: &Path) -> Result<PackageSourceMap> {
+        let lockfile_content = self.read_lockfile(project_path)?;
+        parse_package_sources(&lockfile_content, project_path)
     }
 }
 
@@ -321,5 +327,53 @@ source = { registry = "https://pypi.org/simple" }
         assert!(names.contains("urllib3"));
         assert!(names.contains("certifi"));
         assert!(!names.contains("alpha"));
+    }
+
+    const MIXED_SOURCES_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "git-pkg"
+version = "0.1.0"
+source = { git = "https://github.com/user/repo?rev=abc123" }
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+source = { virtual = "." }
+"#;
+
+    #[test]
+    fn test_read_and_parse_package_sources_reads_from_file() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("uv.lock"), MIXED_SOURCES_LOCK).unwrap();
+
+        let reader = FileSystemReader::new();
+        let map = reader
+            .read_and_parse_package_sources(temp_dir.path())
+            .unwrap();
+
+        use crate::ports::outbound::PackageSourceKind;
+        assert_eq!(map["requests"], PackageSourceKind::PyPi);
+        assert_eq!(
+            map["git-pkg"],
+            PackageSourceKind::Git("https://github.com/user/repo?rev=abc123".to_string())
+        );
+        assert_eq!(map["my-app"], PackageSourceKind::WorkspaceMember);
+    }
+
+    #[test]
+    fn test_read_and_parse_package_sources_returns_error_when_lockfile_missing() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let reader = FileSystemReader::new();
+        let result = reader.read_and_parse_package_sources(temp_dir.path());
+        assert!(result.is_err());
     }
 }

--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -1,4 +1,6 @@
-use crate::ports::outbound::{GroupRoots, LockfileParseResult};
+use crate::ports::outbound::{
+    GroupRoots, LockfileParseResult, PackageSourceKind, PackageSourceMap,
+};
 use crate::sbom_generation::domain::Package;
 use crate::shared::error::SbomError;
 use crate::shared::Result;
@@ -25,11 +27,59 @@ struct PackageSource {
     editable: Option<String>,
     #[serde(rename = "virtual")]
     virtual_path: Option<String>,
+    #[allow(dead_code)]
+    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
+    registry: Option<String>,
+    #[allow(dead_code)]
+    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
+    git: Option<String>,
+    #[allow(dead_code)]
+    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
+    path: Option<String>,
+    #[allow(dead_code)]
+    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
+    url: Option<String>,
 }
 
 impl PackageSource {
     fn is_local(&self) -> bool {
         self.editable.is_some() || self.virtual_path.is_some()
+    }
+
+    /// Classify this source into a `PackageSourceKind`.
+    ///
+    /// Priority when multiple fields are set (uv.lock sets exactly one in practice):
+    /// WorkspaceMember > Git > LocalPath > DirectUrl > Registry.
+    /// A registry URL of `"https://pypi.org/simple"` (with or without trailing slash)
+    /// maps to `PyPi`; all other registry URLs map to `PrivateRegistry`.
+    ///
+    /// If none of the known fields are set (e.g., a future uv.lock source type or
+    /// a `source = {}` empty table), falls back to `PyPi` as a non-flagging default.
+    /// Callers should treat this fallback as "unknown / assumed PyPI" until a richer
+    /// classification can be confirmed.
+    #[allow(dead_code)] // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
+    fn to_kind(&self) -> PackageSourceKind {
+        if self.is_local() {
+            return PackageSourceKind::WorkspaceMember;
+        }
+        if let Some(git) = &self.git {
+            return PackageSourceKind::Git(git.clone());
+        }
+        if let Some(path) = &self.path {
+            return PackageSourceKind::LocalPath(path.clone());
+        }
+        if let Some(url) = &self.url {
+            return PackageSourceKind::DirectUrl(url.clone());
+        }
+        if let Some(reg) = &self.registry {
+            let normalized = reg.trim_end_matches('/');
+            if normalized == "https://pypi.org/simple" {
+                return PackageSourceKind::PyPi;
+            }
+            return PackageSourceKind::PrivateRegistry(reg.clone());
+        }
+        // No source field set — treat as PyPI (non-flagging default).
+        PackageSourceKind::PyPi
     }
 }
 
@@ -227,6 +277,38 @@ pub fn parse_group_roots(content: &str, project_path: &Path) -> Result<GroupRoot
         .unwrap_or_default();
 
     Ok(package_groups)
+}
+
+/// Parse `uv.lock` content into a map of package name → source classification.
+///
+/// Packages whose `[[package]]` entry has no `source` field are omitted from
+/// the returned map. Invalid TOML returns an error.
+#[allow(dead_code)] // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
+pub fn parse_package_sources(content: &str, project_path: &Path) -> Result<PackageSourceMap> {
+    #[derive(Debug, Deserialize)]
+    struct UvPackage {
+        name: String,
+        source: Option<PackageSource>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct UvLock {
+        #[serde(default)]
+        package: Vec<UvPackage>,
+    }
+
+    let lockfile: UvLock = toml::from_str(content).map_err(|e| SbomError::LockfileParseError {
+        path: project_path.join("uv.lock"),
+        details: e.to_string(),
+    })?;
+
+    let mut map = PackageSourceMap::new();
+    for pkg in lockfile.package {
+        if let Some(source) = pkg.source {
+            map.insert(pkg.name, source.to_kind());
+        }
+    }
+    Ok(map)
 }
 
 /// Collect all dependency names from a package (runtime + dev).
@@ -851,5 +933,199 @@ source = { registry = "https://pypi.org/simple" }
     fn test_parse_group_roots_rev3_returns_empty_when_no_project_package() {
         let roots = parse_group_roots(LOCK_REV3_NO_PROJECT_PACKAGE, Path::new("/project")).unwrap();
         assert!(roots.is_empty());
+    }
+
+    // --- PackageSourceKind and parse_package_sources tests ---
+
+    const MIXED_SOURCES_LOCK: &str = r#"
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "private-pkg"
+version = "1.0.0"
+source = { registry = "https://private.example.com/simple" }
+
+[[package]]
+name = "git-pkg"
+version = "0.1.0"
+source = { git = "https://github.com/user/repo?rev=abc123" }
+
+[[package]]
+name = "local-pkg"
+version = "0.2.0"
+source = { path = "/some/local/path" }
+
+[[package]]
+name = "url-pkg"
+version = "0.3.0"
+source = { url = "https://example.com/package.tar.gz" }
+
+[[package]]
+name = "my-app"
+version = "0.1.0"
+source = { virtual = "." }
+
+[[package]]
+name = "my-lib"
+version = "0.1.0"
+source = { editable = "packages/my-lib" }
+
+[[package]]
+name = "no-source-pkg"
+version = "1.0.0"
+"#;
+
+    #[test]
+    fn test_parse_package_sources_classifies_pypi_registry() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(map["requests"], PackageSourceKind::PyPi);
+    }
+
+    #[test]
+    fn test_parse_package_sources_classifies_private_registry() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(
+            map["private-pkg"],
+            PackageSourceKind::PrivateRegistry("https://private.example.com/simple".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_package_sources_classifies_git() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(
+            map["git-pkg"],
+            PackageSourceKind::Git("https://github.com/user/repo?rev=abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_package_sources_classifies_local_path() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(
+            map["local-pkg"],
+            PackageSourceKind::LocalPath("/some/local/path".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_package_sources_classifies_direct_url() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(
+            map["url-pkg"],
+            PackageSourceKind::DirectUrl("https://example.com/package.tar.gz".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_package_sources_classifies_virtual_as_workspace_member() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(map["my-app"], PackageSourceKind::WorkspaceMember);
+    }
+
+    #[test]
+    fn test_parse_package_sources_classifies_editable_as_workspace_member() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert_eq!(map["my-lib"], PackageSourceKind::WorkspaceMember);
+    }
+
+    #[test]
+    fn test_parse_package_sources_omits_packages_without_source() {
+        let map = parse_package_sources(MIXED_SOURCES_LOCK, Path::new("/project")).unwrap();
+        assert!(!map.contains_key("no-source-pkg"));
+    }
+
+    #[test]
+    fn test_parse_package_sources_invalid_toml_returns_error() {
+        let result = parse_package_sources("invalid [[[ toml", Path::new("/project"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_package_sources_pypi_trailing_slash_normalized() {
+        let content = r#"
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple/" }
+"#;
+        let map = parse_package_sources(content, Path::new("/project")).unwrap();
+        assert_eq!(map["requests"], PackageSourceKind::PyPi);
+    }
+
+    #[test]
+    fn test_package_source_kind_is_non_pypi_external() {
+        assert!(!PackageSourceKind::PyPi.is_non_pypi_external());
+        assert!(PackageSourceKind::PrivateRegistry("url".to_string()).is_non_pypi_external());
+        assert!(PackageSourceKind::Git("url".to_string()).is_non_pypi_external());
+        assert!(!PackageSourceKind::LocalPath("path".to_string()).is_non_pypi_external());
+        assert!(PackageSourceKind::DirectUrl("url".to_string()).is_non_pypi_external());
+        assert!(!PackageSourceKind::WorkspaceMember.is_non_pypi_external());
+    }
+
+    #[test]
+    fn test_package_source_kind_label() {
+        assert_eq!(PackageSourceKind::PyPi.label(), "PyPI");
+        assert_eq!(
+            PackageSourceKind::PrivateRegistry("url".to_string()).label(),
+            "Private Registry"
+        );
+        assert_eq!(PackageSourceKind::Git("url".to_string()).label(), "Git");
+        assert_eq!(
+            PackageSourceKind::LocalPath("path".to_string()).label(),
+            "Local Path"
+        );
+        assert_eq!(
+            PackageSourceKind::DirectUrl("url".to_string()).label(),
+            "Direct URL"
+        );
+        assert_eq!(
+            PackageSourceKind::WorkspaceMember.label(),
+            "Workspace Member"
+        );
+    }
+
+    #[test]
+    fn test_package_source_kind_value() {
+        assert_eq!(PackageSourceKind::PyPi.value(), "");
+        assert_eq!(
+            PackageSourceKind::PrivateRegistry("https://example.com".to_string()).value(),
+            "https://example.com"
+        );
+        assert_eq!(
+            PackageSourceKind::Git("https://github.com/u/r".to_string()).value(),
+            "https://github.com/u/r"
+        );
+        assert_eq!(
+            PackageSourceKind::LocalPath("/path/to/pkg".to_string()).value(),
+            "/path/to/pkg"
+        );
+        assert_eq!(
+            PackageSourceKind::DirectUrl("https://example.com/pkg.tar.gz".to_string()).value(),
+            "https://example.com/pkg.tar.gz"
+        );
+        assert_eq!(PackageSourceKind::WorkspaceMember.value(), "");
+    }
+
+    #[test]
+    fn test_to_kind_workspace_member_takes_priority_over_registry() {
+        let source = PackageSource {
+            editable: Some(".".to_string()),
+            virtual_path: None,
+            registry: Some("https://pypi.org/simple".to_string()),
+            git: None,
+            path: None,
+            url: None,
+        };
+        assert_eq!(source.to_kind(), PackageSourceKind::WorkspaceMember);
     }
 }

--- a/src/application/use_cases/generate_diff.rs
+++ b/src/application/use_cases/generate_diff.rs
@@ -188,7 +188,9 @@ mod tests {
     use super::*;
     use crate::application::use_cases::test_doubles::PairedMockVulnerabilityRepository;
     use crate::i18n::Locale;
-    use crate::ports::outbound::lockfile_reader::{GroupRoots, LockfileParseResult};
+    use crate::ports::outbound::lockfile_reader::{
+        GroupRoots, LockfileParseResult, PackageSourceMap,
+    };
     use crate::sbom_generation::domain::dependency_diff::ChangeType;
     use crate::sbom_generation::domain::vulnerability::{Severity, Vulnerability};
     use crate::sbom_generation::domain::Package;
@@ -233,6 +235,10 @@ mod tests {
         }
 
         fn read_and_parse_group_roots(&self, _project_path: &Path) -> Result<GroupRoots> {
+            Ok(HashMap::new())
+        }
+
+        fn read_and_parse_package_sources(&self, _project_path: &Path) -> Result<PackageSourceMap> {
             Ok(HashMap::new())
         }
     }

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::application::use_cases::test_doubles::{
     MockMaintenanceRepository, MockVulnerabilityRepository,
 };
-use crate::ports::outbound::{GroupRoots, LockfileParseResult, PyPiMetadata};
+use crate::ports::outbound::{GroupRoots, LockfileParseResult, PackageSourceMap, PyPiMetadata};
 use crate::sbom_generation::domain::Package;
 use std::collections::HashMap;
 use std::path::Path;
@@ -32,6 +32,10 @@ impl LockfileReader for MockLockfileReader {
 
     fn read_and_parse_group_roots(&self, _path: &Path) -> Result<GroupRoots> {
         Ok(self.group_roots.clone())
+    }
+
+    fn read_and_parse_package_sources(&self, _path: &Path) -> Result<PackageSourceMap> {
+        Ok(PackageSourceMap::new())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub mod prelude {
     pub use crate::application::use_cases::GenerateSbomUseCase;
     pub use crate::ports::outbound::{
         GroupRoots, LicenseRepository, LockfileParseResult, LockfileReader, OutputPresenter,
-        ProgressReporter, ProjectConfigReader, SbomFormatter,
+        PackageSourceKind, PackageSourceMap, ProgressReporter, ProjectConfigReader, SbomFormatter,
     };
     pub use crate::sbom_generation::domain::{
         DependencyGraph, LicenseInfo, Package, PackageName, SbomMetadata,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ use cli::runner::{display_banner, resolve_suggest_fix, validate_project_path};
 use cli::Args;
 use i18n::Messages;
 use ports::outbound::{
-    DiffSource, GroupRoots, LockfileParseResult, LockfileReader, ProjectConfigReader,
-    WorkspaceReader,
+    DiffSource, GroupRoots, LockfileParseResult, LockfileReader, PackageSourceMap,
+    ProjectConfigReader, WorkspaceReader,
 };
 use shared::error::ExitCode;
 use shared::Result;
@@ -74,6 +74,11 @@ impl LockfileReader for MemberScopedLockfileReader {
 
     fn read_and_parse_group_roots(&self, _project_path: &Path) -> Result<GroupRoots> {
         self.inner.read_and_parse_group_roots(&self.workspace_root)
+    }
+
+    fn read_and_parse_package_sources(&self, _project_path: &Path) -> Result<PackageSourceMap> {
+        self.inner
+            .read_and_parse_package_sources(&self.workspace_root)
     }
 }
 

--- a/src/ports/outbound/lockfile_reader.rs
+++ b/src/ports/outbound/lockfile_reader.rs
@@ -15,6 +15,67 @@ pub type LockfileParseResult = (Vec<Package>, DependencyMap);
 /// Empty map when no `[manifest.dependency-groups]` section is present.
 pub type GroupRoots = HashMap<String, Vec<String>>;
 
+/// Classification of a package's `source` field in `uv.lock`.
+#[allow(dead_code)] // WIRE(#627): remove when wired into non-PyPI source detection use case
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageSourceKind {
+    /// Standard PyPI registry (`https://pypi.org/simple`).
+    PyPi,
+    /// A registry URL other than the canonical PyPI registry.
+    PrivateRegistry(String),
+    /// Git repository (plain URL string, may include `?rev=` fragment).
+    Git(String),
+    /// Local filesystem path (`path = "..."`).
+    LocalPath(String),
+    /// Direct URL to an archive or wheel (`url = "..."`).
+    DirectUrl(String),
+    /// Workspace member (`editable` or `virtual` source).
+    WorkspaceMember,
+}
+
+#[allow(dead_code)] // WIRE(#627): remove when PackageSourceKind methods are used by application code
+impl PackageSourceKind {
+    /// Returns `true` for sources that are external but not the canonical PyPI registry.
+    ///
+    /// `PrivateRegistry`, `Git`, and `DirectUrl` are considered non-PyPI external.
+    /// `LocalPath` and `WorkspaceMember` are local; `PyPi` is the canonical registry.
+    pub fn is_non_pypi_external(&self) -> bool {
+        matches!(
+            self,
+            Self::PrivateRegistry(_) | Self::Git(_) | Self::DirectUrl(_)
+        )
+    }
+
+    /// Stable human-readable category label suitable for reports and output.
+    pub fn label(&self) -> &str {
+        match self {
+            Self::PyPi => "PyPI",
+            Self::PrivateRegistry(_) => "Private Registry",
+            Self::Git(_) => "Git",
+            Self::LocalPath(_) => "Local Path",
+            Self::DirectUrl(_) => "Direct URL",
+            Self::WorkspaceMember => "Workspace Member",
+        }
+    }
+
+    /// The associated location string (URL or path).
+    ///
+    /// Returns `""` for `PyPi` and `WorkspaceMember`, which carry no explicit URL.
+    pub fn value(&self) -> &str {
+        match self {
+            Self::PrivateRegistry(s) | Self::Git(s) | Self::LocalPath(s) | Self::DirectUrl(s) => s,
+            Self::PyPi | Self::WorkspaceMember => "",
+        }
+    }
+}
+
+/// Package name → source classification.
+///
+/// Keyed by the package name as it appears in `uv.lock`. Packages without a
+/// `source` field are omitted from the map.
+#[allow(dead_code)] // WIRE(#627): remove when PackageSourceMap is used by application code
+pub type PackageSourceMap = HashMap<String, PackageSourceKind>;
+
 /// LockfileReader port for reading and parsing lockfile contents
 ///
 /// This port abstracts the file system operations and TOML parsing
@@ -82,4 +143,11 @@ pub trait LockfileReader {
     /// Returns an empty map when no `[manifest.dependency-groups]` section is present,
     /// preserving backward compatibility with lock files that have no groups.
     fn read_and_parse_group_roots(&self, project_path: &Path) -> Result<GroupRoots>;
+
+    /// Read `uv.lock` and classify each package's `source` field.
+    ///
+    /// Returns a map of package name → `PackageSourceKind`. Packages whose
+    /// `[[package]]` entry has no `source` field are omitted from the map.
+    #[allow(dead_code)] // WIRE(#627): remove when called by non-PyPI source detection use case
+    fn read_and_parse_package_sources(&self, project_path: &Path) -> Result<PackageSourceMap>;
 }

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -19,7 +19,9 @@ pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
 pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};
-pub use lockfile_reader::{GroupRoots, LockfileParseResult, LockfileReader};
+pub use lockfile_reader::{
+    GroupRoots, LockfileParseResult, LockfileReader, PackageSourceKind, PackageSourceMap,
+};
 // Note: Will be used in subsequent subtasks (abandoned package detection)
 #[allow(unused_imports)]
 pub use maintenance_repository::{MaintenanceInfo, MaintenanceRepository};

--- a/tests/test_utilities/mocks/mock_lockfile_reader.rs
+++ b/tests/test_utilities/mocks/mock_lockfile_reader.rs
@@ -100,4 +100,8 @@ impl LockfileReader for MockLockfileReader {
     fn read_and_parse_group_roots(&self, _project_path: &Path) -> Result<GroupRoots> {
         Ok(HashMap::new())
     }
+
+    fn read_and_parse_package_sources(&self, _project_path: &Path) -> Result<PackageSourceMap> {
+        Ok(HashMap::new())
+    }
 }


### PR DESCRIPTION
## Summary

- Define `PackageSourceKind` enum (6 variants: `PyPi`, `PrivateRegistry`, `Git`, `LocalPath`, `DirectUrl`, `WorkspaceMember`) and `PackageSourceMap` type alias in `src/ports/outbound/lockfile_reader.rs`
- Extend `PackageSource` TOML struct in `lockfile_parser.rs` with `registry`, `git`, `path`, and `url` fields; add `to_kind()` method with PyPI URL normalization (trailing-slash-tolerant) and WorkspaceMember priority
- Add `parse_package_sources` pure function in `lockfile_parser.rs`, wire `read_and_parse_package_sources` in `FileSystemReader`, and add delegating/no-op stubs to all four `LockfileReader` implementors

## Related Issue

Closes #653
Part of #627

## Changes Made

- `src/ports/outbound/lockfile_reader.rs`: Add `PackageSourceKind`, `PackageSourceMap`, and `read_and_parse_package_sources` trait method (all marked `WIRE(#627)`)
- `src/ports/outbound/mod.rs`: Re-export new types
- `src/lib.rs`: Expose `PackageSourceKind` and `PackageSourceMap` in `prelude`
- `src/adapters/outbound/filesystem/lockfile_parser.rs`: Extend `PackageSource`, add `to_kind()`, add `parse_package_sources` pure function, add 14 unit tests
- `src/adapters/outbound/filesystem/file_reader.rs`: Implement `read_and_parse_package_sources`, add 2 integration tests
- `src/main.rs`: Delegate `read_and_parse_package_sources` in `MemberScopedLockfileReader`
- `src/application/use_cases/generate_diff.rs`, `generate_sbom/tests.rs`, `tests/test_utilities/mocks/mock_lockfile_reader.rs`: Add no-op stubs

## WIRE Annotations

This PR introduces `WIRE(#627)` annotations on all new types and the new trait method. They will be cleaned up by Issue #627's Step 4.0 gate when `read_and_parse_package_sources` is called from application code in a follow-up subtask.

## Test Plan

- [x] `cargo test --all` passes (787 lib tests + 16 integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] 14 unit tests for `PackageSourceKind` methods (`is_non_pypi_external`, `label`, `value`, `to_kind`) and `parse_package_sources` covering all 6 source variants, trailing-slash normalization, priority semantics, and error cases

---
Generated with [Claude Code](https://claude.com/claude-code)