### PR TITLE
docs(examples): add non-pypi-sources-project demonstrating --check-non-pypi

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -505,10 +505,10 @@ uv-sbom --check-non-pypi --format markdown
 3個のパッケージが公式PyPIレジストリ以外から取得されています（直接依存 1件、間接依存 2件）。
 
 | パッケージ | バージョン | ソース種別 | 取得元 |
-|-----------|-----------|-----------|--------|
-| my-internal-lib | 2.1.0 | Private Registry | https://internal.company.com/simple |
-| dev-tool | 0.4.0 | Git | https://github.com/user/repo?rev=abc123 |
-| patched-requests | 2.31.0 | Direct URL | https://example.com/patched-requests-2.31.0.tar.gz |
+|-------|-------|-------|-----|
+| acme-analytics-sdk | 1.4.0 | Private Registry | https://pypi.acme-corp.example/simple |
+| edge-config | 2.1.0 | Direct URL | https://downloads.acme-corp.example/edge-config-2.1.0-py3-none-any.whl |
+| telemetry-agent | 0.9.2 | Git | https://github.com/acme-corp/telemetry-agent?rev=9f2c1ab |
 
 > PyPI以外のソースから取得されたパッケージは、PyPIのセキュリティポリシーの対象外である可能性があります。本番環境へのデプロイ前に、各パッケージの取得元を確認してください。
 ```
@@ -519,6 +519,14 @@ check_non_pypi: true
 ```
 
 > **注:** 非PyPIソース検出はネットワークアクセスを必要としません — すべてのデータは `uv.lock` から直接読み取られます。
+
+確実に出力が得られるデモを実行するには：
+
+```bash
+uv-sbom -p examples/non-pypi-sources-project --check-non-pypi --no-check-cve -f markdown
+```
+
+詳細は [`examples/non-pypi-sources-project/README-JP.md`](examples/non-pypi-sources-project/README-JP.md) を参照してください。
 
 ### 脆弱性しきい値オプション
 

--- a/README.md
+++ b/README.md
@@ -509,10 +509,10 @@ uv-sbom --check-non-pypi --format markdown
 3 packages are sourced from outside the official PyPI registry (1 direct, 2 transitive).
 
 | Package | Version | Source Type | Source |
-|---------|---------|--------------|--------|
-| my-internal-lib | 2.1.0 | Private Registry | https://internal.company.com/simple |
-| dev-tool | 0.4.0 | Git | https://github.com/user/repo?rev=abc123 |
-| patched-requests | 2.31.0 | Direct URL | https://example.com/patched-requests-2.31.0.tar.gz |
+|---------|---------|-------------|--------|
+| acme-analytics-sdk | 1.4.0 | Private Registry | https://pypi.acme-corp.example/simple |
+| edge-config | 2.1.0 | Direct URL | https://downloads.acme-corp.example/edge-config-2.1.0-py3-none-any.whl |
+| telemetry-agent | 0.9.2 | Git | https://github.com/acme-corp/telemetry-agent?rev=9f2c1ab |
 
 > Packages from non-PyPI sources may not be subject to PyPI's security policies. Review each package's origin before production deployment.
 ```
@@ -523,6 +523,14 @@ check_non_pypi: true
 ```
 
 > **Note:** Non-PyPI source detection requires no network access — all data is read directly from `uv.lock`.
+
+For a demo with guaranteed output, run:
+
+```bash
+uv-sbom -p examples/non-pypi-sources-project --check-non-pypi --no-check-cve -f markdown
+```
+
+See [`examples/non-pypi-sources-project/README.md`](examples/non-pypi-sources-project/README.md) for a full walkthrough.
 
 ### Vulnerability Threshold Options
 

