### PR TITLE
feat(adapters): add PyPiCompatibilityClient outbound adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +347,24 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "difflib"
@@ -615,6 +643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +707,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -945,6 +986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1072,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2045,6 +2102,7 @@ dependencies = [
  "toml",
  "urlencoding",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -2526,6 +2584,29 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ pep440_rs = "0.7"
 [dev-dependencies]
 assert_cmd = "2.2"
 predicates = "3"
+wiremock = "0.6"
 
 [[bin]]
 name = "uv-sbom"

--- a/src/adapters/outbound/network/mod.rs
+++ b/src/adapters/outbound/network/mod.rs
@@ -2,6 +2,8 @@
 mod caching_pypi_client;
 mod osv_client;
 mod pypi_client;
+// Note: Will be exported once wired into GenerateSbomUseCase and main.rs (#681)
+mod pypi_compatibility_client;
 mod pypi_maintenance_client;
 
 pub use caching_pypi_client::CachingPyPiLicenseRepository;

--- a/src/adapters/outbound/network/pypi_compatibility_client.rs
+++ b/src/adapters/outbound/network/pypi_compatibility_client.rs
@@ -1,0 +1,354 @@
+use crate::ports::outbound::{PythonCompatibilityInfo, PythonCompatibilityRepository};
+use crate::shared::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)] // WIRE(#681): remove when PyPiCompatibilityClient is wired into main.rs
+struct PyPiInfo {
+    #[serde(default)]
+    requires_python: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)] // WIRE(#681): remove when PyPiCompatibilityClient is wired into main.rs
+struct PyPiVersionResponse {
+    #[serde(default)]
+    info: PyPiInfo,
+}
+
+/// PyPiCompatibilityClient adapter for fetching `Requires-Python` metadata from PyPI
+///
+/// Queries the version-level endpoint (`/pypi/{name}/{version}/json`) to
+/// retrieve the `Requires-Python` constraint declared for a specific locked
+/// package version, used for target-Python compatibility checking.
+#[derive(Clone)]
+#[allow(dead_code)] // WIRE(#681): remove when PyPiCompatibilityClient is wired into main.rs
+pub struct PyPiCompatibilityClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+#[allow(dead_code)] // WIRE(#681): remove when PyPiCompatibilityClient is wired into main.rs
+impl PyPiCompatibilityClient {
+    const MAX_RETRIES: u32 = 3;
+    // 10 MB — well above any realistic PyPI package metadata response
+    const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
+
+    /// Creates a new PyPI compatibility client with default configuration
+    ///
+    /// # Errors
+    /// Returns an error if the underlying HTTP client fails to build.
+    pub fn new() -> Result<Self> {
+        let version = env!("CARGO_PKG_VERSION");
+        let user_agent = format!("uv-sbom/{}", version);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent(user_agent)
+            .build()?;
+
+        Ok(Self {
+            client,
+            base_url: "https://pypi.org".to_string(),
+        })
+    }
+
+    #[cfg(test)]
+    fn new_with_base_url_and_timeout(
+        base_url: impl Into<String>,
+        timeout: Duration,
+    ) -> Result<Self> {
+        let user_agent = format!("uv-sbom/{}", env!("CARGO_PKG_VERSION"));
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .user_agent(user_agent)
+            .build()?;
+
+        Ok(Self {
+            client,
+            base_url: base_url.into(),
+        })
+    }
+
+    /// Validates a URL component to prevent injection attacks
+    fn validate_url_component(component: &str, component_type: &str) -> Result<()> {
+        if component.contains('/') || component.contains('\\') {
+            anyhow::bail!(
+                "Security: {} contains path separators which are not allowed",
+                component_type
+            );
+        }
+        if component.contains("..") {
+            anyhow::bail!(
+                "Security: {} contains '..' which is not allowed",
+                component_type
+            );
+        }
+        if component.contains('#') || component.contains('?') || component.contains('@') {
+            anyhow::bail!(
+                "Security: {} contains URL-unsafe characters",
+                component_type
+            );
+        }
+        Ok(())
+    }
+
+    async fn fetch_from_pypi(
+        &self,
+        package_name: &str,
+        package_version: &str,
+    ) -> Result<PyPiVersionResponse> {
+        Self::validate_url_component(package_name, "Package name")?;
+        Self::validate_url_component(package_version, "Package version")?;
+        let encoded_name = urlencoding::encode(package_name);
+        let encoded_version = urlencoding::encode(package_version);
+        let url = format!(
+            "{}/pypi/{}/{}/json",
+            self.base_url, encoded_name, encoded_version
+        );
+
+        let response = self.client.get(&url).send().await?;
+        if !response.status().is_success() {
+            anyhow::bail!("PyPI API returned status code {}", response.status());
+        }
+        // Reject oversized responses before allocating memory
+        if let Some(len) = response.content_length() {
+            if len as usize > Self::MAX_RESPONSE_BYTES {
+                anyhow::bail!("PyPI API response too large: {} bytes", len);
+            }
+        }
+        let bytes = response.bytes().await?;
+        if bytes.len() > Self::MAX_RESPONSE_BYTES {
+            anyhow::bail!(
+                "PyPI API response exceeded {} byte limit",
+                Self::MAX_RESPONSE_BYTES
+            );
+        }
+        Ok(serde_json::from_slice::<PyPiVersionResponse>(&bytes)?)
+    }
+
+    async fn fetch_with_retry(
+        &self,
+        package_name: &str,
+        package_version: &str,
+    ) -> Result<PyPiVersionResponse> {
+        let mut last_error = None;
+        for attempt in 1..=Self::MAX_RETRIES {
+            match self.fetch_from_pypi(package_name, package_version).await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    last_error = Some(e);
+                    if attempt < Self::MAX_RETRIES {
+                        // Linear back-off: 100 ms, 200 ms — matches PyPiMaintenanceRepository
+                        tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
+                    }
+                }
+            }
+        }
+        Err(last_error.unwrap())
+    }
+}
+
+#[async_trait]
+impl PythonCompatibilityRepository for PyPiCompatibilityClient {
+    async fn fetch_python_compatibility(
+        &self,
+        package_name: &str,
+        package_version: &str,
+    ) -> Result<PythonCompatibilityInfo> {
+        let resp = self.fetch_with_retry(package_name, package_version).await?;
+        Ok(PythonCompatibilityInfo {
+            requires_python: resp.info.requires_python,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn test_pypi_compatibility_client_creation() {
+        assert!(PyPiCompatibilityClient::new().is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_component_accepts_normal_name() {
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("requests", "Package name").is_ok()
+        );
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("2.31.0", "Package version").is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_url_component_rejects_path_separators() {
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("pkg/evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("pkg\\evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("pkg..evil", "Package name").is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_url_component_rejects_unsafe_chars() {
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("pkg#evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("pkg?evil", "Package name").is_err()
+        );
+        assert!(
+            PyPiCompatibilityClient::validate_url_component("pkg@evil", "Package name").is_err()
+        );
+    }
+
+    #[test]
+    fn test_deserialize_requires_python_present() {
+        let json = r#"{"info": {"requires_python": ">=3.8,<3.12"}}"#;
+        let response: PyPiVersionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            response.info.requires_python,
+            Some(">=3.8,<3.12".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deserialize_requires_python_absent() {
+        let json = r#"{"info": {}}"#;
+        let response: PyPiVersionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.info.requires_python, None);
+    }
+
+    #[test]
+    fn test_deserialize_requires_python_null() {
+        let json = r#"{"info": {"requires_python": null}}"#;
+        let response: PyPiVersionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.info.requires_python, None);
+    }
+
+    #[test]
+    fn test_deserialize_minimal_response() {
+        let json = r#"{}"#;
+        let response: PyPiVersionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.info.requires_python, None);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_python_compatibility_present() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pypi/requests/2.31.0/json"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"info": {"requires_python": ">=3.7"}})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = PyPiCompatibilityClient::new_with_base_url_and_timeout(
+            mock_server.uri(),
+            Duration::from_secs(5),
+        )
+        .unwrap();
+
+        let info = client
+            .fetch_python_compatibility("requests", "2.31.0")
+            .await
+            .unwrap();
+        assert_eq!(info.requires_python, Some(">=3.7".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_python_compatibility_absent_field() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pypi/somepkg/1.0.0/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"info": {}})))
+            .mount(&mock_server)
+            .await;
+
+        let client = PyPiCompatibilityClient::new_with_base_url_and_timeout(
+            mock_server.uri(),
+            Duration::from_secs(5),
+        )
+        .unwrap();
+
+        let info = client
+            .fetch_python_compatibility("somepkg", "1.0.0")
+            .await
+            .unwrap();
+        assert_eq!(info.requires_python, None);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_python_compatibility_not_found() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pypi/nonexistent/9.9.9/json"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+
+        let client = PyPiCompatibilityClient::new_with_base_url_and_timeout(
+            mock_server.uri(),
+            Duration::from_secs(5),
+        )
+        .unwrap();
+
+        let result = client
+            .fetch_python_compatibility("nonexistent", "9.9.9")
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_python_compatibility_malformed_json() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pypi/badjson/1.0.0/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not-json"))
+            .mount(&mock_server)
+            .await;
+
+        let client = PyPiCompatibilityClient::new_with_base_url_and_timeout(
+            mock_server.uri(),
+            Duration::from_secs(5),
+        )
+        .unwrap();
+
+        let result = client.fetch_python_compatibility("badjson", "1.0.0").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_python_compatibility_timeout() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pypi/slowpkg/1.0.0/json"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"info": {"requires_python": ">=3.8"}}))
+                    .set_delay(Duration::from_millis(500)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = PyPiCompatibilityClient::new_with_base_url_and_timeout(
+            mock_server.uri(),
+            Duration::from_millis(150),
+        )
+        .unwrap();
+
+        let result = client.fetch_python_compatibility("slowpkg", "1.0.0").await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `PyPiCompatibilityClient`, a new outbound adapter that queries PyPI's versioned JSON endpoint (`/pypi/{name}/{version}/json`) to fetch `requires_python` metadata for a specific locked package version
- Implements the `PythonCompatibilityRepository` port introduced in #676
- Mirrors `PyPiMaintenanceRepository`'s security/reliability practices: URL-component validation, 10s timeout, 10 MB response size bound, and linear-backoff retry (100ms * attempt, max 3 attempts)

## Related Issue
Closes #677
Part of #628

## Changes Made
- Added `src/adapters/outbound/network/pypi_compatibility_client.rs`: `PyPiCompatibilityClient` struct implementing `PythonCompatibilityRepository`
- Registered the new module (not yet `pub use`-exported) in `src/adapters/outbound/network/mod.rs`, matching the precedent set by `PyPiMaintenanceRepository` in #553 — the adapter is not wired into `main.rs` until #681, so it carries `#[allow(dead_code)] // WIRE(#681)` per the project's Dead Code Policy
- Added `wiremock = "0.6"` as a dev-dependency to mock HTTP responses in tests (present/absent/null `requires_python`, 404, malformed JSON, timeout) without hitting the real PyPI API

## Test Plan
- [x] `cargo test --all` passes (all unit, integration, and doc tests green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Unit tests cover: present `requires_python`, absent field, null field, 404, malformed JSON, timeout, URL-component validation (path separators, `..`, unsafe chars)

## Notes
- ⚠️ This PR introduces `WIRE(#681)` annotations. Issue #681 is open and tracked as the consumer that will construct `PyPiCompatibilityClient` in `main.rs` and remove these annotations.
- No CHANGELOG entry: this adapter has no user-facing surface yet (not wired into any use case or CLI flag).

---
Generated with [Claude Code](https://claude.com/claude-code)