### PR TITLE
feat(ports): add PEP 440 compatibility evaluation logic and PythonCompatibilityRepository port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pep440_rs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
+dependencies = [
+ "once_cell",
+ "serde",
+ "unicode-width",
+ "unscanny",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +1967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2033,7 @@ dependencies = [
  "futures",
  "indicatif",
  "owo-colors",
+ "pep440_rs",
  "predicates",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ indicatif = "0.18"
 dashmap = "6"
 owo-colors = "4.3"
 futures = "0.3"
+pep440_rs = "0.7"
 
 [dev-dependencies]
 assert_cmd = "2.2"

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -11,6 +11,7 @@ pub mod maintenance_repository;
 pub mod output_presenter;
 pub mod progress_reporter;
 pub mod project_config_reader;
+pub mod python_compatibility_repository;
 pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
@@ -28,6 +29,11 @@ pub use maintenance_repository::{MaintenanceInfo, MaintenanceRepository};
 pub use output_presenter::OutputPresenter;
 pub use progress_reporter::{ProgressCallback, ProgressReporter};
 pub use project_config_reader::ProjectConfigReader;
+// Note: Will be used in subsequent subtasks (target-python compatibility check)
+#[allow(unused_imports)]
+pub use python_compatibility_repository::{
+    is_incompatible, PythonCompatibilityInfo, PythonCompatibilityRepository,
+};
 // Note: This will be used in a subsequent subtask for uv lock simulation
 #[allow(unused_imports)]
 pub use uv_lock_simulator::{SimulationResult, UvLockSimulator};

--- a/src/ports/outbound/python_compatibility_repository.rs
+++ b/src/ports/outbound/python_compatibility_repository.rs
@@ -1,0 +1,201 @@
+use crate::shared::Result;
+use async_trait::async_trait;
+use pep440_rs::{Version, VersionSpecifiers};
+use std::str::FromStr;
+
+/// Python version compatibility metadata for a single package version
+///
+/// Captures the upstream `Requires-Python` constraint (PEP 440) used to
+/// determine whether a package is installable on a target Python interpreter.
+///
+/// # Notes
+/// - `requires_python` is `None` when the package publishes no
+///   `Requires-Python` constraint on the upstream registry. A `None` value
+///   MUST be treated as "compatible with every target" (see
+///   [`PythonCompatibilityInfo::is_incompatible_with`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // WIRE(#681): remove when wired into GenerateSbomUseCase and main.rs
+pub struct PythonCompatibilityInfo {
+    /// Raw PEP 440 `Requires-Python` specifier string (e.g. ">=3.8,<3.12").
+    /// `None` when the package declares no constraint.
+    pub requires_python: Option<String>,
+}
+
+impl PythonCompatibilityInfo {
+    /// Returns `true` iff this package is incompatible with `target`.
+    ///
+    /// A `None` `requires_python` is always treated as compatible.
+    #[allow(dead_code)] // WIRE(#681): remove when wired into GenerateSbomUseCase and main.rs
+    pub fn is_incompatible_with(&self, target: &str) -> bool {
+        self.requires_python
+            .as_deref()
+            .is_some_and(|requires_python| is_incompatible(requires_python, target))
+    }
+}
+
+/// Port for fetching Python version compatibility information from external sources
+///
+/// This trait defines the interface for querying upstream registries
+/// (e.g., PyPI JSON API) to determine the `Requires-Python` constraint of a
+/// specific package version, which is used to detect dependencies that would
+/// break under a target Python version upgrade.
+///
+/// # Security Considerations
+/// - Implementations must not send internal/private package names to public APIs
+/// - Implementations should implement rate limiting to prevent DoS
+/// - Implementations should have timeout mechanisms
+///
+/// # Implementation Notes
+/// - All methods are async to enable parallel fetching across packages
+/// - Implementations should treat "package/version not found" as an error, not
+///   as `PythonCompatibilityInfo { requires_python: None }`
+///
+/// # Example
+/// ```no_run
+/// # use uv_sbom::ports::outbound::PythonCompatibilityRepository;
+/// # use async_trait::async_trait;
+/// # struct MockRepo;
+/// # #[async_trait]
+/// # impl PythonCompatibilityRepository for MockRepo {
+/// #     async fn fetch_python_compatibility(
+/// #         &self,
+/// #         _package_name: &str,
+/// #         _package_version: &str,
+/// #     ) -> uv_sbom::shared::Result<uv_sbom::ports::outbound::PythonCompatibilityInfo> {
+/// #         Ok(uv_sbom::ports::outbound::PythonCompatibilityInfo { requires_python: None })
+/// #     }
+/// # }
+/// # async fn example() -> uv_sbom::shared::Result<()> {
+/// # let repo = MockRepo;
+/// let info = repo.fetch_python_compatibility("requests", "2.31.0").await?;
+/// if let Some(requires_python) = info.requires_python {
+///     println!("Requires Python {}", requires_python);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[async_trait]
+#[allow(dead_code)] // WIRE(#681): remove when wired into GenerateSbomUseCase and main.rs
+pub trait PythonCompatibilityRepository: Send + Sync {
+    /// Fetches the `Requires-Python` constraint for a specific package version
+    ///
+    /// # Arguments
+    /// * `package_name` - Canonical package name (case-insensitive on PyPI)
+    /// * `package_version` - Exact locked version (e.g. from uv.lock)
+    ///
+    /// # Returns
+    /// `PythonCompatibilityInfo` describing the package version's declared
+    /// `Requires-Python` constraint.
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Network request fails
+    /// - Package or version is not found on the upstream registry
+    /// - API response is invalid
+    /// - Timeout occurs
+    async fn fetch_python_compatibility(
+        &self,
+        package_name: &str,
+        package_version: &str,
+    ) -> Result<PythonCompatibilityInfo>;
+}
+
+/// Dummy implementation of PythonCompatibilityRepository for the unit type.
+/// Mirrors the `impl ... for ()` pattern in `MaintenanceRepository`,
+/// allowing `Option<()>` when no target-python checking is configured.
+#[async_trait]
+impl PythonCompatibilityRepository for () {
+    async fn fetch_python_compatibility(
+        &self,
+        _package_name: &str,
+        _package_version: &str,
+    ) -> Result<PythonCompatibilityInfo> {
+        unreachable!("PythonCompatibilityRepository not configured")
+    }
+}
+
+/// Returns `true` iff `target` is excluded by the `requires_python` PEP 440
+/// specifier — i.e. the package is incompatible with that Python version.
+///
+/// # Conservative fallbacks (both return `false`, meaning "assume compatible")
+/// - `requires_python` fails to parse as a PEP 440 `VersionSpecifiers` string.
+/// - `target` fails to parse as a PEP 440 `Version` string.
+///
+/// This never panics: parse failures degrade to "compatible" so a malformed
+/// upstream constraint can never produce a false-positive incompatibility.
+#[allow(dead_code)] // WIRE(#681): remove when wired into GenerateSbomUseCase and main.rs
+pub fn is_incompatible(requires_python: &str, target: &str) -> bool {
+    let (Ok(specifiers), Ok(version)) = (
+        VersionSpecifiers::from_str(requires_python),
+        Version::from_str(target),
+    ) else {
+        return false;
+    };
+    !specifiers.contains(&version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_incompatible_major_version_mismatch() {
+        assert!(is_incompatible(">=3", "2.7"));
+    }
+
+    #[test]
+    fn test_is_incompatible_minor_version_mismatch() {
+        assert!(is_incompatible(">=3.12", "3.11"));
+    }
+
+    #[test]
+    fn test_is_incompatible_range_specifier_outside_range() {
+        assert!(is_incompatible(">=3.8,<3.12", "3.13"));
+    }
+
+    #[test]
+    fn test_is_incompatible_range_specifier_within_range() {
+        assert!(!is_incompatible(">=3.8,<3.12", "3.10"));
+    }
+
+    #[test]
+    fn test_is_incompatible_open_ended_specifier() {
+        assert!(!is_incompatible(">=3.8", "3.13"));
+    }
+
+    #[test]
+    fn test_is_incompatible_unparseable_specifier_treated_as_compatible() {
+        assert!(!is_incompatible("not-a-specifier", "3.11"));
+    }
+
+    #[test]
+    fn test_is_incompatible_unparseable_target_treated_as_compatible() {
+        assert!(!is_incompatible(">=3.8", "not-a-version"));
+    }
+
+    #[test]
+    fn test_python_compatibility_info_none_requires_python_is_compatible() {
+        let info = PythonCompatibilityInfo {
+            requires_python: None,
+        };
+        assert!(!info.is_incompatible_with("3.13"));
+    }
+
+    #[test]
+    fn test_python_compatibility_info_some_requires_python_delegates_to_is_incompatible() {
+        let info = PythonCompatibilityInfo {
+            requires_python: Some(">=3.8,<3.12".to_string()),
+        };
+        assert!(info.is_incompatible_with("3.13"));
+        assert!(!info.is_incompatible_with("3.10"));
+    }
+
+    #[test]
+    fn test_python_compatibility_info_clone_and_eq() {
+        let a = PythonCompatibilityInfo {
+            requires_python: Some(">=3.9".to_string()),
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `pep440_rs` dependency and a new `PythonCompatibilityRepository` outbound port, mirroring the existing `MaintenanceRepository` pattern
- Implement `is_incompatible(requires_python, target)` for PEP 440 specifier evaluation, treating unparseable input conservatively as compatible
- Add `PythonCompatibilityInfo::is_incompatible_with()` convenience method so the "`None` requires_python is compatible" acceptance criterion is directly unit-tested

## Related Issue
Closes #676
Part of #628 (subtask 1 of 7)

## Changes Made
- `Cargo.toml` / `Cargo.lock`: add `pep440_rs = "0.7"`
- `src/ports/outbound/python_compatibility_repository.rs` (new): `PythonCompatibilityInfo`, `PythonCompatibilityRepository` trait, no-op `impl ... for ()`, `is_incompatible()` free function, 10 unit tests
- `src/ports/outbound/mod.rs`: wire the new module and re-export, following the established forward-declared-port convention (`#[allow(unused_imports)]` + note comment)

## Dead Code Notice
This subtask adds a foundational port with no caller yet — the adapter, use case, and wiring into `GenerateSbomUseCase`/`main.rs` are separate tracked subtasks (#677–#682). Per the project's Dead Code Policy, the new items are annotated `#[allow(dead_code)] // WIRE(#681): remove when wired into GenerateSbomUseCase and main.rs`. Issue #681 is open and will consume these items; its `/implement` Step 4.0 gate will auto-detect and enforce removal of these annotations.

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes (unit + integration + doctests)
- [x] `/code-review` skill PASS (no architecture, DDD, security, or i18n violations)

---
Generated with [Claude Code](https://claude.com/claude-code)