--- a/examples/non-pypi-sources-project/README-JP.md
+++ b/examples/non-pypi-sources-project/README-JP.md
@@ -1,0 +1,98 @@
+# non-pypi-sources-project
+
+Git・プライベートレジストリ・直接URLソースと標準PyPIパッケージを含む実際の`uv.lock`を使用して、
+`uv-sbom` の `--check-non-pypi` 機能を実演するサンプルプロジェクトです。
+
+## 目的
+
+`--check-non-pypi` は各パッケージのソースを `uv.lock` から直接分類します。これまで、
+非PyPIソースを含むサンプルプロジェクトが1つも存在しなかったため、`sample-project` に対して
+このフラグを実行しても、常に空の「PyPI以外のパッケージソース」セクションしか得られませんでした。
+
+このプロジェクトの `uv.lock` は、様々なソース種別を組み合わせて手作業で作成されており、
+このフラグを実行すると常に実際の非空の出力が得られます。
+
+## このサンプルに含まれる非PyPIソース
+
+| パッケージ | バージョン | ソース種別 | 直接/間接 | レポートに表示？ |
+|-----------|-----------|-----------|----------|----------------|
+| acme-analytics-sdk | 1.4.0 | Private Registry | 直接 | ✅ 表示される |
+| telemetry-agent | 0.9.2 | Git | 間接 | ✅ 表示される |
+| edge-config | 2.1.0 | Direct URL | 間接 | ✅ 表示される |
+| vendored-parser | 0.5.0 | Local Path | 直接 | ❌ 表示されない（仕様により除外） |
+| requests | 2.32.3 | PyPI | 直接 | ❌ 表示されない（対照用の標準レジストリ） |
+
+## 前提条件
+
+- `uv-sbom` をソースからビルド済み（`cargo build --release`）またはインストール済み
+- `--check-non-pypi` 自体はネットワークアクセス不要です — `uv.lock` から直接ソース分類を
+  読み取ります。（このサンプルの架空パッケージについてはライセンス情報の取得で404警告が
+  表示されますが、これは想定内であり非PyPIレポートには影響しません）
+
+## 使用方法
+
+### Step 1: 非PyPIソース検出
+
+```bash
+# リポジトリルートから実行
+uv-sbom -p examples/non-pypi-sources-project --check-non-pypi --no-check-cve -f markdown --lang ja
+```
+
+**実際にレンダリングされる出力:**
+
+```markdown
+## ⚠️ PyPI以外のパッケージソース
+
+3個のパッケージが公式PyPIレジストリ以外から取得されています（直接依存 1件、間接依存 2件）。
+
+| パッケージ | バージョン | ソース種別 | 取得元 |
+|-------|-------|-------|-----|
+| acme-analytics-sdk | 1.4.0 | Private Registry | https://pypi.acme-corp.example/simple |
+| edge-config | 2.1.0 | Direct URL | https://downloads.acme-corp.example/edge-config-2.1.0-py3-none-any.whl |
+| telemetry-agent | 0.9.2 | Git | https://github.com/acme-corp/telemetry-agent?rev=9f2c1ab |
+
+> PyPI以外のソースから取得されたパッケージは、PyPIのセキュリティポリシーの対象外である可能性があります。本番環境へのデプロイ前に、各パッケージの取得元を確認してください。
+```
+
+`vendored-parser`（Local Path）と `requests`（標準PyPI）は正しく表示**されません**。
+
+### Step 2: 他のチェックと組み合わせ
+
+```bash
+uv-sbom -p examples/non-pypi-sources-project --check-non-pypi --check-cve -f markdown
+```
+
+`requests==2.32.3` は実在の、現在インストール可能なPyPIリリースであり、実際に現時点で
+既知の脆弱性を含む場合があります — 新しいアドバイザリが公開されるたびに出力が変化するため、
+Step 1では非PyPIソース検出のみに焦点を当てるために `--no-check-cve` を使用しています。
+
+## なぜpathソースと標準PyPIパッケージはフラグされないのか
+
+`--check-non-pypi` は **Private Registry**、**Git**、**Direct URL** のソースのみを検出対象と
+します。ローカルファイルシステムパス（`path = "..."`）とワークスペースメンバーは意図的に
+除外されます — これらは通常のuvワークスペース構成で想定される形態であり、サプライチェーン上の
+外部リスクとはみなされません。標準PyPIレジストリ（`https://pypi.org/simple`）は定義上
+「非PyPI」ではありません。
+
+`vendored-parser` の `path = "vendor/vendored-parser"` の参照先はディスク上に存在する必要は
+ありません — `--check-non-pypi` は `uv.lock` からテキストとしてソース分類を読み取るだけで、
+パスを解決することはありません。
+
+## なぜ `sample-project` を使わないのか？
+
+`examples/sample-project/uv.lock` には標準PyPIレジストリのソース（とワークスペースルートの
+エントリ1件）しか含まれていません。これに対して `--check-non-pypi` を実行しても常に0件と
+なるため、この機能を実演できません。
+
+このプロジェクトの `uv.lock` は、フラグされる全ソース種別（`Private Registry`、`Git`、
+`Direct URL`）と、除外される2種類（`Local Path`、標準`PyPI`）を対照として示すために、
+特別に構築されています。
+
+## 他のサンプルとの比較
+
+| | `examples/non-pypi-sources-project` | `examples/sample-project` | `examples/abandoned-packages-project` | `examples/suggest-fix-project` |
+|---|---|---|---|---|
+| 主な機能 | `--check-non-pypi`（特化） | CVE＋ライセンス＋放棄チェック | `--check-abandoned`（特化） | `--suggest-fix` アップグレードアドバイザー |
+| 非PyPIデモ | ✅ あり（3件フラグ、対照用に2件除外） | ❌ なし（全パッケージがPyPI） | ❌ 対象外 | ❌ 対象外 |
+| 脆弱なパッケージ | `requests`（実在の現行CVE） | 直接依存関係 | なし | 間接依存関係 |
+| 設定ファイル | ❌ なし | ✅ あり（`config/`） | ❌ なし | ❌ なし |

