### PR TITLE
refactor(domain): move EnrichedPackage/SimulationResult/UvLockSimulator into domain

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -222,6 +222,8 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `GenerateDiffUseCase<LR,DLR,VR>` | `src/application/use_cases/generate_diff.rs` | Orchestrates dependency diff: reads current via LockfileReader, base via DiffLockfileReader, runs DependencyDiffAnalyzer, optionally fetches CVE delta via VulnerabilityRepository; 3rd param `VR` (default `()`) added in #599 |
 | `CveDeltaView` / `CveDeltaEntry` | `src/application/read_models/cve_delta_view.rs` | Read model for CVE exposure diff between two lock file snapshots; wired into `GenerateDiffUseCase` in #599; consumed by diff formatters (Markdown/JSON) in #600 |
 | `Package` | `src/sbom_generation/domain/` | Core domain model for a dependency |
+| `EnrichedPackage` | `src/sbom_generation/domain/enriched_package.rs` | Value object pairing a `Package` with license/description/sha256 metadata; moved out of `ports/outbound/` in #703 (it has no I/O, so it never belonged there) |
+| `UvLockSimulator` / `SimulationResult` | `src/sbom_generation/domain/uv_lock_simulator.rs` | Domain-owned port (async trait) for simulating `uv lock --upgrade-package`; implemented by `adapters::outbound::uv::UvLockAdapter`. Unlike other outbound ports, this one is defined in the domain — not `src/ports/outbound/` — because the `UpgradeAdvisor` domain service consumes it directly as a generic bound and the domain layer must not import from `ports/`. Moved in #703 |
 | `GroupReachabilityAnalyzer` | `src/sbom_generation/domain/services/group_reachability_analyzer.rs` | Pure domain service for BFS-based group reachability traversal; wired into `GenerateSbomUseCase` via `apply_group_filter` in #623 |
 | `GroupRoots` | `src/ports/outbound/lockfile_reader.rs` | Type alias `HashMap<String, Vec<String>>` mapping dependency group name → root package names; extracted from `[manifest.dependency-groups]` in `uv.lock`; consumed by group reachability traversal in #622; wired into use case in #623 |
 | `NonPyPiPackageView` / `NonPyPiPackagesReport` | `src/application/read_models/non_pypi_package.rs` | Read model for packages sourced from non-PyPI origins (git, url, private registry); populated by `GenerateSbomUseCase` when `check_non_pypi` is true; rendered by the Markdown formatter's `non_pypi_packages` section (#656, #660) |
@@ -234,6 +236,9 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 - **Config resolution order**: CLI args > environment variables > config file > defaults.
   This order is enforced in `config_resolver.rs` and must not be changed without updating tests.
 - **Domain layer has no I/O**: `src/sbom_generation/` must never import from `adapters` or `ports`.
