### PR TITLE
feat(application): add PythonCompatibilityReport read model

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -225,6 +225,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `GroupReachabilityAnalyzer` | `src/sbom_generation/domain/services/group_reachability_analyzer.rs` | Pure domain service for BFS-based group reachability traversal; wired into `GenerateSbomUseCase` via `apply_group_filter` in #623 |
 | `GroupRoots` | `src/ports/outbound/lockfile_reader.rs` | Type alias `HashMap<String, Vec<String>>` mapping dependency group name → root package names; extracted from `[manifest.dependency-groups]` in `uv.lock`; consumed by group reachability traversal in #622; wired into use case in #623 |
 | `NonPyPiPackageView` / `NonPyPiPackagesReport` | `src/application/read_models/non_pypi_package.rs` | Read model for packages sourced from non-PyPI origins (git, url, private registry); populated by `GenerateSbomUseCase` when `check_non_pypi` is true; rendered by the Markdown formatter's `non_pypi_packages` section (#656, #660) |
+| `PythonIncompatibilityView` / `PythonCompatibilityReport` | `src/application/read_models/python_compatibility.rs` | Read model for packages incompatible with a target Python version, independent of how `requires_python` data is fetched; added in #679, not yet wired into a use case (see #680 for `CheckPythonCompatibilityUseCase`) |
 
 ### Important Invariants
 

--- a/src/application/read_models/mod.rs
+++ b/src/application/read_models/mod.rs
@@ -9,6 +9,7 @@ pub mod cve_delta_view;
 pub mod dependency_view;
 pub mod license_compliance_view;
 pub mod non_pypi_package;
+pub mod python_compatibility;
 pub mod resolution_guide_view;
 pub mod sbom_read_model;
 pub mod sbom_read_model_builder;
@@ -29,6 +30,8 @@ pub use license_compliance_view::{
 };
 #[allow(unused_imports)]
 pub use non_pypi_package::{NonPyPiPackageView, NonPyPiPackagesReport};
+#[allow(unused_imports)]
+pub use python_compatibility::{PythonCompatibilityReport, PythonIncompatibilityView};
 #[allow(unused_imports)]
 pub use resolution_guide_view::{IntroducedByView, ResolutionEntryView, ResolutionGuideView};
 #[allow(unused_imports)]