--- a/examples/non-pypi-sources-project/README.md
+++ b/examples/non-pypi-sources-project/README.md
@@ -1,0 +1,99 @@
+# non-pypi-sources-project
+
+An example project demonstrating the `--check-non-pypi` feature of `uv-sbom` using a
+`uv.lock` that contains real git, private-registry, and direct-URL sources alongside a
+standard PyPI package.
+
+## Purpose
+
+`--check-non-pypi` classifies each package's source directly from `uv.lock`. No shipped
+example project used to contain a non-PyPI source, so running the flag against
+`sample-project` always produced an empty "Non-PyPI Package Sources" section.
+
+This project's `uv.lock` was hand-crafted with a mix of source types so the flag always
+produces real, non-empty output.
+
+## Non-PyPI Sources in This Example
+
+| Package | Version | Source Type | Direct/Transitive | In report? |
+|---------|---------|--------------|--------------------|------------|
+| acme-analytics-sdk | 1.4.0 | Private Registry | Direct | ✅ Yes |
+| telemetry-agent | 0.9.2 | Git | Transitive | ✅ Yes |
+| edge-config | 2.1.0 | Direct URL | Transitive | ✅ Yes |
+| vendored-parser | 0.5.0 | Local Path | Direct | ❌ No (excluded by design) |
+| requests | 2.32.3 | PyPI | Direct | ❌ No (canonical registry, for contrast) |
+
+## Prerequisites
+
+- `uv-sbom` built from source (`cargo build --release`) or installed
+- No network access required for `--check-non-pypi` itself — it reads classification
+  directly from `uv.lock`. (License lookups will show 404 warnings for the fictional
+  packages in this example; this is expected and does not affect the non-PyPI report.)
+
+## Usage
+
+### Step 1: Non-PyPI source detection
+
+```bash
+# From the repository root
+uv-sbom -p examples/non-pypi-sources-project --check-non-pypi --no-check-cve -f markdown
+```
+
+**Actual rendered output:**
+
+```markdown
+## ⚠️ Non-PyPI Package Sources
+
+3 packages are sourced from outside the official PyPI registry (1 direct, 2 transitive).
+
+| Package | Version | Source Type | Source |
+|---------|---------|-------------|--------|
+| acme-analytics-sdk | 1.4.0 | Private Registry | https://pypi.acme-corp.example/simple |
+| edge-config | 2.1.0 | Direct URL | https://downloads.acme-corp.example/edge-config-2.1.0-py3-none-any.whl |
+| telemetry-agent | 0.9.2 | Git | https://github.com/acme-corp/telemetry-agent?rev=9f2c1ab |
+
+> Packages from non-PyPI sources may not be subject to PyPI's security policies. Review each package's origin before production deployment.
+```
+
+`vendored-parser` (Local Path) and `requests` (standard PyPI) are correctly **not** listed.
+
+### Step 2: Combined with other checks
+
+```bash
+uv-sbom -p examples/non-pypi-sources-project --check-non-pypi --check-cve -f markdown
+```
+
+`requests==2.32.3` is a real, currently-installable PyPI release and may carry real,
+currently-known vulnerabilities — that output will vary over time as new advisories are
+published, which is why Step 1 uses `--no-check-cve` to keep this demo focused solely on
+non-PyPI source detection.
+
+## Why the Path Source and Standard PyPI Package Are Not Flagged
+
+`--check-non-pypi` only flags **Private Registry**, **Git**, and **Direct URL** sources.
+Local filesystem paths (`path = "..."`) and workspace members are intentionally excluded
+— these are expected in normal uv workspace layouts, not external supply-chain risk. The
+standard PyPI registry (`https://pypi.org/simple`) is, by definition, not "non-PyPI."
+
+`vendored-parser`'s `path = "vendor/vendored-parser"` target does not need to exist on
+disk — `--check-non-pypi` reads source classification as text from `uv.lock` and never
+resolves the path.
+
+## Why Not Just Use `sample-project`?
+
+`examples/sample-project/uv.lock` contains only standard PyPI registry sources (and one
+workspace-root entry). Running `--check-non-pypi` against it always produces zero
+matches, so it cannot demonstrate the feature.
+
+This project's `uv.lock` was built specifically to exercise every flagged source type
+(`Private Registry`, `Git`, `Direct URL`) plus the two excluded types (`Local Path`,
+standard `PyPI`) for contrast.
+
+## Contrast with Other Examples
+
+| | `examples/non-pypi-sources-project` | `examples/sample-project` | `examples/abandoned-packages-project` | `examples/suggest-fix-project` |
+|---|---|---|---|---|
+| Primary feature | `--check-non-pypi` (focused) | CVE + license + abandoned | `--check-abandoned` (focused) | `--suggest-fix` Upgrade Advisor |
+| Non-PyPI demo | ✅ Yes (3 flagged, 2 excluded for contrast) | ❌ No (all packages are PyPI) | ❌ Not focused | ❌ Not focused |
+| Vulnerable packages | `requests` (real, current CVEs) | Direct dependencies | None | Transitive dependencies |
+| Config file | ❌ No | ✅ Yes (`config/`) | ❌ No | ❌ No |