+  A port trait consumed directly by a domain service as a generic bound (e.g. `UvLockSimulator`,
+  used by `UpgradeAdvisor`) is defined in `src/sbom_generation/domain/` instead of `src/ports/outbound/`
+  — the port belongs to the hexagon, and the domain cannot import from `ports/` to reach it (#703).
 - **All GitHub artifacts (commits, PRs, Issues) must be in English** — enforced by skills in `.claude/skills/`.
 
 ### Files NOT to touch unless their issue explicitly targets them

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -88,6 +88,14 @@ Layer boundary violations (🔴 MUST FIX if any):
 
 Port/Adapter structure:
 - Are new port traits placed under src/ports/outbound/ or src/ports/inbound/?
+  Exception: a port trait consumed directly by a domain service as a generic
+  bound (e.g. a domain service function like `fn advise<S: SomeTrait>(...)`)
+  is domain-owned and belongs under src/sbom_generation/domain/ instead — the
+  domain layer must never import from src/ports/, so the port cannot live
+  there if a domain service needs the trait in scope. See UvLockSimulator in
+  src/sbom_generation/domain/uv_lock_simulator.rs (#703) as the reference
+  example. This exception does not apply to traits only consumed from
+  src/application/ or src/adapters/.
 - Are new adapters placed under the correct src/adapters/outbound/ subdirectory?
 - Does every new async trait method have #[async_trait] and Send + Sync bounds?
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ uv-sbom/
 │   │   │   ├── dependency_graph.rs # DependencyGraph aggregate
 │   │   │   ├── sbom_metadata.rs   # SbomMetadata (timestamp, UUID)
 │   │   │   ├── vulnerability.rs   # Vulnerability, Severity, CvssScore
+│   │   │   ├── enriched_package.rs    # EnrichedPackage struct
+│   │   │   ├── uv_lock_simulator.rs   # UvLockSimulator trait (domain-owned port), SimulationResult
 │   │   │   └── services/
 │   │   │       └── vulnerability_checker.rs  # Threshold evaluation
 │   │   ├── services/              # Domain services (pure functions)
@@ -70,8 +72,7 @@ uv-sbom/
 │   │   │   ├── vulnerability_repository.rs # VulnerabilityRepository trait
 │   │   │   ├── formatter.rs               # SbomFormatter trait
 │   │   │   ├── output_presenter.rs        # OutputPresenter trait
-│   │   │   ├── progress_reporter.rs       # ProgressReporter trait
-│   │   │   └── enriched_package.rs        # EnrichedPackage struct
+│   │   │   └── progress_reporter.rs       # ProgressReporter trait
 │   │   └── inbound/               # (reserved for future use)
 │   ├── adapters/                  # Infrastructure implementations
 │   │   └── outbound/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Moved `EnrichedPackage`/`SimulationResult`/`UvLockSimulator` out of `src/ports/outbound/` into `src/sbom_generation/domain/`**: `ResolutionAnalyzer` and `UpgradeAdvisor` (domain services) were importing these types from `ports/outbound/`, violating the invariant that the domain layer must never import from `ports/` or `adapters/`. `EnrichedPackage` and `SimulationResult` are plain value objects with no I/O, so they now live in the domain; `UvLockSimulator`, a genuine port trait consumed by `UpgradeAdvisor` as a generic bound, is now a domain-owned port (still implemented by `adapters::outbound::uv::UvLockAdapter`). Internal refactor only, no behavior change (#703)
+
 ### Fixed
 - **Upgrade advisor's version comparison used a fragile hand-rolled comparator instead of `pep440_rs`**: `UpgradeAdvisor` silently dropped non-numeric dot-separated segments (e.g. `"v1.2.3"` lost its leading segment) and unconditionally treated any pre-release, dev, or post marker in the resolved version as failing to satisfy the fixed-version minimum, regardless of the actual release segment. Replaced with `pep440_rs::Version`, already used elsewhere in the codebase, which correctly implements PEP 440 ordering. As a result, e.g. `"2.0.8.post1" >= "2.0.7"` and `"2.1.0rc1" >= "2.0.0"` now correctly evaluate as satisfying the minimum (#709)
 

--- a/src/adapters/outbound/uv/uv_lock_adapter.rs
+++ b/src/adapters/outbound/uv/uv_lock_adapter.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::time::Duration;
 use tokio::time::timeout;
 
-use crate::ports::outbound::uv_lock_simulator::{SimulationResult, UvLockSimulator};
+use crate::sbom_generation::domain::{SimulationResult, UvLockSimulator};
 
 /// Adapter that implements [`UvLockSimulator`] by shelling out to the `uv` CLI.
 ///

--- a/src/application/dto/sbom_response.rs
+++ b/src/application/dto/sbom_response.rs
@@ -1,10 +1,11 @@
 use crate::application::read_models::abandoned_package::AbandonedPackagesReport;
 use crate::application::read_models::non_pypi_package::NonPyPiPackagesReport;
 use crate::application::read_models::python_compatibility::PythonCompatibilityReport;
-use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::VulnerabilityCheckResult;
-use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata, UpgradeRecommendation};
+use crate::sbom_generation::domain::{
+    DependencyGraph, EnrichedPackage, SbomMetadata, UpgradeRecommendation,
+};
 use crate::shared::error::SbomError;
 
 /// SbomResponse - Internal response DTO from SBOM generation use case

--- a/src/application/read_models/sbom_read_model_builder/component_builder.rs
+++ b/src/application/read_models/sbom_read_model_builder/component_builder.rs
@@ -1,5 +1,4 @@
-use crate::ports::outbound::EnrichedPackage;
-use crate::sbom_generation::domain::DependencyGraph;
+use crate::sbom_generation::domain::{DependencyGraph, EnrichedPackage};
 use crate::sbom_generation::policies::spdx_license_map;
 
 use super::super::component_view::{ComponentView, LicenseView};
@@ -53,7 +52,6 @@ fn build_component(enriched: &EnrichedPackage, graph: Option<&DependencyGraph>) 
 mod tests {
     use super::super::test_helpers as th;
     use super::*;
-    use crate::ports::outbound::EnrichedPackage;
     use crate::sbom_generation::domain::Package;
 
     #[test]

--- a/src/application/read_models/sbom_read_model_builder/mod.rs
+++ b/src/application/read_models/sbom_read_model_builder/mod.rs
@@ -16,11 +16,12 @@ use super::non_pypi_package::NonPyPiPackagesReport;
 use super::python_compatibility::PythonCompatibilityReport;
 use super::resolution_guide_view::ResolutionGuideView;
 use super::sbom_read_model::SbomReadModel;
-use crate::ports::outbound::EnrichedPackage;
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
 use crate::sbom_generation::domain::services::{ResolutionAnalyzer, VulnerabilityCheckResult};
 use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
-use crate::sbom_generation::domain::{DependencyGraph, SbomMetadata, UpgradeRecommendation};
+use crate::sbom_generation::domain::{
+    DependencyGraph, EnrichedPackage, SbomMetadata, UpgradeRecommendation,
+};
 
 /// Builder for constructing SbomReadModel from domain objects
 ///
@@ -106,12 +107,13 @@ impl SbomReadModelBuilder {
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    use crate::ports::outbound::EnrichedPackage;
     use crate::sbom_generation::domain::resolution_guide::{IntroducedBy, ResolutionEntry};
     use crate::sbom_generation::domain::vulnerability::{
         CvssScore, PackageVulnerabilities, Severity, Vulnerability,
     };
-    use crate::sbom_generation::domain::{DependencyGraph, Package, PackageName, SbomMetadata};
+    use crate::sbom_generation::domain::{
+        DependencyGraph, EnrichedPackage, Package, PackageName, SbomMetadata,
+    };
     use std::collections::HashMap;
 
     pub(crate) fn metadata() -> SbomMetadata {

--- a/src/application/use_cases/fetch_licenses.rs
+++ b/src/application/use_cases/fetch_licenses.rs
@@ -1,5 +1,5 @@
-use crate::ports::outbound::{EnrichedPackage, LicenseRepository};
-use crate::sbom_generation::domain::Package;
+use crate::ports::outbound::LicenseRepository;
+use crate::sbom_generation::domain::{EnrichedPackage, Package};
 use crate::shared::Result;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -13,7 +13,7 @@ use crate::application::use_cases::{
 };
 use crate::i18n::{Locale, Messages};
 use crate::ports::outbound::{
-    EnrichedPackage, LicenseRepository, LockfileReader, MaintenanceRepository, ProgressReporter,
+    LicenseRepository, LockfileReader, MaintenanceRepository, ProgressReporter,
     ProjectConfigReader, PythonCompatibilityRepository, VulnerabilityRepository,
 };
 use crate::sbom_generation::domain::license_policy::LicenseComplianceResult;
@@ -22,7 +22,7 @@ use crate::sbom_generation::domain::services::{
     UpgradeAdvisor, VulnerabilityCheckResult, VulnerabilityChecker,
 };
 use crate::sbom_generation::domain::{
-    DependencyGraph, Package, PackageName, UpgradeRecommendation,
+    DependencyGraph, EnrichedPackage, Package, PackageName, UpgradeRecommendation,
 };
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;

--- a/src/ports/outbound/mod.rs
+++ b/src/ports/outbound/mod.rs
@@ -3,7 +3,6 @@
 /// These ports define the interfaces that the application core uses
 /// to interact with external systems (file system, network, console, etc.).
 pub mod diff_lockfile_reader;
-pub mod enriched_package;
 pub mod formatter;
 pub mod license_repository;
 pub mod lockfile_reader;
@@ -12,12 +11,17 @@ pub mod output_presenter;
 pub mod progress_reporter;
 pub mod project_config_reader;
 pub mod python_compatibility_repository;
-pub mod uv_lock_simulator;
 pub mod vulnerability_repository;
 pub mod workspace_reader;
 
+// `EnrichedPackage`, `UvLockSimulator` / `SimulationResult` are defined in
+// `crate::sbom_generation::domain`, not here: `ResolutionAnalyzer` and
+// `UpgradeAdvisor` are domain services that consume them directly (the latter
+// takes `UvLockSimulator` as a generic bound), and the domain layer must not
+// import from `ports/`. `UvLockSimulator` is implemented by
+// `adapters::outbound::uv::UvLockAdapter`. See Issue #703.
+
 pub use diff_lockfile_reader::{DiffLockfileReader, DiffSource};
-pub use enriched_package::EnrichedPackage;
 pub use formatter::SbomFormatter;
 pub use license_repository::{LicenseRepository, PyPiMetadata};
 pub use lockfile_reader::{
@@ -34,9 +38,6 @@ pub use project_config_reader::ProjectConfigReader;
 pub use python_compatibility_repository::{
     is_incompatible, PythonCompatibilityInfo, PythonCompatibilityRepository,
 };
-// Note: This will be used in a subsequent subtask for uv lock simulation
-#[allow(unused_imports)]
-pub use uv_lock_simulator::{SimulationResult, UvLockSimulator};
 // Note: This will be used in subsequent subtasks (Subtask 3-8)
 #[allow(unused_imports)]
 pub use vulnerability_repository::VulnerabilityRepository;

--- a/src/sbom_generation/domain/enriched_package.rs
+++ b/src/sbom_generation/domain/enriched_package.rs
@@ -1,4 +1,4 @@
-use crate::sbom_generation::domain::Package;
+use super::Package;
 
 /// EnrichedPackage represents a package with its license information
 ///

--- a/src/sbom_generation/domain/mod.rs
+++ b/src/sbom_generation/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod dependency_diff;
 pub mod dependency_graph;
+pub mod enriched_package;
 pub mod license_info;
 pub mod license_policy;
 pub mod package;
@@ -7,12 +8,14 @@ pub mod resolution_guide;
 pub mod sbom_metadata;
 pub mod services;
 pub mod upgrade_recommendation;
+pub mod uv_lock_simulator;
 pub mod vulnerability;
 
 // Note: These will be used in subsequent subtasks of the dependency-diff feature (#224)
 #[allow(unused_imports)]
 pub use dependency_diff::{ChangeType, DependencyDiff, DiffSummary, PackageChange};
 pub use dependency_graph::DependencyGraph;
+pub use enriched_package::EnrichedPackage;
 pub use license_info::LicenseInfo;
 // Note: These types are used within the application layer via full paths
 #[allow(unused_imports)]
@@ -39,6 +42,7 @@ pub use services::{ThresholdConfig, VulnerabilityCheckResult, VulnerabilityCheck
 // Note: These will be used in subsequent subtasks (Subtask 2-8)
 #[allow(unused_imports)]
 pub use upgrade_recommendation::UpgradeRecommendation;
+pub use uv_lock_simulator::{SimulationResult, UvLockSimulator};
 // Note: These will be used in subsequent subtasks (Subtask 2-8)
 #[allow(unused_imports)]
 pub use vulnerability::{CvssScore, PackageVulnerabilities, Severity, Vulnerability};

--- a/src/sbom_generation/domain/services/resolution_analyzer.rs
+++ b/src/sbom_generation/domain/services/resolution_analyzer.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
-use crate::ports::outbound::enriched_package::EnrichedPackage;
 use crate::sbom_generation::domain::dependency_graph::DependencyGraph;
 use crate::sbom_generation::domain::package::PackageName;
 use crate::sbom_generation::domain::resolution_guide::{IntroducedBy, ResolutionEntry};
 use crate::sbom_generation::domain::vulnerability::PackageVulnerabilities;
+use crate::sbom_generation::domain::EnrichedPackage;
 
 /// Stateless domain service for cross-referencing vulnerability data with the
 /// dependency graph to identify which direct dependencies introduce vulnerable

--- a/src/sbom_generation/domain/services/upgrade_advisor.rs
+++ b/src/sbom_generation/domain/services/upgrade_advisor.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 
 use pep440_rs::Version;
 
-use crate::ports::outbound::uv_lock_simulator::{SimulationResult, UvLockSimulator};
 use crate::sbom_generation::domain::resolution_guide::ResolutionEntry;
 use crate::sbom_generation::domain::upgrade_recommendation::UpgradeRecommendation;
+use crate::sbom_generation::domain::{SimulationResult, UvLockSimulator};
 
 /// Stateless domain service that orchestrates upgrade simulations and produces
 /// `UpgradeRecommendation` results by comparing resolved transitive versions

--- a/src/sbom_generation/domain/uv_lock_simulator.rs
+++ b/src/sbom_generation/domain/uv_lock_simulator.rs
@@ -1,3 +1,12 @@
+//! Domain-owned port for uv lock simulation.
+//!
+//! Unlike the other outbound ports, this trait is defined in the domain layer
+//! rather than under `src/ports/outbound/`. The `UpgradeAdvisor` domain service
+//! consumes it as a generic bound (`advise<S: UvLockSimulator>`), and the domain
+//! layer must never import from `ports/` or `adapters/`. In Ports & Adapters the
+//! port belongs to the hexagon anyway; it is implemented outside by
+//! `adapters::outbound::uv::UvLockAdapter`. See Issue #703.
+
 use anyhow::Result;
 use std::collections::HashMap;
 


### PR DESCRIPTION
## Summary
- `ResolutionAnalyzer` and `UpgradeAdvisor` (domain services) imported `EnrichedPackage`/`SimulationResult`/`UvLockSimulator` from `src/ports/outbound/`, violating the invariant that `src/sbom_generation/` must never import from `ports/` or `adapters/`.
- `EnrichedPackage` and `SimulationResult` are plain value objects with no I/O, so they move to `src/sbom_generation/domain/`.
- `UvLockSimulator` is a genuine port trait (implemented by `adapters::outbound::uv::UvLockAdapter`), but since `UpgradeAdvisor::advise<S: UvLockSimulator>` needs it in scope as a generic bound, it becomes a domain-owned port instead of living under `ports/outbound/`.

## Related Issue
Closes #703

## Changes Made
- Moved `src/ports/outbound/enriched_package.rs` → `src/sbom_generation/domain/enriched_package.rs` (via `git mv`, content unchanged aside from the import path)
- Moved `src/ports/outbound/uv_lock_simulator.rs` → `src/sbom_generation/domain/uv_lock_simulator.rs` (via `git mv`), with a module doc comment explaining why this port is domain-owned
- Registered both modules and re-exports in `src/sbom_generation/domain/mod.rs`
- Removed the corresponding `pub mod`/`pub use` entries from `src/ports/outbound/mod.rs`, replaced with a pointer comment explaining where the types moved and why
- Fixed the two domain-purity violations: `src/sbom_generation/domain/services/resolution_analyzer.rs` and `src/sbom_generation/domain/services/upgrade_advisor.rs` now import from `crate::sbom_generation::domain::` instead of `crate::ports::outbound::`
- Updated all external call sites to the new import path: `src/application/dto/sbom_response.rs`, `src/application/use_cases/fetch_licenses.rs`, `src/application/use_cases/generate_sbom/mod.rs`, `src/application/read_models/sbom_read_model_builder/mod.rs` (incl. `test_helpers`), `src/application/read_models/sbom_read_model_builder/component_builder.rs`, `src/adapters/outbound/uv/uv_lock_adapter.rs`
- Amended `.claude/skills/code-review/SKILL.md`'s port-placement checklist item to document the domain-owned-port exception, so future `/code-review` runs don't false-positive on this pattern
- Updated `.claude/CLAUDE.md` (Key Types table + Important Invariants) and `AGENTS.md` (directory tree) to reflect the new locations
- Added a `CHANGELOG.md [Unreleased]` entry (internal refactor, no user-facing behavior change)
- Opened a follow-up issue (#716) for a separate design concern noticed during this refactor: `UpgradeAdvisor` is the only domain service that performs live async I/O via an injected trait bound — out of scope for this PR

## Test Plan
- [x] `grep -rn "use crate::ports\|use crate::adapters" src/sbom_generation/` returns zero results
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes with zero warnings
- [x] `cargo test --all` passes (all suites green, no test bodies changed — behavior-preserving move)
- [x] `/code-review` skill run: **PASS**, no issues found

---
Generated with [Claude Code](https://claude.com/claude-code)