### PR TITLE
docs(process): require example-project proof of output in CLI flag gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,6 +63,7 @@ Skills contain mandatory pre-flight checks and language requirements that preven
 - **Issue #59**: `cargo clippy` was run without `-D warnings`, causing CI failure after push
 - **2026-04-18**: v2.2.0 release promoted an empty `[Unreleased]` section. Features added in PRs #441–#483 were never recorded in CHANGELOG. Fixed by Issue #491 (added gate in `/release` Step 3.6 and `/pr` Step 4.5).
 - **2026-05-09 (Issue #511)**: `--check-abandoned` CLI flag was added without updating README.md, README-JP.md, `examples/sample-project/config/uv-sbom.config.yml`, or any example project README. Root cause: `/implement` Step 4 said "update docs as needed" without a concrete gate; `/pr` had no documentation backstop. Fixed by Issue #568 (`/implement` Step 4.3 CLI Flag Documentation Gate) and Issue #569 (`/pr` Step 4.6 CLI Flag Documentation Backstop).
+- **2026-07-08 (Issue #669)**: The `--check-non-pypi` flag (Issue #627) satisfied `/implement` Step 4.3.D with a README paragraph and a hand-fabricated example-output block, but no shipped example project's `uv.lock` contains a non-PyPI source, so running the flag against any example produces empty output. Root cause: Step 4.3.D only required a README *mention*, not *proof* of non-empty output. Fixed by Issue #669 (Step 4.3.D now requires actually running the flag against example data and producing real, non-empty output; a missing trigger is a blocker, not a gap). Note: `/pr` Step 4.6.D has the same weakness and should be hardened in a follow-up Issue.
 
 ### Enforcement
 

--- a/.claude/issue-guidelines.md
+++ b/.claude/issue-guidelines.md
@@ -172,6 +172,8 @@ Before submitting via `gh issue create`:
 - [ ] Files to update/create are listed with explanations
 - [ ] Design decisions documented with rationale
 - [ ] Question: "Can an AI implement this without asking questions?" — Answer: Yes
+- [ ] If the Issue adds a CLI flag: example/demo output shown in the Issue is produced by
+  actually running the CLI against real example data, not hand-written (see `/implement` Step 4.3.D)
 
 ## Examples of Good Issues
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -157,10 +157,18 @@ If the diff is **non-empty**, verify ALL of the following before proceeding to S
 - [ ] `examples/sample-project/config/uv-sbom.config.yml` includes the new config key
   (commented out with the default value, matching the style of existing entries)
 
-#### D. Example project documentation
+#### D. Example project documentation and proof of non-empty output
 
 - [ ] At least one example project README demonstrates the new flag
   (use `examples/sample-project/README.md` if it exists, otherwise note this as a gap)
+- [ ] The flag was actually run against a shipped example project — e.g.
+  `cargo run -- -p examples/sample-project --<new-flag> -f markdown` — and produced
+  non-empty, feature-specific output (not an empty section, not a "no results" message).
+  A README mention alone does NOT satisfy this gate.
+- [ ] If no shipped example project's `uv.lock` triggers non-empty output, this is a
+  BLOCKER, not a gap: add or extend an example project (or its `uv.lock`) so the flag
+  produces real output, then paste the actual output into the README example. Never
+  fabricate example output by hand.
 
 **If any checkbox is unchecked**: implement the missing documentation now, before invoking `/code-review`.
 


### PR DESCRIPTION
## Summary
- Strengthen `/implement` Step 4.3-D so a new CLI flag's example-project documentation isn't satisfied by a README mention alone — the flag must actually be run against a shipped example project and produce real, non-empty output; if no example's data triggers it, that's a blocker requiring a new/extended example, not a noted gap
- Add a matching checkpoint to `issue-guidelines.md`'s Quality Checklist
- Record the incident in `CLAUDE.md`'s Recent Incidents log under Skill Invocation Rules

## Related Issue
Closes #669

## Changes Made
- `.claude/skills/implement/SKILL.md` — Step 4.3-D now requires proof that the flag produces non-empty output against a real example project (with the correct `-p`/`-f` flag syntax for this CLI), not just a README paragraph
- `.claude/issue-guidelines.md` — new Quality Checklist item requiring CLI-flag example output to come from an actual CLI run, not hand-written text
- `.claude/CLAUDE.md` — new dated entry in Recent Incidents documenting the gap found in #627's `--check-non-pypi` flag (no shipped example project's `uv.lock` contains a non-PyPI source, so the flag produced empty output against every example despite passing the old gate)

## Context
Found while auditing whether #627 satisfied its own acceptance criteria (see #667, #668). No Rust source files are touched by this PR — it is purely a process/documentation change. A companion issue (#668) tracks the concrete fix of adding an example project that actually demonstrates `--check-non-pypi`, to be implemented separately.

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (805 lib + 850 bin tests; one e2e test that requires outbound network access to OSV/PyPI fails only due to this sandbox's network restrictions — pre-existing and unrelated to this change, reproduced independently)
- [x] Code review via `/code-review` passed after 2 iterations (first iteration caught a factually incorrect example CLI invocation, fixed)
- No manual testing applicable — documentation/process-only change

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXmRPHuuZ8NBMRUQnGRyWU)_