### PR TITLE
ci: add restore-keys fallback to cargo caches to avoid full rebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,23 +54,31 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      # restore-keys below allow a partial cache hit (prefix match) when Cargo.lock
+      # changes, instead of a fully cold cache. See #701.
       - name: Cache cargo registry
         uses: actions/cache@v6.1.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
         uses: actions/cache@v6.1.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
 
       - name: Cache cargo build
         uses: actions/cache@v6.1.0
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
 
       - name: Run tests
         run: cargo test --all


### PR DESCRIPTION
## Summary
- Adds `restore-keys` fallback to the three `actions/cache@v6.1.0` steps in the `test` job of `.github/workflows/ci.yml` (cargo registry, cargo git index, `target` build cache)
- Fixes the actual root cause behind CI slowness on dependency-bump PRs: without `restore-keys`, any `Cargo.lock` change caused a full cache miss with no partial reuse, forcing a fully cold `target/` rebuild on all 3 OS matrix runners, twice per push (debug + release `test` runs)
- No `src/` changes — this PR is CI-configuration only

## Related Issue
Closes #701

## Changes Made
- `.github/workflows/ci.yml`: added `restore-keys: | ${{ runner.os }}-cargo-registry-` (and the equivalent for `-cargo-index-` and `-cargo-build-target-`) to each of the three cache steps, plus a one-line comment explaining the rationale
- No changes to the `clippy`, `fmt`, or `build` jobs — they don't use these cache steps and are out of scope for this issue

## Design decisions and known limitations (documented per Issue #701 acceptance criteria)

- **This does NOT resolve stale/orphaned cache entries.** `actions/cache` never updates an existing key's contents, and a partial `restore-keys` hit's `target/` carries forward build artifacts for dependencies no longer present in the current `Cargo.lock`. This means saved cache entries can grow monotonically larger over time rather than staying tidy. The fix here trades "full rebuild every Cargo.lock change" (guaranteed slow) for "warm-but-imperfect rebuild" (fast, but caches grow). Cache size control (e.g. a cache-cleaning step, or switching to `Swatinem/rust-cache`) is left for a follow-up issue.
- **Verification limitation**: this PR does not itself change `Cargo.lock`, so its own CI run will hit the exact-match key (as it always did) rather than exercising the new `restore-keys` fallback path. The fallback path will first be exercised on the next PR/push that changes `Cargo.lock` (e.g. the next Dependabot PR) — that run's `actions/cache` step logs should show a `restore-keys`-based partial restore (log line like `Cache restored from key: ...-cargo-build-target-<prefix>...`) instead of `Cache not found`.
- **Not in scope**: the `build`, `clippy`, and `fmt` jobs have no cache steps at all and rebuild from scratch on every run — likely a larger aggregate cost than the `test` job's cache-miss case fixed here. Left for a separate follow-up issue.
- **Not in scope**: the `test`/`build` job's `target` cache key doesn't include the (floating) `stable` Rust toolchain version, so a toolchain bump between runs could restore a `target/` built with an older `rustc`; cargo's fingerprinting still guarantees correctness (full recompile), just with a wasted cache download. Left for a separate follow-up issue.
- This PR originated from an investigation into #693 ("doctest phase adds ~40s overhead"), which was closed as a documented non-issue after measurement showed the actual doctest cost was ~2-5s, not ~40s. This cache-restore-keys gap was identified during that investigation as the real, much larger CI cost lever.

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no warnings)
- [x] `cargo test --all` passes (858 unit tests, all integration test binaries, 8 doctests — all green)
- [x] YAML validity of `.github/workflows/ci.yml` confirmed via `ruby -ryaml`
- [ ] CI green on all 3 matrix OSes for this PR (exact-key cache hit expected, not restore-keys fallback — see limitation above)
- [ ] Follow-up: confirm `restore-keys` fallback path fires correctly on the next Cargo.lock-changing PR

---
Generated with [Claude Code](https://claude.com/claude-code)