### PR TITLE
refactor(application): inject UvLockSimulator via DI in GenerateSbomUseCase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -215,7 +215,7 @@ Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design principles.
 | `MergedConfig` | `src/cli/config_resolver.rs` | Final resolved config (CLI > env > file > default) |
 | `ConfigFile` | `src/config.rs` | Raw deserialized config file struct |
 | `SbomRequest` / `SbomResponse` | `src/application/dto/` | Input/output for the main use case |
-| `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO,PCREPO=()>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555; 7th param `PCREPO: PythonCompatibilityRepository` (defaults to `()`) added in #681 |
+| `GenerateSbomUseCase<LR,PCR,LREPO,PR,VREPO,MREPO,PCREPO=(),USIM=()>` | `src/application/use_cases/generate_sbom/` | Orchestrates SBOM generation; 6th param `MREPO: MaintenanceRepository` added in #555; 7th param `PCREPO: PythonCompatibilityRepository` (defaults to `()`) added in #681; 8th param `USIM: UvLockSimulator` (defaults to `()`, no `+ Clone` bound — only ever borrowed) added in #704, replacing a direct `UvLockAdapter` construction inside `advise_upgrades_if_requested` |
 | `CheckAbandonedPackagesUseCase` | `src/application/use_cases/check_abandoned_packages.rs` | Fetches PyPI maintenance info for all packages with progress bar and soft-fail per package |
 | `DiffRequest` | `src/application/dto/diff_request.rs` | Input DTO for the diff use case (source, project_path, check_cve) |
 | `DiffResult` | `src/application/dto/diff_result.rs` | Output of `GenerateDiffUseCase::execute`; wraps domain `DependencyDiff` with `Option<CveDeltaView>` to keep domain layer free of read-model dependencies |

--- a/src/application/use_cases/generate_sbom/mod.rs
+++ b/src/application/use_cases/generate_sbom/mod.rs
@@ -1,4 +1,3 @@
-use crate::adapters::outbound::uv::UvLockAdapter;
 use crate::application::dto::{SbomRequest, SbomResponse};
 use crate::application::read_models::abandoned_package::{
     AbandonedPackageView, AbandonedPackagesReport,
@@ -22,7 +21,7 @@ use crate::sbom_generation::domain::services::{
     UpgradeAdvisor, VulnerabilityCheckResult, VulnerabilityChecker,
 };
 use crate::sbom_generation::domain::{
-    DependencyGraph, EnrichedPackage, Package, PackageName, UpgradeRecommendation,
+    DependencyGraph, EnrichedPackage, Package, PackageName, UpgradeRecommendation, UvLockSimulator,
 };
 use crate::sbom_generation::services::{DependencyAnalyzer, PackageFilter, SbomGenerator};
 use crate::shared::Result;
@@ -47,7 +46,8 @@ type PackagesWithDependencyMap = (Vec<Package>, std::collections::HashMap<String
 /// * `VREPO` - VulnerabilityRepository implementation (optional)
 /// * `MREPO` - MaintenanceRepository implementation (optional)
 /// * `PCREPO` - PythonCompatibilityRepository implementation (optional)
-pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO = ()> {
+/// * `USIM` - UvLockSimulator implementation (optional)
+pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO = (), USIM = ()> {
     lockfile_reader: LR,
     project_config_reader: PCR,
     license_repository: LREPO,
@@ -55,11 +55,12 @@ pub struct GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO = ()> {
     vulnerability_repository: Option<VREPO>,
     maintenance_repository: Option<MREPO>,
     compatibility_repository: Option<PCREPO>,
+    uv_lock_simulator: Option<USIM>,
     locale: Locale,
 }
 
-impl<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO>
-    GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO>
+impl<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO, USIM>
+    GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO, USIM>
 where
     LR: LockfileReader,
     PCR: ProjectConfigReader,
@@ -68,6 +69,7 @@ where
     VREPO: VulnerabilityRepository + Clone,
     MREPO: MaintenanceRepository + Clone,
     PCREPO: PythonCompatibilityRepository + Clone,
+    USIM: UvLockSimulator,
 {
     /// Creates a new GenerateSbomUseCase with injected dependencies
     #[allow(clippy::too_many_arguments)]
@@ -79,6 +81,7 @@ where
         vulnerability_repository: Option<VREPO>,
         maintenance_repository: Option<MREPO>,
         compatibility_repository: Option<PCREPO>,
+        uv_lock_simulator: Option<USIM>,
         locale: Locale,
     ) -> Self {
         Self {
@@ -89,6 +92,7 @@ where
             vulnerability_repository,
             maintenance_repository,
             compatibility_repository,
+            uv_lock_simulator,
             locale,
         }
     }
@@ -705,9 +709,15 @@ where
             &[&unique_dep_count.to_string(), unit],
         ));
 
-        let simulator = UvLockAdapter::new();
-        let recommendations =
-            UpgradeAdvisor::advise(&simulator, &entries, &request.project_path).await;
+        // `None` is unreachable in production (the CLI composition root always
+        // injects a real simulator); it exists only for tests that deliberately
+        // omit one.
+        let recommendations = match self.uv_lock_simulator.as_ref() {
+            Some(simulator) => {
+                UpgradeAdvisor::advise(simulator, &entries, &request.project_path).await
+            }
+            None => Vec::new(),
+        };
 
         for rec in &recommendations {
             match rec {

--- a/src/application/use_cases/generate_sbom/tests.rs
+++ b/src/application/use_cases/generate_sbom/tests.rs
@@ -3,7 +3,7 @@ use crate::application::use_cases::test_doubles::{
     MockMaintenanceRepository, MockPythonCompatibilityRepository, MockVulnerabilityRepository,
 };
 use crate::ports::outbound::{GroupRoots, LockfileParseResult, PackageSourceMap, PyPiMetadata};
-use crate::sbom_generation::domain::Package;
+use crate::sbom_generation::domain::{Package, SimulationResult};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -78,6 +78,59 @@ impl ProgressReporter for MockProgressReporter {
     fn report_completion(&self, _message: &str) {}
 }
 
+/// Configurable in-memory mock implementing `UvLockSimulator`.
+///
+/// Responses are keyed by package name rather than a FIFO queue, because
+/// `UpgradeAdvisor::advise` iterates a `HashMap` of unique direct deps — a
+/// FIFO queue would make test assertions depend on nondeterministic
+/// iteration order, matching the reasoning behind
+/// `MockPythonCompatibilityRepository` in `test_doubles.rs`. Not shared via
+/// `test_doubles.rs` since this use case is its only consumer.
+#[derive(Default)]
+struct MockUvLockSimulator {
+    results: HashMap<String, SimulationResult>,
+    errors: HashMap<String, String>,
+}
+
+impl MockUvLockSimulator {
+    fn with_result(package: &str, result: SimulationResult) -> Self {
+        let mut results = HashMap::new();
+        results.insert(package.to_string(), result);
+        Self {
+            results,
+            errors: HashMap::new(),
+        }
+    }
+
+    fn with_error(package: &str, error: &str) -> Self {
+        let mut errors = HashMap::new();
+        errors.insert(package.to_string(), error.to_string());
+        Self {
+            results: HashMap::new(),
+            errors,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UvLockSimulator for MockUvLockSimulator {
+    async fn simulate_upgrade(
+        &self,
+        package_name: &str,
+        _project_path: &Path,
+    ) -> Result<SimulationResult> {
+        if let Some(error) = self.errors.get(package_name) {
+            anyhow::bail!("{}", error);
+        }
+        self.results.get(package_name).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "MockUvLockSimulator: no response configured for {}",
+                package_name
+            )
+        })
+    }
+}
+
 mod test_helpers {
     use super::*;
     use crate::i18n::Locale;
@@ -90,6 +143,7 @@ mod test_helpers {
         MockVulnerabilityRepository,
         MockMaintenanceRepository,
         MockPythonCompatibilityRepository,
+        MockUvLockSimulator,
     >;
 
     pub(super) struct UseCaseBuilder {
@@ -101,6 +155,7 @@ mod test_helpers {
         vuln: Option<MockVulnerabilityRepository>,
         maint: Option<MockMaintenanceRepository>,
         pyc: Option<MockPythonCompatibilityRepository>,
+        sim: Option<MockUvLockSimulator>,
     }
 
     impl Default for UseCaseBuilder {
@@ -114,6 +169,7 @@ mod test_helpers {
                 vuln: None,
                 maint: None,
                 pyc: None,
+                sim: None,
             }
         }
     }
@@ -162,6 +218,11 @@ mod test_helpers {
             self
         }
 
+        pub(super) fn with_simulator(mut self, sim: MockUvLockSimulator) -> Self {
+            self.sim = Some(sim);
+            self
+        }
+
         pub(super) fn with_source_map(mut self, map: PackageSourceMap) -> Self {
             self.source_map = map;
             self
@@ -183,6 +244,7 @@ mod test_helpers {
                 self.vuln,
                 self.maint,
                 self.pyc,
+                self.sim,
                 Locale::default(),
             )
         }
@@ -1468,5 +1530,194 @@ mod tests_python_compat_markdown {
 
         assert!(markdown.contains("## ✅ Python 3.13 Compatibility"));
         assert!(!markdown.contains("Compatibility Issues"));
+    }
+}
+
+mod tests_upgrade_advisor {
+    use super::test_helpers::*;
+    use super::*;
+    use crate::sbom_generation::domain::vulnerability::{CvssScore, Severity, Vulnerability};
+    use crate::sbom_generation::domain::{DependencyGraph, PackageName, PackageVulnerabilities};
+
+    /// Builds a minimal fixture: a direct dependency `app-dep` that transitively
+    /// introduces `vuln-lib`, which has one vulnerability with a fixed version.
+    /// This is the shape `ResolutionAnalyzer::analyze` requires to produce a
+    /// non-empty `ResolutionEntry` list (see resolution_analyzer.rs).
+    struct Fixture {
+        graph: DependencyGraph,
+        vulns: Vec<PackageVulnerabilities>,
+        enriched: Vec<EnrichedPackage>,
+    }
+
+    fn make_fixture() -> Fixture {
+        let direct = vec![PackageName::new("app-dep".to_string()).unwrap()];
+        let transitive = HashMap::from([(
+            PackageName::new("app-dep".to_string()).unwrap(),
+            vec![PackageName::new("vuln-lib".to_string()).unwrap()],
+        )]);
+        let graph = DependencyGraph::new(direct, transitive, HashMap::new());
+
+        let vuln = Vulnerability::new(
+            "CVE-2024-0001".to_string(),
+            Some(CvssScore::new(7.5).unwrap()),
+            Severity::High,
+            Some("2.0.0".to_string()),
+            None,
+        )
+        .unwrap();
+        let vulns = vec![PackageVulnerabilities::new(
+            "vuln-lib".to_string(),
+            "1.0.0".to_string(),
+            vec![vuln],
+        )];
+
+        let enriched = vec![EnrichedPackage::new(
+            pkg("app-dep", "1.0.0"),
+            Some("MIT".to_string()),
+            None,
+        )];
+
+        Fixture {
+            graph,
+            vulns,
+            enriched,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_advise_returns_none_when_suggest_fix_disabled() {
+        let use_case = UseCaseBuilder::default().build();
+        let fixture = make_fixture();
+
+        let result = use_case
+            .advise_upgrades_if_requested(
+                &default_request(),
+                Some(&fixture.graph),
+                Some(&fixture.vulns),
+                &fixture.enriched,
+            )
+            .await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_advise_returns_empty_when_no_graph_or_vuln_report() {
+        let use_case = UseCaseBuilder::default().build();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .suggest_fix(true)
+            .build()
+            .unwrap();
+
+        let result = use_case
+            .advise_upgrades_if_requested(&request, None, None, &[])
+            .await;
+
+        assert!(result.expect("suggest_fix enabled → Some").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_advise_returns_empty_when_no_resolution_entries() {
+        let use_case = UseCaseBuilder::default().build();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .suggest_fix(true)
+            .build()
+            .unwrap();
+        let graph = DependencyGraph::new(vec![], HashMap::new(), HashMap::new());
+
+        let result = use_case
+            .advise_upgrades_if_requested(&request, Some(&graph), Some(&[]), &[])
+            .await;
+
+        assert!(result.expect("suggest_fix enabled → Some").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_advise_returns_upgradable_with_mock_simulator() {
+        let simulator = MockUvLockSimulator::with_result(
+            "app-dep",
+            SimulationResult {
+                upgraded_to_version: "3.0.0".to_string(),
+                resolved_versions: HashMap::from([("vuln-lib".to_string(), "2.0.0".to_string())]),
+            },
+        );
+        let use_case = UseCaseBuilder::default().with_simulator(simulator).build();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .suggest_fix(true)
+            .build()
+            .unwrap();
+        let fixture = make_fixture();
+
+        let result = use_case
+            .advise_upgrades_if_requested(
+                &request,
+                Some(&fixture.graph),
+                Some(&fixture.vulns),
+                &fixture.enriched,
+            )
+            .await;
+
+        let recommendations = result.expect("suggest_fix enabled with entries → Some");
+        assert_eq!(recommendations.len(), 1);
+        assert!(matches!(
+            recommendations[0],
+            UpgradeRecommendation::Upgradable { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_advise_returns_simulation_failed_on_simulator_error() {
+        let simulator = MockUvLockSimulator::with_error("app-dep", "uv command timed out");
+        let use_case = UseCaseBuilder::default().with_simulator(simulator).build();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .suggest_fix(true)
+            .build()
+            .unwrap();
+        let fixture = make_fixture();
+
+        let result = use_case
+            .advise_upgrades_if_requested(
+                &request,
+                Some(&fixture.graph),
+                Some(&fixture.vulns),
+                &fixture.enriched,
+            )
+            .await;
+
+        let recommendations = result.expect("suggest_fix enabled with entries → Some");
+        assert_eq!(recommendations.len(), 1);
+        assert!(matches!(
+            recommendations[0],
+            UpgradeRecommendation::SimulationFailed { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_advise_returns_empty_when_no_simulator_injected() {
+        // No `.with_simulator(...)` — documents the injected-`None` branch:
+        // `self.uv_lock_simulator` is `None`, so `advise_upgrades_if_requested`
+        // must not panic or call a simulator, even with real entries present.
+        let use_case = UseCaseBuilder::default().build();
+        let request = SbomRequest::builder()
+            .project_path("/test/project")
+            .suggest_fix(true)
+            .build()
+            .unwrap();
+        let fixture = make_fixture();
+
+        let result = use_case
+            .advise_upgrades_if_requested(
+                &request,
+                Some(&fixture.graph),
+                Some(&fixture.vulns),
+                &fixture.enriched,
+            )
+            .await;
+
+        assert!(result.expect("suggest_fix enabled → Some").is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //!     None, // No vulnerability checking in this example
 //!     None, // No abandoned-package checking in this example
 //!     None, // No Python compatibility checking in this example
+//!     None, // No upgrade simulation in this example
 //!     uv_sbom::i18n::Locale::default(),
 //! );
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use adapters::outbound::network::{
     CachingPyPiLicenseRepository, OsvClient, PyPiCompatibilityClient, PyPiLicenseRepository,
     PyPiMaintenanceRepository,
 };
-use adapters::outbound::uv::UvWorkspaceReader;
+use adapters::outbound::uv::{UvLockAdapter, UvWorkspaceReader};
 use application::dto::{DiffRequest, OutputFormat, SbomRequest, SbomResponse};
 use application::factories::{FormatterFactory, PresenterFactory, PresenterType};
 use application::read_models::SbomReadModelBuilder;
@@ -95,6 +95,7 @@ type WiredSbomUseCase<LR> = GenerateSbomUseCase<
     OsvClient,
     PyPiMaintenanceRepository,
     PyPiCompatibilityClient,
+    UvLockAdapter,
 >;
 
 /// Builds a fully-wired `GenerateSbomUseCase` from the resolved config.
@@ -132,6 +133,14 @@ fn build_use_case<LR: LockfileReader>(
         None
     };
 
+    // Upgrade simulator: unconditionally injected. `UvLockAdapter::new()` is
+    // infallible and constructs a zero-sized struct with no I/O, so there is
+    // nothing to gate on here (unlike the repositories above, which build real
+    // HTTP clients). Whether it is actually used is decided later by
+    // `SbomRequest::suggest_fix`, which is resolved by the caller after this
+    // function returns.
+    let uv_lock_simulator = Some(UvLockAdapter::new());
+
     Ok(GenerateSbomUseCase::new(
         lockfile_reader,
         project_config_reader,
@@ -140,6 +149,7 @@ fn build_use_case<LR: LockfileReader>(
         vulnerability_repository,
         maintenance_repository,
         compatibility_repository,
+        uv_lock_simulator,
         locale,
     ))
 }

--- a/src/sbom_generation/domain/uv_lock_simulator.rs
+++ b/src/sbom_generation/domain/uv_lock_simulator.rs
@@ -36,3 +36,20 @@ pub trait UvLockSimulator: Send + Sync {
         project_path: &std::path::Path,
     ) -> Result<SimulationResult>;
 }
+
+/// Null-object impl so `GenerateSbomUseCase`'s `USIM = ()` default satisfies the
+/// trait bound. Never called in practice: the use case only reaches the
+/// simulator through `Option<USIM>`, which the CLI composition root always
+/// populates with a real `UvLockAdapter`; `None`/`()` only arises in tests that
+/// intentionally omit a simulator. Mirrors `impl PythonCompatibilityRepository
+/// for ()` in `src/ports/outbound/python_compatibility_repository.rs`.
+#[async_trait::async_trait]
+impl UvLockSimulator for () {
+    async fn simulate_upgrade(
+        &self,
+        _package_name: &str,
+        _project_path: &std::path::Path,
+    ) -> Result<SimulationResult> {
+        unreachable!("UvLockSimulator not configured")
+    }
+}

