### PR TITLE
docs: document --check-non-pypi flag in README.md and README-JP.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `--check-non-pypi` CLI flag and `check_non_pypi` config key for opt-in non-PyPI package source detection (git, path, url, private registries) — groundwork for #627
+- `--check-non-pypi` CLI flag and `check_non_pypi` config key for opt-in non-PyPI package source detection (git, direct URL, private registries) — groundwork for #627
 - **Non-PyPI Package Sources Markdown section**: When `--check-non-pypi` is active and non-PyPI packages are detected, a new `## ⚠️ Non-PyPI Package Sources` section is rendered in Markdown output after the Abandoned Packages section, showing a direct/transitive count summary, a table of Package, Version, Source Type, and Source, and an advisory note. The section is omitted entirely when the check is disabled or no non-PyPI packages are found. Local-path packages are intentionally excluded, consistent with existing source classification. Fully localized for EN and JA (#656, #660).
+- `--check-non-pypi` documented in `README.md` and `README-JP.md`: new "Non-PyPI Source Detection" subsection with a "How it works" breakdown and example Markdown output, plus the flag added to the CLI options reference alongside previously-undocumented `--check-abandoned`, `--abandoned-threshold-days`, and `--diff` (#657).
 
 ## [2.6.0] - 2026-06-27
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -482,11 +482,35 @@ uv-sbom -p examples/abandoned-packages-project --check-abandoned -f markdown
 
 ### 非PyPIソース検出
 
-`--check-non-pypi` オプションを使用して、公式PyPIレジストリ以外のソース（git URL、ローカルパス、直接URL、プライベートレジストリ）からインストールされたパッケージを特定できます。uv.lockはすべてのパッケージのソース種別を明示的に記録しているため、サプライチェーンリスクの検出に役立ちます。
+`--check-non-pypi` オプションを使用して、公式PyPIレジストリ以外のソース（gitリポジトリ、直接URL、プライベートレジストリ）からインストールされたパッケージを特定できます。uv.lockはすべてのパッケージのソース種別を明示的に記録しているため、サプライチェーンリスクの検出に役立ちます。
 
 ```bash
 # 非PyPIソース検出を有効化
 uv-sbom --check-non-pypi --format markdown
+```
+
+**動作の仕組み:**
+- `uv.lock` からソース分類を直接読み取ります（ネットワークアクセスやPyPI APIの呼び出しは不要）
+- **プライベートレジストリ**、**Git**リポジトリ、**直接URL**から取得されたパッケージを検出対象とします
+- ローカルファイルシステムパス（`path = "..."`）やワークスペースメンバーは検出対象外です — これらはuvワークスペース構成では通常のパターンであり、サプライチェーン上の外部リスクとはみなされません
+
+**出力:**
+- **非PyPIパッケージソースセクション**: Markdown出力に、件数（直接依存 / 間接依存）とパッケージ・バージョン・ソース種別・取得元の列を持つテーブルが表示されます
+- `--check-non-pypi` を指定しない場合、または該当パッケージがない場合は、セクション自体が省略されます
+
+**出力例（`--lang ja` 指定時）:**
+```markdown
+## ⚠️ PyPI以外のパッケージソース
+
+3個のパッケージが公式PyPIレジストリ以外から取得されています（直接依存 1件、間接依存 2件）。
+
+| パッケージ | バージョン | ソース種別 | 取得元 |
+|-----------|-----------|-----------|--------|
+| my-internal-lib | 2.1.0 | Private Registry | https://internal.company.com/simple |
+| dev-tool | 0.4.0 | Git | https://github.com/user/repo?rev=abc123 |
+| patched-requests | 2.31.0 | Direct URL | https://example.com/patched-requests-2.31.0.tar.gz |
+
+> PyPI以外のソースから取得されたパッケージは、PyPIのセキュリティポリシーの対象外である可能性があります。本番環境へのデプロイ前に、各パッケージの取得元を確認してください。
 ```
 
 **設定ファイルの場合:**
@@ -925,7 +949,11 @@ Options:
                                      --no-check-cveとの同時使用は不可、uvのインストール、プロジェクトディレクトリのpyproject.tomlが必要
       --workspace                    ワークスペースの各メンバーに対して SBOM を生成
                                      --outputとの同時使用は不可
+      --diff <REF_OR_PATH>           現在のuv.lockをベース（gitのref、タグ、コミットSHA、またはuv.lockファイルへのパス）と比較
       --check-license                ライセンスコンプライアンスをポリシーに対してチェック
+      --check-abandoned              廃止/メンテナンス停止パッケージをチェック（しきい値日数以内に新しいリリースがない）
+      --abandoned-threshold-days <DAYS>  廃止パッケージ検出の非活動しきい値（日数、デフォルト: 730）
+      --check-non-pypi               非PyPIソース（git、直接URL、プライベートレジストリ）からのパッケージをチェック
       --license-allow <LIST>         許可するライセンスパターンのカンマ区切りリスト（設定ファイルを上書き）
       --license-deny <LIST>          拒否するライセンスパターンのカンマ区切りリスト（設定ファイルを上書き）
       --exclude-groups <GROUPS>      指定した依存関係グループからのみ到達可能なパッケージを除外（カンマ区切り）

--- a/README.md
+++ b/README.md
@@ -486,11 +486,35 @@ See [`examples/abandoned-packages-project/README.md`](examples/abandoned-package
 
 ### Non-PyPI Source Detection
 
-Use the `--check-non-pypi` option to identify packages installed from sources other than the official PyPI registry (git URLs, local paths, direct URLs, private registries). This helps detect potential supply chain risks unique to uv projects, since uv.lock explicitly records the source type for every package.
+Use the `--check-non-pypi` option to identify packages installed from sources other than the official PyPI registry (git repositories, direct URLs, private registries). This helps detect potential supply chain risks unique to uv projects, since uv.lock explicitly records the source type for every package.
 
 ```bash
 # Enable non-PyPI source detection
 uv-sbom --check-non-pypi --format markdown
+```
+
+**How it works:**
+- Reads the source classification directly from `uv.lock` (no network access, no PyPI API calls)
+- Flags packages sourced from a **Private Registry**, **Git** repository, or **Direct URL**
+- Local filesystem paths (`path = "..."`) and workspace members are not flagged — these are expected in uv workspace layouts and are not considered external supply chain risk
+
+**Output:**
+- **Non-PyPI Package Sources section**: Appears in the Markdown output listing the total count (direct vs. transitive) followed by a table of Package, Version, Source Type, and Source
+- When `--check-non-pypi` is not passed, or no packages match, the section is omitted entirely
+
+**Example output:**
+```markdown
+## ⚠️ Non-PyPI Package Sources
+
+3 packages are sourced from outside the official PyPI registry (1 direct, 2 transitive).
+
+| Package | Version | Source Type | Source |
+|---------|---------|--------------|--------|
+| my-internal-lib | 2.1.0 | Private Registry | https://internal.company.com/simple |
+| dev-tool | 0.4.0 | Git | https://github.com/user/repo?rev=abc123 |
+| patched-requests | 2.31.0 | Direct URL | https://example.com/patched-requests-2.31.0.tar.gz |
+
+> Packages from non-PyPI sources may not be subject to PyPI's security policies. Review each package's origin before production deployment.
 ```
 
 **Config file equivalent:**
@@ -931,7 +955,11 @@ Options:
                                      Requires uv CLI installed and pyproject.toml in project directory
       --workspace                    Generate one SBOM per workspace member
                                      Cannot be used with --output
+      --diff <REF_OR_PATH>           Compare current uv.lock against a base (git ref, tag, commit SHA, or path to a uv.lock file)
       --check-license                Check license compliance against policy
+      --check-abandoned              Check for abandoned/unmaintained packages (no upstream release within threshold days)
+      --abandoned-threshold-days <DAYS>  Inactivity threshold in days for abandoned-package detection (default: 730)
+      --check-non-pypi               Check for packages sourced from non-PyPI origins (git, direct URL, private registries)
       --license-allow <LIST>         Comma-separated list of allowed license patterns (overrides config)
       --license-deny <LIST>          Comma-separated list of denied license patterns (overrides config)
       --exclude-groups <GROUPS>      Exclude packages reachable only through the specified dependency groups (comma-separated)


### PR DESCRIPTION
## Summary
- Expand the "Non-PyPI Source Detection" section in README.md/README-JP.md with a "How it works" breakdown, an "Output" summary, and an example Markdown output block, matching the existing `--check-abandoned` documentation format.
- Add `--check-non-pypi`, `--check-abandoned`, `--abandoned-threshold-days`, and `--diff` to the "Command-line options" reference block in both READMEs, which had drifted out of sync with the actual `--help` output.
- Fix an inaccuracy (present in both READMEs and the CHANGELOG Unreleased entry): `--check-non-pypi` does not flag local filesystem paths — `PackageSourceKind::is_non_pypi_external()` only matches `PrivateRegistry`, `Git`, and `DirectUrl`.

## Related Issue
Closes #657

## Changes Made
- `README.md`: expanded Non-PyPI Source Detection section, corrected source-type description, added missing CLI flags to the options reference
- `README-JP.md`: full Japanese translation of the above changes
- `CHANGELOG.md`: corrected the same source-type inaccuracy in the Unreleased entry and added an entry for this documentation update

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (documentation-only change, no behavior affected)

---
Generated with [Claude Code](https://claude.com/claude-code)