### PR TITLE
chore(release): prepare v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **Moved `EnrichedPackage`/`SimulationResult`/`UvLockSimulator` out of `src/ports/outbound/` into `src/sbom_generation/domain/`**: `ResolutionAnalyzer` and `UpgradeAdvisor` (domain services) were importing these types from `ports/outbound/`, violating the invariant that the domain layer must never import from `ports/` or `adapters/`. `EnrichedPackage` and `SimulationResult` are plain value objects with no I/O, so they now live in the domain; `UvLockSimulator`, a genuine port trait consumed by `UpgradeAdvisor` as a generic bound, is now a domain-owned port (still implemented by `adapters::outbound::uv::UvLockAdapter`). Internal refactor only, no behavior change (#703)
+## [2.8.1] - 2026-08-09
 
 ### Fixed
 - **`--diff` Markdown output could break the CVE Delta table when a vulnerability summary contained a newline**: `diff_markdown_formatter.rs` escaped `|` in CVE summaries but not `\n`; a free-text OSV summary containing a literal newline would split the table row across lines and corrupt rendering. Now reuses the same `escape_markdown_table_cell` helper already used elsewhere in Markdown output, which handles both cases (#708)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "uv-sbom"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-sbom"
-version = "2.8.0"
+version = "2.8.1"
 edition = "2021"
 authors = ["Taketo Yoda <exhaust7.drs@gmail.com>"]
 description = "SBOM generation tool for uv projects - Generate CycloneDX SBOMs from uv.lock files"

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "uv-sbom-bin"
-version = "2.8.0"
+version = "2.8.1"
 description = "Python wrapper for uv-sbom - SBOM generation tool for uv projects"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-wrapper/uv_sbom_bin/install.py
+++ b/python-wrapper/uv_sbom_bin/install.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from urllib.request import urlretrieve
 
 # Version of uv-sbom to install
-UV_SBOM_VERSION = "2.8.0"
+UV_SBOM_VERSION = "2.8.1"
 
 # GitHub release URL template
 RELEASE_URL_TEMPLATE = (


### PR DESCRIPTION
## Summary
- Prepare release v2.8.1
- Update version numbers in all required files
- Update CHANGELOG with release date

## Version Files Updated
- `Cargo.toml`: version = "2.8.1"
- `python-wrapper/pyproject.toml`: version = "2.8.1"
- `python-wrapper/uv_sbom_bin/install.py`: UV_SBOM_VERSION = "2.8.1"

## CHANGELOG
- Converted [Unreleased] to [2.8.1] - 2026-08-09
- Added empty [Unreleased] section
- Removed an internal-only refactor entry (#703, explicitly "no behavior change") from the promoted section per the Step 3.6 cleanup gate; kept both user-facing Fixed entries (#708, #709)

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` passes
- [x] All version strings are consistent

## Post-Merge Manual Steps
After merging this PR into `develop`:
1. Open a PR: `develop` → `main`
2. Merge the PR to main
3. Create tag: `git tag v2.8.1`
4. Push tag: `git push origin v2.8.1`
5. Verify CI release workflow completes successfully

---
Generated with [Claude Code](https://claude.com/claude-code)