### PR TITLE
docs(changelog): add Security entry for v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.8.0] - 2026-07-26
 
+### Security
+- Updated `quinn-proto` to 0.11.16 to fix GHSA-4w2j-m93h-cj5j (remote memory exhaustion via unbounded out-of-order stream reassembly) (#698)
+
 ### Added
 - `--target-python` CLI flag and `target_python` config key for specifying a target Python version, resolved as CLI > config > None and validated as a PEP 440 version before any network calls (#678)
 - **Python version compatibility checking**: When `--target-python` is set, uv-sbom now queries PyPI for each locked package's `Requires-Python` constraint and reports packages incompatible with the target version via a stderr progress summary (e.g. `N package(s) incompatible with Python 3.8 (D direct, T transitive)`) and a Markdown section (#628, #679, #680, #681)


### PR DESCRIPTION
## Summary
- The quinn-proto security fix (GHSA-4w2j-m93h-cj5j) was merged directly to `develop` via #698 (GitHub's automated Dependabot security PR), after the v2.8.0 release PR (#697) had already merged.
- This PR backfills the `[2.8.0]` CHANGELOG entry with a `### Security` section documenting the fix, so the release notes accurately reflect what shipped in v2.8.0.

## Change
- `CHANGELOG.md`: Added `### Security` section under `[2.8.0] - 2026-07-26`:
  > Updated `quinn-proto` to 0.11.16 to fix GHSA-4w2j-m93h-cj5j (remote memory exhaustion via unbounded out-of-order stream reassembly) (#698)

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes

---
Generated with [Claude Code](https://claude.com/claude-code)