--- a/examples/non-pypi-sources-project/pyproject.toml
+++ b/examples/non-pypi-sources-project/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "non-pypi-sources-project"
+version = "0.1.0"
+description = "Example project demonstrating --check-non-pypi with git, private-registry, and direct-URL sources alongside a standard PyPI package"
+requires-python = ">=3.11"
+dependencies = [
+    # Package sources are recorded in uv.lock; --check-non-pypi reads them from there.
+    "acme-analytics-sdk==1.4.0",  # Private registry (non-PyPI) - flagged; pulls in git + direct-URL transitives
+    "requests==2.32.3",           # Standard PyPI - not flagged (contrast)
+    "vendored-parser==0.5.0",     # Local path source - intentionally NOT flagged (excluded by design)
+]

--- a/examples/non-pypi-sources-project/uv.lock
+++ b/examples/non-pypi-sources-project/uv.lock
@@ -1,0 +1,49 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "non-pypi-sources-project"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "acme-analytics-sdk" },
+    { name = "requests" },
+    { name = "vendored-parser" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "acme-analytics-sdk", specifier = "==1.4.0" },
+    { name = "requests", specifier = "==2.32.3" },
+    { name = "vendored-parser", specifier = "==0.5.0" },
+]
+
+[[package]]
+name = "acme-analytics-sdk"
+version = "1.4.0"
+source = { registry = "https://pypi.acme-corp.example/simple" }
+dependencies = [
+    { name = "edge-config" },
+    { name = "telemetry-agent" },
+]
+
+[[package]]
+name = "edge-config"
+version = "2.1.0"
+source = { url = "https://downloads.acme-corp.example/edge-config-2.1.0-py3-none-any.whl" }
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "telemetry-agent"
+version = "0.9.2"
+source = { git = "https://github.com/acme-corp/telemetry-agent?rev=9f2c1ab" }
+
+[[package]]
+name = "vendored-parser"
+version = "0.5.0"
+source = { path = "vendor/vendored-parser" }


### PR DESCRIPTION
## Summary
- Add `examples/non-pypi-sources-project/`, a new example project whose `uv.lock` contains real git, private-registry, and direct-URL sources so `--check-non-pypi` produces genuine non-empty output (no shipped example project could demonstrate this flag before)
- Replace the previously fabricated "Example output" block in the root README's Non-PyPI Source Detection section with real, verified output from the new example, and add a cross-reference (mirroring the existing `--check-abandoned` / `abandoned-packages-project` pattern)

## Related Issue
Closes #668

## Changes Made
- `examples/non-pypi-sources-project/pyproject.toml` — minimal project definition
- `examples/non-pypi-sources-project/uv.lock` — hand-authored lockfile with `acme-analytics-sdk` (Private Registry, direct), `telemetry-agent` (Git, transitive), `edge-config` (Direct URL, transitive) — all flagged — plus `vendored-parser` (Local Path) and `requests` (standard PyPI), both correctly excluded from the report
- `examples/non-pypi-sources-project/README.md` / `README-JP.md` — usage guide with real, verified output from both English and `--lang ja` runs
- `README.md` / `README-JP.md` — replaced fabricated example output in "Non-PyPI Source Detection" with real output, added cross-reference to the new example project

## Test Plan
- [x] `cargo run -- -p examples/non-pypi-sources-project --check-non-pypi --no-check-cve -f markdown` produces the exact output pasted into the README (verified, not assumed)
- [x] `cargo run -- -p examples/non-pypi-sources-project --check-non-pypi --no-check-cve -f markdown --lang ja` produces the exact output pasted into README-JP.md (verified)
- [x] `cargo test --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] No `src/` changes (docs/example-only, confirmed via `git diff origin/develop...HEAD --name-only`)
- [x] Reviewed via `/code-review` — caught and fixed a `--lang ja` mismatch between the documented command and documented output in `README-JP.md`; re-review passed

---
Generated with [Claude Code](https://claude.com/claude-code)