### PR TITLE
refactor(shared): extract shared retry/URL-validation helpers for PyPI clients

### DIFF
--- a/src/adapters/outbound/network/pypi_client.rs
+++ b/src/adapters/outbound/network/pypi_client.rs
@@ -47,10 +47,11 @@ struct PyPiInfo {
 #[derive(Clone)]
 pub struct PyPiLicenseRepository {
     client: reqwest::Client,
-    max_retries: u32,
 }
 
 impl PyPiLicenseRepository {
+    const MAX_RETRIES: u32 = 3;
+
     /// Creates a new PyPI license repository with default configuration
     pub fn new() -> Result<Self> {
         let version = env!("CARGO_PKG_VERSION");
@@ -60,65 +61,22 @@ impl PyPiLicenseRepository {
             .user_agent(user_agent)
             .build()?;
 
-        Ok(Self {
-            client,
-            max_retries: 3,
-        })
+        Ok(Self { client })
     }
 
     /// Fetches package information from PyPI with retry logic (async)
     async fn fetch_with_retry(&self, package_name: &str, version: &str) -> Result<PyPiPackageInfo> {
-        let mut last_error = None;
-
-        for attempt in 1..=self.max_retries {
-            match self.fetch_from_pypi(package_name, version).await {
-                Ok(result) => return Ok(result),
-                Err(e) => {
-                    last_error = Some(e);
-                    if attempt < self.max_retries {
-                        // Retry after a short wait (async)
-                        tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
-                    }
-                }
-            }
-        }
-
-        Err(last_error.unwrap())
-    }
-
-    /// Validates and sanitizes package name and version for URL safety
-    fn validate_url_component(component: &str, component_type: &str) -> Result<()> {
-        // Security: Prevent URL injection attacks
-        if component.contains('/') || component.contains('\\') {
-            anyhow::bail!(
-                "Security: {} contains path separators which are not allowed",
-                component_type
-            );
-        }
-
-        if component.contains("..") {
-            anyhow::bail!(
-                "Security: {} contains '..' which is not allowed",
-                component_type
-            );
-        }
-
-        // Check for URL-unsafe characters that could cause issues
-        if component.contains('#') || component.contains('?') || component.contains('@') {
-            anyhow::bail!(
-                "Security: {} contains URL-unsafe characters",
-                component_type
-            );
-        }
-
-        Ok(())
+        crate::shared::http_retry::fetch_with_retry(Self::MAX_RETRIES, || {
+            self.fetch_from_pypi(package_name, version)
+        })
+        .await
     }
 
     /// Fetches package information from PyPI API (async)
     async fn fetch_from_pypi(&self, package_name: &str, version: &str) -> Result<PyPiPackageInfo> {
         // Security: Validate URL components before using them
-        Self::validate_url_component(package_name, "Package name")?;
-        Self::validate_url_component(version, "Version")?;
+        crate::shared::security::validate_url_component(package_name, "Package name")?;
+        crate::shared::security::validate_url_component(version, "Version")?;
 
         // URL encode components to handle special characters safely
         let encoded_package = urlencoding::encode(package_name);

--- a/src/adapters/outbound/network/pypi_compatibility_client.rs
+++ b/src/adapters/outbound/network/pypi_compatibility_client.rs
@@ -67,36 +67,13 @@ impl PyPiCompatibilityClient {
         })
     }
 
-    /// Validates a URL component to prevent injection attacks
-    fn validate_url_component(component: &str, component_type: &str) -> Result<()> {
-        if component.contains('/') || component.contains('\\') {
-            anyhow::bail!(
-                "Security: {} contains path separators which are not allowed",
-                component_type
-            );
-        }
-        if component.contains("..") {
-            anyhow::bail!(
-                "Security: {} contains '..' which is not allowed",
-                component_type
-            );
-        }
-        if component.contains('#') || component.contains('?') || component.contains('@') {
-            anyhow::bail!(
-                "Security: {} contains URL-unsafe characters",
-                component_type
-            );
-        }
-        Ok(())
-    }
-
     async fn fetch_from_pypi(
         &self,
         package_name: &str,
         package_version: &str,
     ) -> Result<PyPiVersionResponse> {
-        Self::validate_url_component(package_name, "Package name")?;
-        Self::validate_url_component(package_version, "Package version")?;
+        crate::shared::security::validate_url_component(package_name, "Package name")?;
+        crate::shared::security::validate_url_component(package_version, "Package version")?;
         let encoded_name = urlencoding::encode(package_name);
         let encoded_version = urlencoding::encode(package_version);
         let url = format!(
@@ -129,20 +106,10 @@ impl PyPiCompatibilityClient {
         package_name: &str,
         package_version: &str,
     ) -> Result<PyPiVersionResponse> {
-        let mut last_error = None;
-        for attempt in 1..=Self::MAX_RETRIES {
-            match self.fetch_from_pypi(package_name, package_version).await {
-                Ok(result) => return Ok(result),
-                Err(e) => {
-                    last_error = Some(e);
-                    if attempt < Self::MAX_RETRIES {
-                        // Linear back-off: 100 ms, 200 ms — matches PyPiMaintenanceRepository
-                        tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
-                    }
-                }
-            }
-        }
-        Err(last_error.unwrap())
+        crate::shared::http_retry::fetch_with_retry(Self::MAX_RETRIES, || {
+            self.fetch_from_pypi(package_name, package_version)
+        })
+        .await
     }
 }
 
@@ -169,42 +136,6 @@ mod tests {
     #[test]
     fn test_pypi_compatibility_client_creation() {
         assert!(PyPiCompatibilityClient::new().is_ok());
-    }
-
-    #[test]
-    fn test_validate_url_component_accepts_normal_name() {
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("requests", "Package name").is_ok()
-        );
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("2.31.0", "Package version").is_ok()
-        );
-    }
-
-    #[test]
-    fn test_validate_url_component_rejects_path_separators() {
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("pkg/evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("pkg\\evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("pkg..evil", "Package name").is_err()
-        );
-    }
-
-    #[test]
-    fn test_validate_url_component_rejects_unsafe_chars() {
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("pkg#evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("pkg?evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiCompatibilityClient::validate_url_component("pkg@evil", "Package name").is_err()
-        );
     }
 
     #[test]

--- a/src/adapters/outbound/network/pypi_maintenance_client.rs
+++ b/src/adapters/outbound/network/pypi_maintenance_client.rs
@@ -43,31 +43,8 @@ impl PyPiMaintenanceRepository {
         Ok(Self { client })
     }
 
-    /// Validates a URL component to prevent injection attacks
-    fn validate_url_component(component: &str, component_type: &str) -> Result<()> {
-        if component.contains('/') || component.contains('\\') {
-            anyhow::bail!(
-                "Security: {} contains path separators which are not allowed",
-                component_type
-            );
-        }
-        if component.contains("..") {
-            anyhow::bail!(
-                "Security: {} contains '..' which is not allowed",
-                component_type
-            );
-        }
-        if component.contains('#') || component.contains('?') || component.contains('@') {
-            anyhow::bail!(
-                "Security: {} contains URL-unsafe characters",
-                component_type
-            );
-        }
-        Ok(())
-    }
-
     async fn fetch_from_pypi(&self, package_name: &str) -> Result<PyPiPackageResponse> {
-        Self::validate_url_component(package_name, "Package name")?;
+        crate::shared::security::validate_url_component(package_name, "Package name")?;
         let encoded = urlencoding::encode(package_name);
         let url = format!("https://pypi.org/pypi/{}/json", encoded);
 
@@ -92,20 +69,10 @@ impl PyPiMaintenanceRepository {
     }
 
     async fn fetch_with_retry(&self, package_name: &str) -> Result<PyPiPackageResponse> {
-        let mut last_error = None;
-        for attempt in 1..=Self::MAX_RETRIES {
-            match self.fetch_from_pypi(package_name).await {
-                Ok(result) => return Ok(result),
-                Err(e) => {
-                    last_error = Some(e);
-                    if attempt < Self::MAX_RETRIES {
-                        // Linear back-off: 100 ms, 200 ms — matches PyPiLicenseRepository
-                        tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
-                    }
-                }
-            }
-        }
-        Err(last_error.unwrap())
+        crate::shared::http_retry::fetch_with_retry(Self::MAX_RETRIES, || {
+            self.fetch_from_pypi(package_name)
+        })
+        .await
     }
 
     /// Parses the latest release date from a PyPI package response.
@@ -242,44 +209,6 @@ mod tests {
         }"#;
         let response: PyPiPackageResponse = serde_json::from_str(json).unwrap();
         assert_eq!(response.urls.len(), 1);
-    }
-
-    #[test]
-    fn test_validate_url_component_accepts_normal_name() {
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("requests", "Package name").is_ok()
-        );
-        assert!(PyPiMaintenanceRepository::validate_url_component(
-            "my-package-123",
-            "Package name"
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_validate_url_component_rejects_path_separators() {
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("pkg/evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("pkg\\evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("pkg..evil", "Package name").is_err()
-        );
-    }
-
-    #[test]
-    fn test_validate_url_component_rejects_unsafe_chars() {
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("pkg#evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("pkg?evil", "Package name").is_err()
-        );
-        assert!(
-            PyPiMaintenanceRepository::validate_url_component("pkg@evil", "Package name").is_err()
-        );
     }
 
     // Integration tests - require network access

--- a/src/shared/http_retry.rs
+++ b/src/shared/http_retry.rs
@@ -1,0 +1,87 @@
+use crate::shared::Result;
+
+/// Retries an async operation with linear backoff (100ms * attempt number).
+///
+/// Calls `f` up to `max_retries` times, waiting between attempts. Returns the
+/// first successful result, or the last error if every attempt fails.
+///
+/// # Errors
+/// Returns the error from the final attempt if `f` fails on every call.
+///
+/// # Panics
+/// Panics if `max_retries` is 0 (no attempt is ever made, so there is no error
+/// to return). All current call sites pass a positive retry count.
+pub async fn fetch_with_retry<F, Fut, T>(max_retries: u32, mut f: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut last_error = None;
+
+    for attempt in 1..=max_retries {
+        match f().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                last_error = Some(e);
+                if attempt < max_retries {
+                    tokio::time::sleep(std::time::Duration::from_millis(100 * attempt as u64))
+                        .await;
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn test_fetch_with_retry_succeeds_first_attempt() {
+        let attempts = AtomicUsize::new(0);
+        let result = fetch_with_retry(3, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            async { Ok::<_, anyhow::Error>(42) }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_retry_succeeds_after_failures() {
+        let attempts = AtomicUsize::new(0);
+        let result = fetch_with_retry(3, || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            async move {
+                if attempt < 3 {
+                    Err(anyhow::anyhow!("transient failure on attempt {}", attempt))
+                } else {
+                    Ok(99)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 99);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_with_retry_exhausts_and_returns_last_error() {
+        let attempts = AtomicUsize::new(0);
+        let result: Result<()> = fetch_with_retry(3, || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            async move { Err(anyhow::anyhow!("failure {}", attempt)) }
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "failure 3");
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
+pub mod http_retry;
 pub mod result;
 pub mod security;
 

--- a/src/shared/security.rs
+++ b/src/shared/security.rs
@@ -215,6 +215,41 @@ pub fn validate_directory_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Validates a URL path component (e.g. a package name or version) to prevent
+/// path traversal and URL injection when building PyPI API request URLs.
+///
+/// # Arguments
+/// * `component` - The value to validate (e.g. a package name or version string)
+/// * `component_type` - Description of the component for error messages
+///
+/// # Errors
+/// Returns an error if the component contains path separators, `..`, or
+/// URL-unsafe characters (`#`, `?`, `@`).
+pub fn validate_url_component(component: &str, component_type: &str) -> Result<()> {
+    if component.contains('/') || component.contains('\\') {
+        anyhow::bail!(
+            "Security: {} contains path separators which are not allowed",
+            component_type
+        );
+    }
+
+    if component.contains("..") {
+        anyhow::bail!(
+            "Security: {} contains '..' which is not allowed",
+            component_type
+        );
+    }
+
+    if component.contains('#') || component.contains('?') || component.contains('@') {
+        anyhow::bail!(
+            "Security: {} contains URL-unsafe characters",
+            component_type
+        );
+    }
+
+    Ok(())
+}
+
 /// Validates that a path is not a symbolic link
 ///
 /// # Security
@@ -377,5 +412,26 @@ mod tests {
         assert!(result.is_err());
         let err_string = format!("{}", result.unwrap_err());
         assert!(err_string.contains("Not a directory"));
+    }
+
+    #[test]
+    fn test_validate_url_component_accepts_normal_name() {
+        assert!(validate_url_component("requests", "Package name").is_ok());
+        assert!(validate_url_component("my-package-123", "Package name").is_ok());
+        assert!(validate_url_component("2.31.0", "Package version").is_ok());
+    }
+
+    #[test]
+    fn test_validate_url_component_rejects_path_separators() {
+        assert!(validate_url_component("pkg/evil", "Package name").is_err());
+        assert!(validate_url_component("pkg\\evil", "Package name").is_err());
+        assert!(validate_url_component("pkg..evil", "Package name").is_err());
+    }
+
+    #[test]
+    fn test_validate_url_component_rejects_unsafe_chars() {
+        assert!(validate_url_component("pkg#evil", "Package name").is_err());
+        assert!(validate_url_component("pkg?evil", "Package name").is_err());
+        assert!(validate_url_component("pkg@evil", "Package name").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Extract byte-for-byte-duplicated `validate_url_component` and `fetch_with_retry` logic out of three PyPI HTTP client adapters into new shared helpers.
- Add `shared::security::validate_url_component` and a new `shared::http_retry::fetch_with_retry` generic retry combinator.
- Update `PyPiLicenseRepository`, `PyPiMaintenanceRepository`, and `PyPiCompatibilityClient` to call the shared helpers instead of their local copies.

## Related Issue
Closes #706

## Changes Made
- Added `src/shared/http_retry.rs` — generic async `fetch_with_retry(max_retries, f)` combinator with linear backoff (100ms * attempt), reused via a zero-arg closure at each call site. Includes dedicated unit tests (succeeds first try, succeeds after N failures, exhausts retries and returns last error).
- Added `validate_url_component` to `src/shared/security.rs`, alongside the existing `validate_directory_path`/`validate_not_symlink` helpers. Consolidated the three per-client test copies into one canonical set of tests.
- Registered `pub mod http_retry;` in `src/shared/mod.rs`.
- Removed the local `validate_url_component`/`fetch_with_retry` methods from `pypi_client.rs`, `pypi_maintenance_client.rs`, and `pypi_compatibility_client.rs`, replacing their bodies with calls to the shared helpers.
- `PyPiLicenseRepository`'s `max_retries: u32` field became a `MAX_RETRIES` const (matching the other two clients), since no external caller configures the retry count (verified via `git grep`).
- `src/adapters/outbound/network/osv_client.rs` was intentionally left unchanged — it has no retry by design (fail-fast for CVE checks) and does not embed package names into URL paths, so it needs neither helper.
- Response-size guards (`MAX_RESPONSE_BYTES`) in `pypi_maintenance_client.rs`/`pypi_compatibility_client.rs` are unrelated to this duplication and were left local, per client.

## Test Plan
- [x] `cargo test --all` passes (865 lib tests + doc tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Existing per-client unit tests for retry/validation behavior preserved (moved to `src/shared/security.rs` / new tests added to `src/shared/http_retry.rs`)

---
Generated with [Claude Code](https://claude.com/claude-code)