### PR TITLE
feat(application): add NonPyPiPackagesReport read model and integrate into GenerateSbomUseCase

### DIFF
--- a/src/adapters/outbound/filesystem/lockfile_parser.rs
+++ b/src/adapters/outbound/filesystem/lockfile_parser.rs
@@ -27,17 +27,9 @@ struct PackageSource {
     editable: Option<String>,
     #[serde(rename = "virtual")]
     virtual_path: Option<String>,
-    #[allow(dead_code)]
-    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
     registry: Option<String>,
-    #[allow(dead_code)]
-    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
     git: Option<String>,
-    #[allow(dead_code)]
-    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
     path: Option<String>,
-    #[allow(dead_code)]
-    // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
     url: Option<String>,
 }
 
@@ -57,7 +49,6 @@ impl PackageSource {
     /// a `source = {}` empty table), falls back to `PyPi` as a non-flagging default.
     /// Callers should treat this fallback as "unknown / assumed PyPI" until a richer
     /// classification can be confirmed.
-    #[allow(dead_code)] // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
     fn to_kind(&self) -> PackageSourceKind {
         if self.is_local() {
             return PackageSourceKind::WorkspaceMember;
@@ -283,7 +274,6 @@ pub fn parse_group_roots(content: &str, project_path: &Path) -> Result<GroupRoot
 ///
 /// Packages whose `[[package]]` entry has no `source` field are omitted from
 /// the returned map. Invalid TOML returns an error.
-#[allow(dead_code)] // WIRE(#627): remove when read_and_parse_package_sources is invoked from application code
 pub fn parse_package_sources(content: &str, project_path: &Path) -> Result<PackageSourceMap> {
     #[derive(Debug, Deserialize)]
     struct UvPackage {

--- a/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/cyclonedx_formatter/mod.rs
@@ -101,6 +101,7 @@ mod tests {
             resolution_guide: None,
             upgrade_recommendations: None,
             abandoned_packages: None,
+            non_pypi_packages: None,
             applied_group_filter: vec![],
         }
     }

--- a/src/adapters/outbound/formatters/markdown_formatter/links.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/links.rs
@@ -107,6 +107,7 @@ mod tests {
             resolution_guide: None,
             upgrade_recommendations: None,
             abandoned_packages: None,
+            non_pypi_packages: None,
             applied_group_filter: vec![],
         }
     }

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -174,6 +174,7 @@ mod tests {
                 resolution_guide: None,
                 upgrade_recommendations: None,
                 abandoned_packages: None,
+                non_pypi_packages: None,
                 applied_group_filter: vec![],
             }
         }

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/resolution_guide.rs
@@ -190,6 +190,7 @@ mod tests {
             resolution_guide: None,
             upgrade_recommendations: None,
             abandoned_packages: None,
+            non_pypi_packages: None,
             applied_group_filter: vec![],
         }
     }

--- a/src/application/dto/sbom_request.rs
+++ b/src/application/dto/sbom_request.rs
@@ -40,6 +40,8 @@ pub struct SbomRequest {
     /// Inactivity threshold in days for abandoned-package detection.
     /// Only meaningful when `check_abandoned` is true.
     pub abandoned_threshold_days: u64,
+    /// Whether to detect packages sourced from non-PyPI origins.
+    pub check_non_pypi: bool,
     /// Dependency group names to exclude from the SBOM (e.g. ["dev", "lint"]).
     /// Empty = no group filtering.
     pub exclude_groups: Vec<String>,
@@ -107,6 +109,7 @@ pub struct SbomRequestBuilder {
     suggest_fix: bool,
     check_abandoned: bool,
     abandoned_threshold_days: u64,
+    check_non_pypi: bool,
     exclude_groups: Vec<String>,
     locale: Locale,
 }
@@ -137,6 +140,7 @@ impl SbomRequestBuilder {
             suggest_fix: false,
             check_abandoned: false,
             abandoned_threshold_days: 730,
+            check_non_pypi: false,
             exclude_groups: Vec::new(),
             locale: Locale::default(),
         }
@@ -228,6 +232,12 @@ impl SbomRequestBuilder {
         self
     }
 
+    /// Sets whether to detect packages sourced from non-PyPI origins.
+    pub fn check_non_pypi(mut self, check: bool) -> Self {
+        self.check_non_pypi = check;
+        self
+    }
+
     /// Sets dependency group names to exclude from the SBOM (e.g. `["dev", "lint"]`).
     pub fn exclude_groups(mut self, groups: Vec<String>) -> Self {
         self.exclude_groups = groups;
@@ -264,6 +274,7 @@ impl SbomRequestBuilder {
             suggest_fix: self.suggest_fix,
             check_abandoned: self.check_abandoned,
             abandoned_threshold_days: self.abandoned_threshold_days,
+            check_non_pypi: self.check_non_pypi,
             exclude_groups: self.exclude_groups,
             locale: self.locale,
         })

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -1,4 +1,5 @@
 use crate::application::read_models::abandoned_package::AbandonedPackagesReport;
+use crate::application::read_models::non_pypi_package::NonPyPiPackagesReport;
 use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
@@ -33,6 +34,9 @@ pub struct SbomResponse {
     /// Abandoned packages report.
     /// Populated only when `check_abandoned` was true in the request.
     pub abandoned_packages_report: Option<AbandonedPackagesReport>,
+    /// Non-PyPI packages report.
+    /// Populated only when `check_non_pypi` was true in the request.
+    pub non_pypi_packages_report: Option<NonPyPiPackagesReport>,
     /// Dependency groups that were excluded during SBOM generation.
     /// Empty when no group filter was applied.
     pub applied_group_filter: Vec<String>,
@@ -54,6 +58,7 @@ pub struct SbomResponseBuilder {
     has_license_violations: bool,
     upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
     abandoned_packages_report: Option<AbandonedPackagesReport>,
+    non_pypi_packages_report: Option<NonPyPiPackagesReport>,
     applied_group_filter: Vec<String>,
 }
 
@@ -69,6 +74,7 @@ impl SbomResponseBuilder {
             has_license_violations: false,
             upgrade_recommendations: None,
             abandoned_packages_report: None,
+            non_pypi_packages_report: None,
             applied_group_filter: Vec::new(),
         }
     }
@@ -124,6 +130,11 @@ impl SbomResponseBuilder {
         self
     }
 
+    pub fn non_pypi_packages_report(mut self, report: NonPyPiPackagesReport) -> Self {
+        self.non_pypi_packages_report = Some(report);
+        self
+    }
+
     pub fn applied_group_filter(mut self, groups: Vec<String>) -> Self {
         self.applied_group_filter = groups;
         self
@@ -144,6 +155,7 @@ impl SbomResponseBuilder {
             has_license_violations: self.has_license_violations,
             upgrade_recommendations: self.upgrade_recommendations,
             abandoned_packages_report: self.abandoned_packages_report,
+            non_pypi_packages_report: self.non_pypi_packages_report,
             applied_group_filter: self.applied_group_filter,
         })
     }

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -8,6 +8,7 @@ pub mod component_view;
 pub mod cve_delta_view;
 pub mod dependency_view;
 pub mod license_compliance_view;
+pub mod non_pypi_package;
 pub mod resolution_guide_view;
 pub mod sbom_read_model;
 pub mod sbom_read_model_builder;
@@ -26,6 +27,8 @@ pub use dependency_view::DependencyView;
 pub use license_compliance_view::{
     LicenseComplianceSummary, LicenseComplianceView, LicenseViolationView, LicenseWarningView,
 };
+#[allow(unused_imports)]
+pub use non_pypi_package::{NonPyPiPackageView, NonPyPiPackagesReport};
 #[allow(unused_imports)]
 pub use resolution_guide_view::{IntroducedByView, ResolutionEntryView, ResolutionGuideView};
 #[allow(unused_imports)]

--- a/src/application/read_models/non_pypi_package.rs
+++ b/src/application/read_models/non_pypi_package.rs
@@ -1,0 +1,118 @@
+//! Non-PyPI package view structs for read model
+//!
+//! These structs provide a query-optimized view of packages sourced from
+//! registries, VCS, or URLs other than the canonical PyPI registry.
+
+/// View representation of a single package sourced from a non-PyPI origin.
+///
+/// All classification fields are pre-computed at construction time so consumers
+/// (formatters, presenters) do not need access to port types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonPyPiPackageView {
+    /// Package name as listed in the lockfile
+    pub name: String,
+    /// Package version as listed in the lockfile
+    pub version: String,
+    /// Stable category label derived from `PackageSourceKind::label()`.
+    /// Examples: "Private Registry", "Git", "Direct URL".
+    pub source_label: String,
+    /// Location string derived from `PackageSourceKind::value()`.
+    /// Empty for kinds that carry no explicit location.
+    pub source_location: String,
+    /// Whether the package is a direct dependency of the current project.
+    pub is_direct: bool,
+}
+
+/// View representation of a non-PyPI packages report.
+///
+/// Holds the pre-categorized list of packages whose source is external but
+/// not the canonical PyPI registry.
+#[derive(Debug, Clone, Default)]
+pub struct NonPyPiPackagesReport {
+    /// Packages sourced from non-PyPI external origins.
+    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter renders this field
+    pub packages: Vec<NonPyPiPackageView>,
+}
+
+impl NonPyPiPackagesReport {
+    /// Returns the total number of non-PyPI packages.
+    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
+    pub fn total_count(&self) -> usize {
+        self.packages.len()
+    }
+
+    /// Returns the number of non-PyPI packages that are direct dependencies.
+    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
+    pub fn direct_count(&self) -> usize {
+        self.packages.iter().filter(|p| p.is_direct).count()
+    }
+
+    /// Returns the number of non-PyPI packages that are transitive dependencies.
+    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
+    pub fn transitive_count(&self) -> usize {
+        self.packages.iter().filter(|p| !p.is_direct).count()
+    }
+
+    /// Returns `true` when no non-PyPI packages were found.
+    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
+    pub fn is_empty(&self) -> bool {
+        self.packages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_view(name: &str, is_direct: bool) -> NonPyPiPackageView {
+        NonPyPiPackageView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            source_label: "Git".to_string(),
+            source_location: "https://github.com/example/repo".to_string(),
+            is_direct,
+        }
+    }
+
+    #[test]
+    fn test_default_report_is_empty() {
+        let report = NonPyPiPackagesReport::default();
+        assert!(report.is_empty());
+        assert_eq!(report.total_count(), 0);
+        assert_eq!(report.direct_count(), 0);
+        assert_eq!(report.transitive_count(), 0);
+    }
+
+    #[test]
+    fn test_total_count() {
+        let report = NonPyPiPackagesReport {
+            packages: vec![
+                make_view("a", true),
+                make_view("b", false),
+                make_view("c", false),
+            ],
+        };
+        assert_eq!(report.total_count(), 3);
+        assert!(!report.is_empty());
+    }
+
+    #[test]
+    fn test_direct_and_transitive_counts() {
+        let report = NonPyPiPackagesReport {
+            packages: vec![
+                make_view("a", true),
+                make_view("b", true),
+                make_view("c", false),
+            ],
+        };
+        assert_eq!(report.direct_count(), 2);
+        assert_eq!(report.transitive_count(), 1);
+    }
+
+    #[test]
+    fn test_view_clone_and_eq() {
+        let a = make_view("my-pkg", true);
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -7,6 +7,7 @@ use super::abandoned_package::AbandonedPackagesReport;
 use super::component_view::ComponentView;
 use super::dependency_view::DependencyView;
 use super::license_compliance_view::LicenseComplianceView;
+use super::non_pypi_package::NonPyPiPackagesReport;
 use super::resolution_guide_view::ResolutionGuideView;
 use super::upgrade_recommendation_view::UpgradeRecommendationView;
 use super::vulnerability_view::VulnerabilityReportView;
@@ -35,6 +36,10 @@ pub struct SbomReadModel {
     /// Abandoned packages report.
     /// Populated only when `check_abandoned` was true in the request.
     pub abandoned_packages: Option<AbandonedPackagesReport>,
+    /// Non-PyPI packages report.
+    /// Populated only when `check_non_pypi` was true in the request.
+    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter reads this field
+    pub non_pypi_packages: Option<NonPyPiPackagesReport>,
     /// Dependency groups that were excluded during generation. Empty = no filter.
     pub applied_group_filter: Vec<String>,
 }

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -12,6 +12,7 @@ mod upgrade_recommendation_builder;
 mod vulnerability_builder;
 
 use super::abandoned_package::AbandonedPackagesReport;
+use super::non_pypi_package::NonPyPiPackagesReport;
 use super::resolution_guide_view::ResolutionGuideView;
 use super::sbom_read_model::SbomReadModel;
 use crate::ports::outbound::EnrichedPackage;
@@ -39,6 +40,7 @@ impl SbomReadModelBuilder {
         project_component: Option<(&str, &str)>,
         upgrade_recommendations: Option<&[UpgradeRecommendation]>,
         abandoned_packages_report: Option<&AbandonedPackagesReport>,
+        non_pypi_packages_report: Option<&NonPyPiPackagesReport>,
         applied_group_filter: &[String],
     ) -> SbomReadModel {
         let metadata_view = metadata_builder::build_metadata(metadata, project_component);
@@ -61,6 +63,7 @@ impl SbomReadModelBuilder {
             .map(upgrade_recommendation_builder::build_upgrade_recommendations);
 
         let abandoned_packages = abandoned_packages_report.cloned();
+        let non_pypi_packages = non_pypi_packages_report.cloned();
 
         SbomReadModel {
             metadata: metadata_view,
@@ -71,6 +74,7 @@ impl SbomReadModelBuilder {
             resolution_guide,
             upgrade_recommendations,
             abandoned_packages,
+            non_pypi_packages,
             applied_group_filter: applied_group_filter.to_vec(),
         }
     }
@@ -209,6 +213,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
         );
 
@@ -229,6 +234,7 @@ mod tests {
         let read_model = SbomReadModelBuilder::build_with_project(
             packages,
             &metadata,
+            None,
             None,
             None,
             None,
@@ -260,6 +266,7 @@ mod tests {
             &metadata,
             None,
             Some(&vuln_result),
+            None,
             None,
             None,
             None,
@@ -309,6 +316,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
         );
 
@@ -341,6 +349,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
         );
 
@@ -357,6 +366,7 @@ mod tests {
             packages,
             &metadata,
             Some(&graph),
+            None,
             None,
             None,
             None,
@@ -391,6 +401,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
         );
 
@@ -410,6 +421,7 @@ mod tests {
             None,
             None,
             Some(("my-project", "1.0.0")),
+            None,
             None,
             None,
             &[],

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -3,6 +3,9 @@ use crate::application::dto::{SbomRequest, SbomResponse};
 use crate::application::read_models::abandoned_package::{
     AbandonedPackageView, AbandonedPackagesReport,
 };
+use crate::application::read_models::non_pypi_package::{
+    NonPyPiPackageView, NonPyPiPackagesReport,
+};
 use crate::application::use_cases::{
     CheckAbandonedPackagesUseCase, CheckVulnerabilitiesUseCase, FetchLicensesUseCase,
 };
@@ -146,7 +149,14 @@ where
             .check_abandoned_if_requested(&request, &filtered_packages, dependency_graph.as_ref())
             .await?;
 
-        // Step 10: Build and return response
+        // Step 10: Non-PyPI source detection if requested
+        let non_pypi_packages_report = self.check_non_pypi_if_requested(
+            &request,
+            &filtered_packages,
+            dependency_graph.as_ref(),
+        )?;
+
+        // Step 11: Build and return response
         Ok(self.build_response(
             enriched_packages,
             dependency_graph,
@@ -154,6 +164,7 @@ where
             license_compliance_result,
             upgrade_recommendations,
             abandoned_packages_report,
+            non_pypi_packages_report,
             request.exclude_groups.clone(),
         ))
     }
@@ -196,9 +207,7 @@ where
         }
 
         let today = Utc::now().date_naive();
-        let direct_names: HashSet<&str> = dependency_graph
-            .map(|g| g.direct_dependencies().iter().map(|p| p.as_str()).collect())
-            .unwrap_or_default();
+        let direct_names = Self::resolve_direct_names(dependency_graph);
 
         let threshold = request.abandoned_threshold_days as i64;
         let mut abandoned_packages: Vec<AbandonedPackageView> = results
@@ -247,6 +256,58 @@ where
         }
 
         Ok(Some(report))
+    }
+
+    /// Detects packages sourced from non-PyPI origins when `check_non_pypi` is enabled.
+    ///
+    /// When `dependency_graph` is `None` (e.g. non-Markdown output without dep analysis),
+    /// `is_direct` defaults to `false` for all packages — consistent with the existing
+    /// pattern in `check_abandoned_if_requested`.
+    fn check_non_pypi_if_requested(
+        &self,
+        request: &SbomRequest,
+        packages: &[Package],
+        dependency_graph: Option<&DependencyGraph>,
+    ) -> Result<Option<NonPyPiPackagesReport>> {
+        if !request.check_non_pypi {
+            return Ok(None);
+        }
+
+        let source_map = self
+            .lockfile_reader
+            .read_and_parse_package_sources(&request.project_path)?;
+
+        let direct_names = Self::resolve_direct_names(dependency_graph);
+
+        let mut views: Vec<NonPyPiPackageView> = packages
+            .iter()
+            .filter_map(|pkg| {
+                let kind = source_map.get(pkg.name())?;
+                if !kind.is_non_pypi_external() {
+                    return None;
+                }
+                Some(NonPyPiPackageView {
+                    name: pkg.name().to_string(),
+                    version: pkg.version().to_string(),
+                    source_label: kind.label().to_string(),
+                    source_location: kind.value().to_string(),
+                    is_direct: direct_names.contains(pkg.name()),
+                })
+            })
+            .collect();
+        views.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(Some(NonPyPiPackagesReport { packages: views }))
+    }
+
+    /// Returns the set of direct dependency names from the graph.
+    ///
+    /// When `dependency_graph` is `None`, returns an empty set so every package
+    /// is treated as transitive — consistent across all `check_*_if_requested` methods.
+    fn resolve_direct_names(dependency_graph: Option<&DependencyGraph>) -> HashSet<&str> {
+        dependency_graph
+            .map(|g| g.direct_dependencies().iter().map(|p| p.as_str()).collect())
+            .unwrap_or_default()
     }
 
     /// Reads and parses the lockfile, reporting progress
@@ -680,6 +741,7 @@ where
         license_compliance_result: Option<LicenseComplianceResult>,
         upgrade_recommendations: Option<Vec<UpgradeRecommendation>>,
         abandoned_packages_report: Option<AbandonedPackagesReport>,
+        non_pypi_packages_report: Option<NonPyPiPackagesReport>,
         exclude_groups: Vec<String>,
     ) -> SbomResponse {
         let metadata = SbomGenerator::generate_default_metadata();
@@ -716,6 +778,9 @@ where
         }
         if let Some(report) = abandoned_packages_report {
             builder = builder.abandoned_packages_report(report);
+        }
+        if let Some(report) = non_pypi_packages_report {
+            builder = builder.non_pypi_packages_report(report);
         }
 
         builder.build().expect("response build should not fail")

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -1146,10 +1146,7 @@ mod tests_non_pypi {
     #[test]
     fn test_check_non_pypi_pypi_packages_excluded() {
         let mut source_map = PackageSourceMap::new();
-        source_map.insert(
-            "requests".to_string(),
-            PackageSourceKind::PyPi,
-        );
+        source_map.insert("requests".to_string(), PackageSourceKind::PyPi);
         let use_case = UseCaseBuilder::default()
             .with_lockfile(vec![pkg("requests", "2.31.0")])
             .with_source_map(source_map)
@@ -1196,7 +1193,10 @@ mod tests_non_pypi {
         let view = &result.packages[0];
         assert_eq!(view.name, "my-lib");
         assert_eq!(view.source_label, "Git");
-        assert_eq!(view.source_location, "https://github.com/user/my-lib?rev=abc123");
+        assert_eq!(
+            view.source_location,
+            "https://github.com/user/my-lib?rev=abc123"
+        );
         assert!(!view.is_direct, "no graph → is_direct defaults to false");
     }
 

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -11,6 +11,7 @@ struct MockLockfileReader {
     packages: Vec<Package>,
     deps: HashMap<String, Vec<String>>,
     group_roots: GroupRoots,
+    source_map: PackageSourceMap,
 }
 
 impl LockfileReader for MockLockfileReader {
@@ -35,7 +36,7 @@ impl LockfileReader for MockLockfileReader {
     }
 
     fn read_and_parse_package_sources(&self, _path: &Path) -> Result<PackageSourceMap> {
-        Ok(PackageSourceMap::new())
+        Ok(self.source_map.clone())
     }
 }
 
@@ -94,6 +95,7 @@ mod test_helpers {
         packages: Vec<Package>,
         deps: HashMap<String, Vec<String>>,
         group_roots: GroupRoots,
+        source_map: PackageSourceMap,
         project_name: String,
         vuln: Option<MockVulnerabilityRepository>,
         maint: Option<MockMaintenanceRepository>,
@@ -105,6 +107,7 @@ mod test_helpers {
                 packages: Vec::new(),
                 deps: HashMap::new(),
                 group_roots: HashMap::new(),
+                source_map: PackageSourceMap::new(),
                 project_name: "test-project".to_string(),
                 vuln: None,
                 maint: None,
@@ -148,12 +151,18 @@ mod test_helpers {
             self
         }
 
+        pub(super) fn with_source_map(mut self, map: PackageSourceMap) -> Self {
+            self.source_map = map;
+            self
+        }
+
         pub(super) fn build(self) -> TestUseCase {
             GenerateSbomUseCase::new(
                 MockLockfileReader {
                     packages: self.packages,
                     deps: self.deps,
                     group_roots: self.group_roots,
+                    source_map: self.source_map,
                 },
                 MockProjectConfigReader {
                     project_name: self.project_name,
@@ -416,8 +425,16 @@ mod tests_response {
             Some("Test description".to_string()),
         )];
 
-        let response =
-            use_case.build_response(enriched_packages, None, None, None, None, None, vec![]);
+        let response = use_case.build_response(
+            enriched_packages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            vec![],
+        );
 
         assert_eq!(response.enriched_packages.len(), 1);
         assert!(response.dependency_graph.is_none());
@@ -459,6 +476,7 @@ mod tests_response {
             enriched_packages,
             None,
             Some(check_result),
+            None,
             None,
             None,
             None,
@@ -507,6 +525,7 @@ mod tests_response {
             enriched_packages,
             None,
             Some(check_result),
+            None,
             None,
             None,
             None,
@@ -1082,5 +1101,137 @@ mod tests_group_exclusion {
         let response = use_case.execute(request).await.unwrap();
 
         assert_eq!(response.enriched_packages.len(), 2);
+    }
+}
+
+mod tests_non_pypi {
+    use super::test_helpers::*;
+    use super::*;
+    use crate::ports::outbound::lockfile_reader::PackageSourceKind;
+
+    #[test]
+    fn test_check_non_pypi_disabled_returns_none() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+
+        let result = use_case
+            .check_non_pypi_if_requested(&default_request(), &packages, None)
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_non_pypi_empty_source_map_returns_empty_report() {
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_non_pypi(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_non_pypi_if_requested(&request, &packages, None)
+            .unwrap();
+
+        let report = result.expect("check enabled → Some");
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn test_check_non_pypi_pypi_packages_excluded() {
+        let mut source_map = PackageSourceMap::new();
+        source_map.insert(
+            "requests".to_string(),
+            PackageSourceKind::PyPi,
+        );
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("requests", "2.31.0")])
+            .with_source_map(source_map)
+            .build();
+        let packages = [pkg("requests", "2.31.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_non_pypi(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_non_pypi_if_requested(&request, &packages, None)
+            .unwrap()
+            .expect("check enabled → Some");
+
+        assert!(result.is_empty(), "PyPI packages must not appear in report");
+    }
+
+    #[test]
+    fn test_check_non_pypi_git_package_detected() {
+        let mut source_map = PackageSourceMap::new();
+        source_map.insert(
+            "my-lib".to_string(),
+            PackageSourceKind::Git("https://github.com/user/my-lib?rev=abc123".to_string()),
+        );
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("my-lib", "0.1.0")])
+            .with_source_map(source_map)
+            .build();
+        let packages = [pkg("my-lib", "0.1.0")];
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_non_pypi(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_non_pypi_if_requested(&request, &packages, None)
+            .unwrap()
+            .expect("check enabled → Some");
+
+        assert_eq!(result.total_count(), 1);
+        let view = &result.packages[0];
+        assert_eq!(view.name, "my-lib");
+        assert_eq!(view.source_label, "Git");
+        assert_eq!(view.source_location, "https://github.com/user/my-lib?rev=abc123");
+        assert!(!view.is_direct, "no graph → is_direct defaults to false");
+    }
+
+    #[test]
+    fn test_check_non_pypi_is_direct_from_dependency_graph() {
+        use crate::sbom_generation::domain::{DependencyGraph, PackageName};
+
+        let mut source_map = PackageSourceMap::new();
+        source_map.insert(
+            "internal".to_string(),
+            PackageSourceKind::PrivateRegistry("https://internal.example.com/simple".to_string()),
+        );
+
+        let use_case = UseCaseBuilder::default()
+            .with_lockfile(vec![pkg("internal", "1.0.0")])
+            .with_source_map(source_map)
+            .build();
+        let packages = [pkg("internal", "1.0.0")];
+
+        let direct = vec![PackageName::new("internal".to_string()).unwrap()];
+        let graph = DependencyGraph::new(direct, Default::default(), Default::default());
+
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .check_non_pypi(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .check_non_pypi_if_requested(&request, &packages, Some(&graph))
+            .unwrap()
+            .expect("check enabled → Some");
+
+        assert_eq!(result.direct_count(), 1);
+        assert_eq!(result.transitive_count(), 0);
+        assert!(result.packages[0].is_direct);
     }
 }

--- a/src/cli/config_resolver.rs
+++ b/src/cli/config_resolver.rs
@@ -20,7 +20,6 @@ pub struct MergedConfig {
     pub suggest_fix: bool,
     pub check_abandoned: bool,
     pub abandoned_threshold_days: u64,
-    #[allow(dead_code)] // WIRE(#627): remove when check_non_pypi is wired into SbomRequest
     pub check_non_pypi: bool,
     /// Dependency groups whose exclusively-reachable packages should be excluded from the SBOM.
     /// Populated from `--exclude-groups` (CLI) or `exclude_groups` (config file).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //!     None,
 //!     None,
 //!     None, // No abandoned-package report in this example
+//!     None, // No non-PyPI packages report in this example
 //!     &[], // No group filter in this example
 //! );
 //! let formatter = CycloneDxFormatter::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,7 @@ async fn run(args: Args) -> Result<bool> {
         .suggest_fix(suggest_fix)
         .check_abandoned(merged.check_abandoned)
         .abandoned_threshold_days(merged.abandoned_threshold_days)
+        .check_non_pypi(merged.check_non_pypi)
         .exclude_groups(exclude_groups)
         .locale(locale)
         .build()?;
@@ -354,6 +355,7 @@ async fn run(args: Args) -> Result<bool> {
             .map(|(n, v)| (n.as_str(), v.as_str())),
         response.upgrade_recommendations.as_deref(),
         response.abandoned_packages_report.as_ref(),
+        response.non_pypi_packages_report.as_ref(),
         &applied_group_filter,
     );
 
@@ -495,6 +497,7 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             .suggest_fix(false)
             .check_abandoned(merged.check_abandoned)
             .abandoned_threshold_days(merged.abandoned_threshold_days)
+            .check_non_pypi(merged.check_non_pypi)
             .exclude_groups(workspace_exclude_groups.clone())
             .locale(locale)
             .build()?;
@@ -512,6 +515,7 @@ async fn run_workspace(args: Args, workspace_root: PathBuf) -> Result<()> {
             None,
             response.upgrade_recommendations.as_deref(),
             response.abandoned_packages_report.as_ref(),
+            response.non_pypi_packages_report.as_ref(),
             &applied_group_filter,
         );
 

--- a/src/ports/outbound/lockfile_reader.rs
+++ b/src/ports/outbound/lockfile_reader.rs
@@ -16,7 +16,6 @@ pub type LockfileParseResult = (Vec<Package>, DependencyMap);
 pub type GroupRoots = HashMap<String, Vec<String>>;
 
 /// Classification of a package's `source` field in `uv.lock`.
-#[allow(dead_code)] // WIRE(#627): remove when wired into non-PyPI source detection use case
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackageSourceKind {
     /// Standard PyPI registry (`https://pypi.org/simple`).
@@ -33,7 +32,6 @@ pub enum PackageSourceKind {
     WorkspaceMember,
 }
 
-#[allow(dead_code)] // WIRE(#627): remove when PackageSourceKind methods are used by application code
 impl PackageSourceKind {
     /// Returns `true` for sources that are external but not the canonical PyPI registry.
     ///
@@ -73,7 +71,6 @@ impl PackageSourceKind {
 ///
 /// Keyed by the package name as it appears in `uv.lock`. Packages without a
 /// `source` field are omitted from the map.
-#[allow(dead_code)] // WIRE(#627): remove when PackageSourceMap is used by application code
 pub type PackageSourceMap = HashMap<String, PackageSourceKind>;
 
 /// LockfileReader port for reading and parsing lockfile contents
@@ -148,6 +145,5 @@ pub trait LockfileReader {
     ///
     /// Returns a map of package name → `PackageSourceKind`. Packages whose
     /// `[[package]]` entry has no `source` field are omitted from the map.
-    #[allow(dead_code)] // WIRE(#627): remove when called by non-PyPI source detection use case
     fn read_and_parse_package_sources(&self, project_path: &Path) -> Result<PackageSourceMap>;
 }

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -106,6 +106,7 @@ async fn test_e2e_json_format() {
         None,
         None,
         None,
+        None,
         &applied_group_filter,
     );
     let formatter = CycloneDxFormatter::new();
@@ -158,6 +159,7 @@ async fn test_e2e_markdown_format() {
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
         None,
         None,
         None,
@@ -508,6 +510,7 @@ async fn test_e2e_exclude_root_project_markdown_output() {
         response.dependency_graph.as_ref(),
         response.vulnerability_check_result.as_ref(),
         response.license_compliance_result.as_ref(),
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
## Summary

- Add `NonPyPiPackageView` and `NonPyPiPackagesReport` read model types and wire them into `SbomResponse`, `SbomReadModel`, and `SbomReadModelBuilder`
- Integrate `check_non_pypi_if_requested()` into `GenerateSbomUseCase::execute()` (Step 10) using `PackageSourceKind::is_non_pypi_external()` to detect git/url/private-registry packages
- Remove all `WIRE(#627)` dead-code annotations; add `WIRE(#660)` on formatter-facing fields pending Markdown renderer in Issue #660

## Related Issue

Closes #655
Part of #627 (`--check-non-pypi` feature)

## Changes Made

- **New file** `src/application/read_models/non_pypi_package.rs`: `NonPyPiPackageView` (name, version, source_label, source_location, is_direct) and `NonPyPiPackagesReport` (packages, total/direct/transitive counts)
- **`SbomRequest`**: added `check_non_pypi: bool` field
- **`SbomResponse`**: added `non_pypi_packages_report: Option<NonPyPiPackagesReport>`
- **`SbomReadModel`**: added `non_pypi_packages: Option<NonPyPiPackagesReport>` with `WIRE(#660)` annotation
- **`SbomReadModelBuilder::build_with_project`**: new 10th parameter `non_pypi_packages_report`
- **`GenerateSbomUseCase`**: added `check_non_pypi_if_requested()` (reads source map via port, classifies packages, derives `is_direct` from dependency graph) and extracted `resolve_direct_names()` helper shared with `check_abandoned_if_requested()`
- **`src/main.rs`**: wired `check_non_pypi` and `non_pypi_packages_report` in both `run()` and `run_workspace()`
- **WIRE cleanup**: removed 10 `WIRE(#627)` annotations from `lockfile_reader.rs`, `lockfile_parser.rs`, `config_resolver.rs`

## WIRE Annotations Introduced

> ⚠️ This PR introduces `WIRE(#660)` annotations. Issue #660 (Markdown formatter for non-PyPI section) is open and will consume these items. The annotation will be auto-detected by `/implement` Step 4.0 when Issue #660 is implemented.

## CHANGELOG Note

The user-facing `--check-non-pypi` flag was already documented in `CHANGELOG.md [Unreleased]` by PR #659. This PR is a backend implementation step with no new user-visible flags.

## Test Plan

- [x] `cargo test --all` passes (5 new unit tests in `tests_non_pypi`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

---
Generated with [Claude Code](https://claude.com/claude-code)