--- a/tests/e2e_test.rs
+++ b/tests/e2e_test.rs
@@ -84,6 +84,7 @@ async fn test_e2e_json_format() {
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -138,6 +139,7 @@ async fn test_e2e_markdown_format() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -200,6 +202,7 @@ async fn test_e2e_nonexistent_project() {
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -226,6 +229,7 @@ async fn test_e2e_package_count() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -270,6 +274,7 @@ async fn test_e2e_exclude_single_package() {
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -308,6 +313,7 @@ async fn test_e2e_exclude_multiple_packages() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -356,6 +362,7 @@ async fn test_e2e_exclude_with_wildcard() {
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -394,6 +401,7 @@ async fn test_e2e_exclude_all_packages_error() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -441,6 +449,7 @@ async fn test_e2e_exclude_root_project_preserves_dependency_classification() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -496,6 +505,7 @@ async fn test_e2e_exclude_root_project_markdown_output() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40,6 +40,7 @@ source = { registry = "https://pypi.org/simple" }
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -95,6 +96,7 @@ source = { registry = "https://pypi.org/simple" }
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -131,6 +133,7 @@ async fn test_generate_sbom_lockfile_read_failure() {
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -163,6 +166,7 @@ source = { registry = "https://pypi.org/simple" }
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -205,6 +209,7 @@ source = { registry = "https://pypi.org/simple" }
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -239,6 +244,7 @@ async fn test_generate_sbom_invalid_toml() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -278,6 +284,7 @@ source = { registry = "https://pypi.org/simple" }
         project_config_reader,
         license_repository,
         progress_reporter.clone(),
+        None,
         None,
         None,
         None,
@@ -329,6 +336,7 @@ source = { registry = "https://pypi.org/simple" }
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -406,6 +414,7 @@ source = { registry = "https://pypi.org/simple" }
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -465,6 +474,7 @@ source = { registry = "https://pypi.org/simple" }
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -506,6 +516,7 @@ source = { registry = "https://pypi.org/simple" }
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,
@@ -570,6 +581,7 @@ source = { registry = "https://pypi.org/simple" }
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,

--- a/tests/non_pypi_test.rs
+++ b/tests/non_pypi_test.rs
@@ -43,6 +43,7 @@ async fn test_non_pypi_section_rendered_when_check_non_pypi_enabled() {
         None,
         None,
         None,
+        None,
         uv_sbom::i18n::Locale::En,
     );
 
@@ -116,6 +117,7 @@ async fn test_non_pypi_section_absent_when_check_non_pypi_disabled() {
         project_config_reader,
         license_repository,
         progress_reporter,
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
## Summary
- `GenerateSbomUseCase::advise_upgrades_if_requested` previously constructed a concrete `adapters::outbound::uv::UvLockAdapter` directly instead of receiving it through the struct's existing DI pattern — the only dependency in the whole use case that wasn't mockable.
- Adds an 8th generic type parameter `USIM: UvLockSimulator` (default `()`), following the exact pattern of the existing 7 injected dependencies.
- Adds `impl UvLockSimulator for ()` as a null object, and adds `MockUvLockSimulator` + 6 new unit tests exercising the upgrade-advice path without a real `uv` subprocess.

## Related Issue
Closes #704

## Changes Made
- `GenerateSbomUseCase<LR, PCR, LREPO, PR, VREPO, MREPO, PCREPO = (), USIM = ()>` — 8th param `USIM: UvLockSimulator`. **No `+ Clone` bound**, unlike `VREPO`/`MREPO`/`PCREPO`: `UpgradeAdvisor::advise` only ever borrows the simulator via `&S`, never clones it.
- `advise_upgrades_if_requested` now uses `self.uv_lock_simulator.as_ref()` instead of `UvLockAdapter::new()` inline; the adapter import is removed from `generate_sbom/mod.rs` — the use case no longer references any concrete adapter type.
- `impl UvLockSimulator for ()` added to `src/sbom_generation/domain/uv_lock_simulator.rs` (its home since #703 moved the trait out of `ports/outbound/`), mirroring the existing `impl PythonCompatibilityRepository for ()` null object.
- `main.rs`'s `build_use_case()` constructs `Some(UvLockAdapter::new())` **unconditionally** — unlike the other three optional repositories, which gate on `merged.check_cve` / `merged.check_abandoned` / `target_python.is_some()`. That gating exists because those adapters build real HTTP clients and return `Result`; `UvLockAdapter::new()` is an infallible, zero-sized-struct constructor with no I/O, so there's nothing to gate on — and `merged` (the value `build_use_case` receives) doesn't even carry the effective `suggest_fix` the caller resolves afterward in a separate step.
- `MockUvLockSimulator` (keyed by package name, not a FIFO queue — `UpgradeAdvisor::advise` iterates a `HashMap` of unique direct deps in nondeterministic order, same reasoning as the existing `MockPythonCompatibilityRepository`) and a new `mod tests_upgrade_advisor` with 6 tests in `generate_sbom/tests.rs`.
- All 27 `GenerateSbomUseCase::new()` call sites (`main.rs`, `lib.rs` doctest, `generate_sbom/tests.rs`, `tests/e2e_test.rs` ×10, `tests/integration_test.rs` ×12, `tests/non_pypi_test.rs` ×2) get a mechanical 4th `None`/`Some(...)` argument before `locale`. Type annotations (`GenerateSbomUseCase<_, _, _, _, (), ()>`) needed no changes — `PCREPO` and the new `USIM` both default to `()`.

## Test Plan
- [x] `cargo test --all` (incl. `--doc`) passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] New unit tests (`tests_upgrade_advisor`, 6 cases) cover: `suggest_fix` disabled → `None`; no graph/vuln report → `Some([])`; no resolution entries → `Some([])`; mock simulator success → `Upgradable`; mock simulator error → `SimulationFailed`; no simulator injected → `Some([])` (documents the production-unreachable `None` branch)
- [x] Manual smoke test: `cargo run -- -p examples/suggest-fix-project -f markdown --suggest-fix` — confirms the DI-wired `UvLockAdapter` still runs real `uv lock --upgrade-package` simulations end-to-end and produces both `⬆️ Upgrade` and `⚠️ Cannot resolve` recommendations in the rendered Markdown

---
Generated with [Claude Code](https://claude.com/claude-code)