--- a/src/application/read_models/python_compatibility.rs
+++ b/src/application/read_models/python_compatibility.rs
@@ -1,0 +1,127 @@
+//! Python compatibility view structs for read model
+//!
+//! These structs provide a query-optimized view of the result of a Python
+//! compatibility check against a target Python version, independent of how
+//! the underlying `requires_python` data is fetched.
+
+/// View representation of a single package incompatible with the target Python version
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PythonIncompatibilityView {
+    /// Package name as listed in the lockfile
+    pub name: String,
+    /// Package version as listed in the lockfile
+    pub version: String,
+    /// PEP 440 `requires_python` specifier reported by PyPI for this package version.
+    ///
+    /// `None` when PyPI declares no constraint (a package with no constraint is never
+    /// classified as incompatible, so in practice this is always `Some` for entries
+    /// that appear in a report, but the type mirrors the upstream
+    /// `PythonCompatibilityInfo.requires_python` field for consistency).
+    pub requires_python: Option<String>,
+    /// Whether the package is a direct dependency of the current project
+    pub is_direct: bool,
+}
+
+/// View representation of a Python compatibility report
+///
+/// Holds the list of packages incompatible with the target Python version
+/// along with the target version string used to classify them.
+#[derive(Debug, Clone)]
+pub struct PythonCompatibilityReport {
+    /// Target Python version the report was checked against (e.g. "3.13")
+    pub target_python: String,
+    /// Packages incompatible with `target_python`
+    pub incompatible: Vec<PythonIncompatibilityView>,
+}
+
+impl PythonCompatibilityReport {
+    /// Returns `true` when no packages were classified as incompatible.
+    pub fn is_empty(&self) -> bool {
+        self.incompatible.is_empty()
+    }
+
+    /// Returns the total number of incompatible packages.
+    pub fn total_count(&self) -> usize {
+        self.incompatible.len()
+    }
+
+    /// Returns the number of incompatible packages that are direct dependencies.
+    pub fn direct_count(&self) -> usize {
+        self.incompatible.iter().filter(|p| p.is_direct).count()
+    }
+
+    /// Returns the number of incompatible packages that are transitive dependencies.
+    pub fn transitive_count(&self) -> usize {
+        self.incompatible.iter().filter(|p| !p.is_direct).count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_view(name: &str, is_direct: bool) -> PythonIncompatibilityView {
+        PythonIncompatibilityView {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            requires_python: Some(">=3.9".to_string()),
+            is_direct,
+        }
+    }
+
+    #[test]
+    fn test_empty_report() {
+        let report = PythonCompatibilityReport {
+            target_python: "3.13".to_string(),
+            incompatible: vec![],
+        };
+        assert!(report.is_empty());
+        assert_eq!(report.total_count(), 0);
+        assert_eq!(report.direct_count(), 0);
+        assert_eq!(report.transitive_count(), 0);
+    }
+
+    #[test]
+    fn test_total_count() {
+        let report = PythonCompatibilityReport {
+            target_python: "3.13".to_string(),
+            incompatible: vec![
+                make_view("a", true),
+                make_view("b", false),
+                make_view("c", false),
+            ],
+        };
+        assert_eq!(report.total_count(), 3);
+        assert!(!report.is_empty());
+    }
+
+    #[test]
+    fn test_direct_and_transitive_counts() {
+        let report = PythonCompatibilityReport {
+            target_python: "3.13".to_string(),
+            incompatible: vec![
+                make_view("a", true),
+                make_view("b", true),
+                make_view("c", false),
+            ],
+        };
+        assert_eq!(report.direct_count(), 2);
+        assert_eq!(report.transitive_count(), 1);
+    }
+
+    #[test]
+    fn test_view_clone_and_eq() {
+        let a = make_view("requests", true);
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_target_python_preserved() {
+        let report = PythonCompatibilityReport {
+            target_python: "3.12".to_string(),
+            incompatible: vec![],
+        };
+        assert_eq!(report.target_python, "3.12");
+    }
+}

--- a/src/application/read_models/python_compatibility.rs
+++ b/src/application/read_models/python_compatibility.rs
@@ -5,6 +5,7 @@
 //! the underlying `requires_python` data is fetched.
 
 /// View representation of a single package incompatible with the target Python version
+#[allow(dead_code)] // WIRE(#680): remove when CheckPythonCompatibilityUseCase constructs this view
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PythonIncompatibilityView {
     /// Package name as listed in the lockfile
@@ -26,6 +27,7 @@ pub struct PythonIncompatibilityView {
 ///
 /// Holds the list of packages incompatible with the target Python version
 /// along with the target version string used to classify them.
+#[allow(dead_code)] // WIRE(#680): remove when CheckPythonCompatibilityUseCase constructs this report
 #[derive(Debug, Clone)]
 pub struct PythonCompatibilityReport {
     /// Target Python version the report was checked against (e.g. "3.13")
@@ -34,6 +36,7 @@ pub struct PythonCompatibilityReport {
     pub incompatible: Vec<PythonIncompatibilityView>,
 }
 
+#[allow(dead_code)] // WIRE(#680): remove when CheckPythonCompatibilityUseCase calls these methods
 impl PythonCompatibilityReport {
     /// Returns `true` when no packages were classified as incompatible.
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Summary
- Add `PythonIncompatibilityView` and `PythonCompatibilityReport` read model types representing the result of a Python version compatibility check, independent of how the data is fetched
- Follows the existing `abandoned_package.rs` pattern with `total_count`/`direct_count`/`transitive_count`/`is_empty` helper methods
- Re-export new types from `src/application/read_models/mod.rs`

## Related Issue
Closes #679

Part of #628 (this subtask covers only the read-model data structures; the use case, wiring, and Markdown formatter are separate subtask issues #680, #681, #682)

## Changes Made
- Added `src/application/read_models/python_compatibility.rs` with `PythonIncompatibilityView` (`name`, `version`, `requires_python`, `is_direct`) and `PythonCompatibilityReport` (`target_python`, `incompatible`)
- Registered the new module and re-exports in `src/application/read_models/mod.rs`
- Added unit tests covering empty report, mixed direct/transitive counts, and view clone/eq

## Test Plan
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `/code-review` skill: PASS (no 🔴 findings)

Note: this read model has no consumer yet (issue #680 will wire it into a use case), so no CHANGELOG entry was added — no user-facing behavior changes in this PR.

---
Generated with [Claude Code](https://claude.com/claude-code)