### PR TITLE
feat(adapters): render non-PyPI package sources in Markdown formatter

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -223,6 +223,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
 | `GroupReachabilityAnalyzer` | `src/sbom_generation/domain/services/group_reachability_analyzer.rs` | Pure domain service for BFS-based group reachability traversal; wired into `GenerateSbomUseCase` via `apply_group_filter` in #623 |
 | `GroupRoots` | `src/ports/outbound/lockfile_reader.rs` | Type alias `HashMap<String, Vec<String>>` mapping dependency group name → root package names; extracted from `[manifest.dependency-groups]` in `uv.lock`; consumed by group reachability traversal in #622; wired into use case in #623 |
+| `NonPyPiPackageView` / `NonPyPiPackagesReport` | `src/application/read_models/non_pypi_package.rs` | Read model for packages sourced from non-PyPI origins (git, url, private registry); populated by `GenerateSbomUseCase` when `check_non_pypi` is true; rendered by the Markdown formatter's `non_pypi_packages` section (#656, #660) |
 
 ### Important Invariants
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `--check-non-pypi` CLI flag and `check_non_pypi` config key for opt-in non-PyPI package source detection (git, path, url, private registries) — groundwork for #627
+- **Non-PyPI Package Sources Markdown section**: When `--check-non-pypi` is active and non-PyPI packages are detected, a new `## ⚠️ Non-PyPI Package Sources` section is rendered in Markdown output after the Abandoned Packages section, showing a direct/transitive count summary, a table of Package, Version, Source Type, and Source, and an advisory note. The section is omitted entirely when the check is disabled or no non-PyPI packages are found. Local-path packages are intentionally excluded, consistent with existing source classification. Fully localized for EN and JA (#656, #660).
 
 ## [2.6.0] - 2026-06-27
 

--- a/src/adapters/outbound/formatters/markdown_formatter/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/mod.rs
@@ -92,6 +92,11 @@ impl MarkdownFormatter {
         if let Some(report) = &model.abandoned_packages {
             sections::abandoned_packages::render(self.messages, output, report);
         }
+        if let Some(report) = &model.non_pypi_packages {
+            if !report.is_empty() {
+                sections::non_pypi_packages::render(self.messages, output, report);
+            }
+        }
         if let Some(guide) = &model.resolution_guide {
             if !guide.entries.is_empty() {
                 sections::resolution_guide::render(
@@ -908,5 +913,81 @@ mod tests {
         let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
         assert!(markdown.contains("| Abandoned packages | 2 | ⚠️ |"));
         assert!(!markdown.contains("_Abandoned package check skipped._"));
+    }
+
+    // ===== Non-PyPI packages section tests =====
+
+    fn with_non_pypi_packages(
+        packages: Vec<crate::application::read_models::NonPyPiPackageView>,
+    ) -> crate::application::read_models::SbomReadModel {
+        use crate::application::read_models::NonPyPiPackagesReport;
+        let mut model = test_fixtures::base_model();
+        model.non_pypi_packages = Some(NonPyPiPackagesReport { packages });
+        model
+    }
+
+    #[test]
+    fn test_non_pypi_section_absent_when_none() {
+        let model = test_fixtures::base_model(); // non_pypi_packages: None
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(!markdown.contains("## ⚠️ Non-PyPI Package Sources"));
+    }
+
+    #[test]
+    fn test_non_pypi_section_absent_when_empty() {
+        let model = with_non_pypi_packages(vec![]);
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert!(!markdown.contains("## ⚠️ Non-PyPI Package Sources"));
+    }
+
+    #[test]
+    fn test_non_pypi_section_order_after_abandoned_before_resolution_guide() {
+        use crate::application::read_models::{
+            AbandonedPackageView, AbandonedPackagesReport, IntroducedByView, NonPyPiPackageView,
+            ResolutionEntryView, ResolutionGuideView,
+        };
+        use chrono::NaiveDate;
+
+        let mut model = with_non_pypi_packages(vec![NonPyPiPackageView {
+            name: "dev-tool".to_string(),
+            version: "1.0.0".to_string(),
+            source_label: "Git".to_string(),
+            source_location: "https://github.com/example/repo".to_string(),
+            is_direct: true,
+        }]);
+        model.abandoned_packages = Some(AbandonedPackagesReport {
+            packages: vec![AbandonedPackageView {
+                name: "stale-lib".to_string(),
+                version: "1.0.0".to_string(),
+                last_release_date: NaiveDate::from_ymd_opt(2020, 1, 1).unwrap(),
+                days_inactive: 900,
+                is_direct: true,
+            }],
+            threshold_days: 730,
+        });
+        model.resolution_guide = Some(ResolutionGuideView {
+            entries: vec![ResolutionEntryView {
+                vulnerable_package: "requests".to_string(),
+                current_version: "2.31.0".to_string(),
+                fixed_version: Some("2.32.0".to_string()),
+                severity: SeverityView::High,
+                vulnerability_id: "CVE-2024-0001".to_string(),
+                introduced_by: vec![IntroducedByView {
+                    package_name: "requests".to_string(),
+                    version: "2.31.0".to_string(),
+                }],
+                dependency_chains: vec![],
+            }],
+        });
+
+        let markdown = MarkdownFormatter::new(Locale::En).format(&model).unwrap();
+        assert_section_order(
+            &markdown,
+            &[
+                "## Abandoned Packages",
+                "## ⚠️ Non-PyPI Package Sources",
+                "## Vulnerability Resolution Guide",
+            ],
+        );
     }
 }

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/mod.rs
@@ -3,5 +3,6 @@ pub(super) mod components;
 pub(super) mod dependencies;
 pub(super) mod header;
 pub(super) mod license_compliance;
+pub(super) mod non_pypi_packages;
 pub(super) mod resolution_guide;
 pub(super) mod summary;

--- a/src/adapters/outbound/formatters/markdown_formatter/sections/non_pypi_packages.rs
+++ b/src/adapters/outbound/formatters/markdown_formatter/sections/non_pypi_packages.rs
@@ -1,0 +1,167 @@
+use crate::application::read_models::NonPyPiPackagesReport;
+use crate::i18n::Messages;
+
+/// Renders the non-PyPI packages section.
+///
+/// Callers MUST check `report.is_empty()` before calling this function and skip
+/// the call entirely when empty — unlike the abandoned-packages section, there is
+/// no empty-state message here, and this function does not guard against an empty
+/// report itself; calling it with one produces a misleading "0 packages" section.
+pub(in super::super) fn render(
+    messages: &'static Messages,
+    output: &mut String,
+    report: &NonPyPiPackagesReport,
+) {
+    output.push('\n');
+    output.push_str(messages.section_non_pypi_packages);
+    output.push_str("\n\n");
+    output.push_str(&Messages::format(
+        messages.summary_non_pypi_packages,
+        &[
+            &report.total_count().to_string(),
+            &report.direct_count().to_string(),
+            &report.transitive_count().to_string(),
+        ],
+    ));
+    output.push_str("\n\n");
+
+    output.push_str(&format!(
+        "| {} | {} | {} | {} |\n",
+        messages.col_package, messages.col_version, messages.col_source_type, messages.col_source,
+    ));
+    output.push_str(&super::super::table::make_separator(&[
+        messages.col_package,
+        messages.col_version,
+        messages.col_source_type,
+        messages.col_source,
+    ]));
+
+    for pkg in &report.packages {
+        output.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            super::super::table::escape_markdown_table_cell(&pkg.name),
+            super::super::table::escape_markdown_table_cell(&pkg.version),
+            super::super::table::escape_markdown_table_cell(&pkg.source_label),
+            super::super::table::escape_markdown_table_cell(&pkg.source_location),
+        ));
+    }
+    output.push('\n');
+
+    output.push_str(messages.note_non_pypi_packages);
+    output.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::read_models::NonPyPiPackageView;
+    use crate::i18n::{Locale, Messages};
+
+    fn make_view(
+        name: &str,
+        source_label: &str,
+        source_location: &str,
+        is_direct: bool,
+    ) -> NonPyPiPackageView {
+        NonPyPiPackageView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            source_label: source_label.to_string(),
+            source_location: source_location.to_string(),
+            is_direct,
+        }
+    }
+
+    fn render_en(report: &NonPyPiPackagesReport) -> String {
+        let mut output = String::new();
+        render(Messages::for_locale(Locale::En), &mut output, report);
+        output
+    }
+
+    fn render_ja(report: &NonPyPiPackagesReport) -> String {
+        let mut output = String::new();
+        render(Messages::for_locale(Locale::Ja), &mut output, report);
+        output
+    }
+
+    #[test]
+    fn test_section_rendered_with_correct_rows_en() {
+        let report = NonPyPiPackagesReport {
+            packages: vec![
+                make_view(
+                    "my-internal-lib",
+                    "Private Registry",
+                    "https://internal.company.com/simple",
+                    true,
+                ),
+                make_view(
+                    "dev-tool",
+                    "Git",
+                    "https://github.com/user/repo?rev=abc123",
+                    false,
+                ),
+            ],
+        };
+        let output = render_en(&report);
+        assert!(output.contains("## ⚠️ Non-PyPI Package Sources"));
+        assert!(output.contains(
+            "2 packages are sourced from outside the official PyPI registry (1 direct, 1 transitive)."
+        ));
+        assert!(output.contains("| Package | Version | Source Type | Source |"));
+        assert!(output.contains(
+            "| my-internal-lib | 1.0.0 | Private Registry | https://internal.company.com/simple |"
+        ));
+        assert!(
+            output.contains("| dev-tool | 1.0.0 | Git | https://github.com/user/repo?rev=abc123 |")
+        );
+        assert!(output.contains(
+            "> Packages from non-PyPI sources may not be subject to PyPI's security policies."
+        ));
+    }
+
+    #[test]
+    fn test_section_rendered_ja() {
+        let report = NonPyPiPackagesReport {
+            packages: vec![make_view(
+                "my-internal-lib",
+                "Private Registry",
+                "https://internal.company.com/simple",
+                true,
+            )],
+        };
+        let output = render_ja(&report);
+        assert!(output.contains("## ⚠️ PyPI以外のパッケージソース"));
+        assert!(output.contains("1個のパッケージが公式PyPIレジストリ以外から取得されています（直接依存 1件、間接依存 0件）。"));
+        assert!(output.contains("| パッケージ | バージョン | ソース種別 | 取得元 |"));
+        assert!(output.contains("PyPI以外のソースから取得されたパッケージは"));
+    }
+
+    #[test]
+    fn test_direct_and_transitive_counts_shown() {
+        let report = NonPyPiPackagesReport {
+            packages: vec![
+                make_view("a", "Git", "https://example.com/a", true),
+                make_view("b", "Git", "https://example.com/b", false),
+                make_view("c", "Git", "https://example.com/c", false),
+            ],
+        };
+        let output = render_en(&report);
+        assert!(output.contains(
+            "3 packages are sourced from outside the official PyPI registry (1 direct, 2 transitive)."
+        ));
+    }
+
+    #[test]
+    fn test_package_name_with_pipe_is_escaped() {
+        let report = NonPyPiPackagesReport {
+            packages: vec![make_view(
+                "pkg|evil",
+                "Git",
+                "https://example.com/pkg",
+                true,
+            )],
+        };
+        let output = render_en(&report);
+        assert!(output.contains("pkg\\|evil"));
+    }
+}

--- a/src/application/read_models/non_pypi_package.rs
+++ b/src/application/read_models/non_pypi_package.rs
@@ -30,31 +30,26 @@ pub struct NonPyPiPackageView {
 #[derive(Debug, Clone, Default)]
 pub struct NonPyPiPackagesReport {
     /// Packages sourced from non-PyPI external origins.
-    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter renders this field
     pub packages: Vec<NonPyPiPackageView>,
 }
 
 impl NonPyPiPackagesReport {
     /// Returns the total number of non-PyPI packages.
-    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
     pub fn total_count(&self) -> usize {
         self.packages.len()
     }
 
     /// Returns the number of non-PyPI packages that are direct dependencies.
-    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
     pub fn direct_count(&self) -> usize {
         self.packages.iter().filter(|p| p.is_direct).count()
     }
 
     /// Returns the number of non-PyPI packages that are transitive dependencies.
-    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
     pub fn transitive_count(&self) -> usize {
         self.packages.iter().filter(|p| !p.is_direct).count()
     }
 
     /// Returns `true` when no non-PyPI packages were found.
-    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter calls this method
     pub fn is_empty(&self) -> bool {
         self.packages.is_empty()
     }

--- a/src/application/read_models/sbom_read_model.rs
+++ b/src/application/read_models/sbom_read_model.rs
@@ -38,7 +38,6 @@ pub struct SbomReadModel {
     pub abandoned_packages: Option<AbandonedPackagesReport>,
     /// Non-PyPI packages report.
     /// Populated only when `check_non_pypi` was true in the request.
-    #[allow(dead_code)] // WIRE(#660): remove when Markdown formatter reads this field
     pub non_pypi_packages: Option<NonPyPiPackagesReport>,
     /// Dependency groups that were excluded during generation. Empty = no filter.
     pub applied_group_filter: Vec<String>,

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -185,6 +185,13 @@ pub struct Messages {
     pub col_days_inactive: &'static str,
     pub col_type: &'static str,
 
+    // Non-PyPI packages section
+    pub section_non_pypi_packages: &'static str,
+    pub summary_non_pypi_packages: &'static str,
+    pub note_non_pypi_packages: &'static str,
+    pub col_source_type: &'static str,
+    pub col_source: &'static str,
+
     // Diff Markdown formatter strings
     pub diff_section_title: &'static str,
     pub diff_compared_line: &'static str,
@@ -394,6 +401,13 @@ static EN_MESSAGES: Messages = Messages {
     col_days_inactive: "Days Inactive",
     col_type: "Type",
 
+    // Non-PyPI packages section
+    section_non_pypi_packages: "## ⚠️ Non-PyPI Package Sources",
+    summary_non_pypi_packages: "{} packages are sourced from outside the official PyPI registry ({} direct, {} transitive).",
+    note_non_pypi_packages: "> Packages from non-PyPI sources may not be subject to PyPI's security policies. Review each package's origin before production deployment.",
+    col_source_type: "Source Type",
+    col_source: "Source",
+
     // Diff Markdown formatter strings
     diff_section_title: "## Dependency Diff Report",
     diff_compared_line: "Compared: `{}` vs current `uv.lock`",
@@ -573,6 +587,13 @@ static JA_MESSAGES: Messages = Messages {
     col_last_release: "最終リリース",
     col_days_inactive: "非アクティブ日数",
     col_type: "種別",
+
+    // Non-PyPI packages section
+    section_non_pypi_packages: "## ⚠️ PyPI以外のパッケージソース",
+    summary_non_pypi_packages: "{}個のパッケージが公式PyPIレジストリ以外から取得されています（直接依存 {}件、間接依存 {}件）。",
+    note_non_pypi_packages: "> PyPI以外のソースから取得されたパッケージは、PyPIのセキュリティポリシーの対象外である可能性があります。本番環境へのデプロイ前に、各パッケージの取得元を確認してください。",
+    col_source_type: "ソース種別",
+    col_source: "取得元",
 
     // Diff Markdown formatter strings
     diff_section_title: "## 依存関係差分レポート",
@@ -1096,6 +1117,44 @@ mod tests {
         assert_eq!(msgs.col_last_release, "最終リリース");
         assert_eq!(msgs.col_days_inactive, "非アクティブ日数");
         assert_eq!(msgs.col_type, "種別");
+    }
+
+    #[test]
+    fn test_messages_non_pypi_section_en() {
+        let msgs = Messages::for_locale(Locale::En);
+        assert_eq!(
+            msgs.section_non_pypi_packages,
+            "## ⚠️ Non-PyPI Package Sources"
+        );
+        assert_eq!(
+            Messages::format(msgs.summary_non_pypi_packages, &["3", "1", "2"]),
+            "3 packages are sourced from outside the official PyPI registry (1 direct, 2 transitive)."
+        );
+        assert_eq!(
+            msgs.note_non_pypi_packages,
+            "> Packages from non-PyPI sources may not be subject to PyPI's security policies. Review each package's origin before production deployment."
+        );
+        assert_eq!(msgs.col_source_type, "Source Type");
+        assert_eq!(msgs.col_source, "Source");
+    }
+
+    #[test]
+    fn test_messages_non_pypi_section_ja() {
+        let msgs = Messages::for_locale(Locale::Ja);
+        assert_eq!(
+            msgs.section_non_pypi_packages,
+            "## ⚠️ PyPI以外のパッケージソース"
+        );
+        assert_eq!(
+            Messages::format(msgs.summary_non_pypi_packages, &["3", "1", "2"]),
+            "3個のパッケージが公式PyPIレジストリ以外から取得されています（直接依存 1件、間接依存 2件）。"
+        );
+        assert_eq!(
+            msgs.note_non_pypi_packages,
+            "> PyPI以外のソースから取得されたパッケージは、PyPIのセキュリティポリシーの対象外である可能性があります。本番環境へのデプロイ前に、各パッケージの取得元を確認してください。"
+        );
+        assert_eq!(msgs.col_source_type, "ソース種別");
+        assert_eq!(msgs.col_source, "取得元");
     }
 
     #[test]

--- a/tests/fixtures/non_pypi_project/pyproject.toml
+++ b/tests/fixtures/non_pypi_project/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "non-pypi-project"
+version = "0.1.0"
+description = "A fixture project with non-PyPI package sources for testing"
+requires-python = ">=3.8"
+dependencies = [
+    "my-internal-lib",
+    "standard-lib",
+    "local-lib",
+    "internal-workspace-pkg",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/tests/fixtures/non_pypi_project/uv.lock
+++ b/tests/fixtures/non_pypi_project/uv.lock
@@ -1,0 +1,47 @@
+version = 1
+requires-python = ">=3.8"
+
+[[package]]
+name = "non-pypi-project"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "my-internal-lib" },
+    { name = "standard-lib" },
+    { name = "local-lib" },
+    { name = "internal-workspace-pkg" },
+]
+
+[[package]]
+name = "my-internal-lib"
+version = "1.2.0"
+source = { registry = "https://internal.company.com/simple" }
+
+[[package]]
+name = "standard-lib"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dev-tool" },
+    { name = "remote-archive" },
+]
+
+[[package]]
+name = "dev-tool"
+version = "0.1.0"
+source = { git = "https://github.com/user/repo?rev=abc123" }
+
+[[package]]
+name = "remote-archive"
+version = "3.0.0"
+source = { url = "https://example.com/remote-archive-3.0.0-py3-none-any.whl" }
+
+[[package]]
+name = "local-lib"
+version = "0.9.0"
+source = { path = "vendor/local-lib" }
+
+[[package]]
+name = "internal-workspace-pkg"
+version = "0.2.0"
+source = { editable = "packages/internal-workspace-pkg" }

--- a/tests/non_pypi_test.rs
+++ b/tests/non_pypi_test.rs
@@ -1,0 +1,153 @@
+/// Integration tests for the non-PyPI packages Markdown section (`--check-non-pypi`).
+use std::path::PathBuf;
+use uv_sbom::prelude::*;
+
+fn create_test_license_repository() -> impl LicenseRepository + Clone {
+    #[derive(Clone)]
+    struct TestLicenseRepository;
+
+    #[async_trait::async_trait]
+    impl LicenseRepository for TestLicenseRepository {
+        async fn fetch_license_info(
+            &self,
+            _package_name: &str,
+            _version: &str,
+        ) -> Result<(
+            Option<String>,
+            Option<String>,
+            Vec<String>,
+            Option<String>,
+            Option<String>,
+        )> {
+            Ok((None, None, vec![], None, None))
+        }
+    }
+
+    TestLicenseRepository
+}
+
+#[tokio::test]
+async fn test_non_pypi_section_rendered_when_check_non_pypi_enabled() {
+    let project_path = PathBuf::from("tests/fixtures/non_pypi_project");
+
+    let lockfile_reader = FileSystemReader::new();
+    let project_config_reader = FileSystemReader::new();
+    let license_repository = create_test_license_repository();
+    let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
+
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
+        lockfile_reader,
+        project_config_reader,
+        license_repository,
+        progress_reporter,
+        None,
+        None,
+        uv_sbom::i18n::Locale::En,
+    );
+
+    let request = SbomRequest::builder()
+        .project_path(project_path)
+        .include_dependency_info(true)
+        .check_non_pypi(true)
+        .build()
+        .unwrap();
+    let result = use_case.execute(request).await;
+
+    assert!(result.is_ok(), "execute failed: {:?}", result.err());
+    let response = result.unwrap();
+
+    let applied_group_filter = response.applied_group_filter.clone();
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build_with_project(
+        response.enriched_packages,
+        &response.metadata,
+        response.dependency_graph.as_ref(),
+        response.vulnerability_check_result.as_ref(),
+        response.license_compliance_result.as_ref(),
+        None,
+        None,
+        None,
+        response.non_pypi_packages_report.as_ref(),
+        &applied_group_filter,
+    );
+
+    let formatter = MarkdownFormatter::new(uv_sbom::i18n::Locale::En);
+    let markdown = formatter.format(&read_model).unwrap();
+
+    assert!(markdown.contains("## ⚠️ Non-PyPI Package Sources"));
+
+    // Private registry, git, and direct-URL packages are non-PyPI external and must appear.
+    assert!(markdown.contains("my-internal-lib"));
+    assert!(markdown.contains("Private Registry"));
+    assert!(markdown.contains("https://internal.company.com/simple"));
+    assert!(markdown.contains("dev-tool"));
+    assert!(markdown.contains("Git"));
+    assert!(markdown.contains("https://github.com/user/repo?rev=abc123"));
+    assert!(markdown.contains("remote-archive"));
+    assert!(markdown.contains("Direct URL"));
+    assert!(markdown.contains("https://example.com/remote-archive-3.0.0-py3-none-any.whl"));
+
+    // PyPI, local-path, and workspace-member packages must NOT appear in the section.
+    // (local-lib is intentionally excluded by existing domain logic: PackageSourceKind::LocalPath
+    // is not classified as "non-pypi external".)
+    assert!(!markdown.contains("| local-lib |"));
+    assert!(!markdown.contains("| standard-lib |"));
+    assert!(!markdown.contains("| internal-workspace-pkg |"));
+
+    // Direct/transitive breakdown: my-internal-lib is a direct dependency of the root project;
+    // dev-tool and remote-archive are transitive (pulled in via standard-lib).
+    assert!(markdown.contains(
+        "3 packages are sourced from outside the official PyPI registry (1 direct, 2 transitive)."
+    ));
+}
+
+#[tokio::test]
+async fn test_non_pypi_section_absent_when_check_non_pypi_disabled() {
+    let project_path = PathBuf::from("tests/fixtures/non_pypi_project");
+
+    let lockfile_reader = FileSystemReader::new();
+    let project_config_reader = FileSystemReader::new();
+    let license_repository = create_test_license_repository();
+    let progress_reporter = StderrProgressReporter::new(uv_sbom::i18n::Locale::En);
+
+    let use_case: GenerateSbomUseCase<_, _, _, _, (), ()> = GenerateSbomUseCase::new(
+        lockfile_reader,
+        project_config_reader,
+        license_repository,
+        progress_reporter,
+        None,
+        None,
+        uv_sbom::i18n::Locale::En,
+    );
+
+    let request = SbomRequest::builder()
+        .project_path(project_path)
+        .include_dependency_info(true)
+        .build()
+        .unwrap();
+    let result = use_case.execute(request).await;
+
+    assert!(result.is_ok(), "execute failed: {:?}", result.err());
+    let response = result.unwrap();
+
+    assert!(response.non_pypi_packages_report.is_none());
+
+    let applied_group_filter = response.applied_group_filter.clone();
+    let read_model = uv_sbom::application::read_models::SbomReadModelBuilder::build_with_project(
+        response.enriched_packages,
+        &response.metadata,
+        response.dependency_graph.as_ref(),
+        response.vulnerability_check_result.as_ref(),
+        response.license_compliance_result.as_ref(),
+        None,
+        None,
+        None,
+        response.non_pypi_packages_report.as_ref(),
+        &applied_group_filter,
+    );
+
+    let formatter = MarkdownFormatter::new(uv_sbom::i18n::Locale::En);
+    let markdown = formatter.format(&read_model).unwrap();
+
+    assert!(!markdown.contains("## ⚠️ Non-PyPI Package Sources"));
+    assert!(!markdown.contains("Non-PyPI"));
+}


### PR DESCRIPTION
## Summary
- Adds a `## ⚠️ Non-PyPI Package Sources` section to the Markdown formatter, rendered after the Abandoned Packages section when `SbomReadModel.non_pypi_packages` is `Some` and non-empty (omitted entirely otherwise, mirroring the existing `resolution_guide` gate).
- Clears the `WIRE(#660)` dead-code annotations on `NonPyPiPackagesReport` and `SbomReadModel.non_pypi_packages` that were left pending this formatter wiring.
- Adds a new fixture project (`tests/fixtures/non_pypi_project`) covering private-registry, git, direct-URL, local-path, PyPI, and workspace-member sources, plus integration tests verifying the section's presence/content with `--check-non-pypi` and its absence without the flag.

## Related Issues
Closes #656
Closes #660

Note: these two issues had overlapping scope (both targeted rendering the non-PyPI section in the Markdown formatter — #656 focused on fixture/integration tests, #660 on i18n/direct-transitive counts/unit tests). Confirmed with the repo owner to implement the merged scope in a single PR rather than split.

## Changes Made
- New `sections::non_pypi_packages::render()` in `src/adapters/outbound/formatters/markdown_formatter/sections/non_pypi_packages.rs`: header, direct/transitive count summary line, package table, advisory note — fully localized (EN/JA) via 5 new `src/i18n/mod.rs` keys.
- Wired into `MarkdownFormatter::render_optional_sections` after `abandoned_packages`, before `resolution_guide`.
- Removed `#[allow(dead_code)] // WIRE(#660)` annotations now that `packages`, `total_count()`, `direct_count()`, `transitive_count()`, `is_empty()`, and `SbomReadModel.non_pypi_packages` are referenced by production code.
- `local-lib` (Local Path source) is intentionally excluded from the report — confirmed with repo owner to keep the existing `PackageSourceKind::is_non_pypi_external()` domain classification unchanged (only `PrivateRegistry`/`Git`/`DirectUrl` count as non-PyPI-external) rather than changing already-merged domain logic to match the issue's illustrative sample output.
- `CHANGELOG.md`: extended the existing `--check-non-pypi` groundwork entry under `[Unreleased]`.
- `.claude/CLAUDE.md`: updated the `NonPyPiPackageView` / `NonPyPiPackagesReport` Architecture Overview row to remove the now-resolved `WIRE(#660)` note.

## Test Plan
- [x] `cargo test --all` passes (all suites, including 2 new integration tests in `tests/non_pypi_test.rs` and unit tests in `sections/non_pypi_packages.rs`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `git grep -n "WIRE(#660)" src/` returns empty
- [x] Reviewed via `/code-review` (2 iterations: 1 MUST FIX + 2 SHOULD FIX found and fixed in round 1 — file-size/test-bloat in `markdown_formatter/mod.rs`, test duplication, misleading doc comment; round 2 PASS)

---
Generated with [Claude Code](https://claude.com/claude-code)